### PR TITLE
Refactor client into modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ add_library(lantern STATIC
     src/consensus/state.c
     src/consensus/ssz.c
     src/core/client.c
+    src/core/client/common.c
+    src/core/client/http_handlers.c
+    src/core/client/options.c
+    src/core/client/validator_service.c
     src/genesis/genesis.c
     src/encoding/snappy.c
     src/networking/enr.c

--- a/include/lantern/core/client.h
+++ b/include/lantern/core/client.h
@@ -18,88 +18,17 @@
 #include "lantern/networking/reqresp_service.h"
 #include "lantern/support/string_list.h"
 
+#include "lantern/core/client/options.h"
+#include "lantern/core/client/types.h"
 #include "pq-bindings-c-rust.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define LANTERN_DEFAULT_DATA_DIR "./data"
-#define LANTERN_DEFAULT_GENESIS_CONFIG "./genesis/config.yaml"
-#define LANTERN_DEFAULT_VALIDATOR_REGISTRY "./genesis/validators.yaml"
-#define LANTERN_DEFAULT_NODES_FILE "./genesis/nodes.yaml"
-#define LANTERN_DEFAULT_GENESIS_STATE "./genesis/genesis.ssz"
-#define LANTERN_DEFAULT_VALIDATOR_CONFIG "./genesis/validator-config.yaml"
-#define LANTERN_DEFAULT_NODE_ID "lantern_0"
-#define LANTERN_DEFAULT_LISTEN_ADDR "/ip4/0.0.0.0/udp/9000/quic-v1"
-#define LANTERN_DEFAULT_HTTP_PORT 5052
-#define LANTERN_DEFAULT_METRICS_PORT 8080
-#define LANTERN_DEFAULT_DEVNET "devnet"
-
-struct lantern_client_options {
-    const char *data_dir;
-    const char *genesis_config_path;
-    const char *validator_registry_path;
-    const char *nodes_path;
-    const char *genesis_state_path;
-    const char *validator_config_path;
-    const char *node_id;
-    const char *node_key_hex;
-    const char *node_key_path;
-    const char *listen_address;
-    uint16_t http_port;
-    uint16_t metrics_port;
-    const char *devnet;
-    struct lantern_string_list bootnodes;
-    const char *hash_sig_key_dir;
-    const char *hash_sig_public_path;
-    const char *hash_sig_secret_path;
-    const char *hash_sig_public_template;
-    const char *hash_sig_secret_template;
-};
-
 struct libp2p_subscription;
 struct libp2p_protocol_server;
 struct lantern_peer_status_entry;
-struct lantern_pending_block {
-    LanternSignedBlock block;
-    LanternRoot root;
-    LanternRoot parent_root;
-    char peer_text[128];
-    bool parent_requested;
-};
-
-struct lantern_pending_block_list {
-    struct lantern_pending_block *items;
-    size_t length;
-    size_t capacity;
-};
-
-struct lantern_validator_duty_state {
-    uint64_t last_slot;
-    uint32_t last_interval;
-    bool have_timepoint;
-    bool slot_proposed;
-    bool slot_attested;
-    bool pending_local_proposal;
-    uint64_t pending_local_index;
-    bool proposal_signal_pending;
-};
-
-struct lantern_local_validator {
-    uint64_t global_index;
-    const struct lantern_validator_record *registry;
-    uint8_t *secret;
-    size_t secret_len;
-    bool has_secret;
-    struct PQSignatureSchemeSecretKey *secret_key;
-    bool has_secret_handle;
-    uint64_t last_proposed_slot;
-    uint64_t last_attested_slot;
-    LanternSignedVote pending_attestation;
-    uint64_t pending_attestation_slot;
-    bool has_pending_attestation;
-};
 
 struct lantern_client {
     char *data_dir;
@@ -174,10 +103,6 @@ struct lantern_client {
     char *hash_sig_public_path;
     char *hash_sig_secret_path;
 };
-
-void lantern_client_options_init(struct lantern_client_options *options);
-void lantern_client_options_free(struct lantern_client_options *options);
-int lantern_client_options_add_bootnode(struct lantern_client_options *options, const char *bootnode);
 
 int lantern_init(struct lantern_client *client, const struct lantern_client_options *options);
 void lantern_shutdown(struct lantern_client *client);

--- a/include/lantern/core/client/options.h
+++ b/include/lantern/core/client/options.h
@@ -1,0 +1,54 @@
+#ifndef LANTERN_CORE_CLIENT_OPTIONS_H
+#define LANTERN_CORE_CLIENT_OPTIONS_H
+
+#include <stdint.h>
+
+#include "lantern/support/string_list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LANTERN_DEFAULT_DATA_DIR "./data"
+#define LANTERN_DEFAULT_GENESIS_CONFIG "./genesis/config.yaml"
+#define LANTERN_DEFAULT_VALIDATOR_REGISTRY "./genesis/validators.yaml"
+#define LANTERN_DEFAULT_NODES_FILE "./genesis/nodes.yaml"
+#define LANTERN_DEFAULT_GENESIS_STATE "./genesis/genesis.ssz"
+#define LANTERN_DEFAULT_VALIDATOR_CONFIG "./genesis/validator-config.yaml"
+#define LANTERN_DEFAULT_NODE_ID "lantern_0"
+#define LANTERN_DEFAULT_LISTEN_ADDR "/ip4/0.0.0.0/udp/9000/quic-v1"
+#define LANTERN_DEFAULT_HTTP_PORT 5052
+#define LANTERN_DEFAULT_METRICS_PORT 8080
+#define LANTERN_DEFAULT_DEVNET "devnet"
+
+struct lantern_client_options {
+    const char *data_dir;
+    const char *genesis_config_path;
+    const char *validator_registry_path;
+    const char *nodes_path;
+    const char *genesis_state_path;
+    const char *validator_config_path;
+    const char *node_id;
+    const char *node_key_hex;
+    const char *node_key_path;
+    const char *listen_address;
+    uint16_t http_port;
+    uint16_t metrics_port;
+    const char *devnet;
+    struct lantern_string_list bootnodes;
+    const char *hash_sig_key_dir;
+    const char *hash_sig_public_path;
+    const char *hash_sig_secret_path;
+    const char *hash_sig_public_template;
+    const char *hash_sig_secret_template;
+};
+
+void lantern_client_options_init(struct lantern_client_options *options);
+void lantern_client_options_free(struct lantern_client_options *options);
+int lantern_client_options_add_bootnode(struct lantern_client_options *options, const char *bootnode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LANTERN_CORE_CLIENT_OPTIONS_H */

--- a/include/lantern/core/client/types.h
+++ b/include/lantern/core/client/types.h
@@ -1,0 +1,62 @@
+#ifndef LANTERN_CORE_CLIENT_TYPES_H
+#define LANTERN_CORE_CLIENT_TYPES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lantern/consensus/containers.h"
+#include "lantern/consensus/state.h"
+#include "pq-bindings-c-rust.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct lantern_validator_record;
+
+struct lantern_pending_block {
+    LanternSignedBlock block;
+    LanternRoot root;
+    LanternRoot parent_root;
+    char peer_text[128];
+    bool parent_requested;
+};
+
+struct lantern_pending_block_list {
+    struct lantern_pending_block *items;
+    size_t length;
+    size_t capacity;
+};
+
+struct lantern_validator_duty_state {
+    uint64_t last_slot;
+    uint32_t last_interval;
+    bool have_timepoint;
+    bool slot_proposed;
+    bool slot_attested;
+    bool pending_local_proposal;
+    uint64_t pending_local_index;
+    bool proposal_signal_pending;
+};
+
+struct lantern_local_validator {
+    uint64_t global_index;
+    const struct lantern_validator_record *registry;
+    uint8_t *secret;
+    size_t secret_len;
+    bool has_secret;
+    struct PQSignatureSchemeSecretKey *secret_key;
+    bool has_secret_handle;
+    uint64_t last_proposed_slot;
+    uint64_t last_attested_slot;
+    LanternSignedVote pending_attestation;
+    uint64_t pending_attestation_slot;
+    bool has_pending_attestation;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LANTERN_CORE_CLIENT_TYPES_H */

--- a/src/core/client/common.c
+++ b/src/core/client/common.c
@@ -1,0 +1,72 @@
+#include "core/client/common.h"
+
+#include <time.h>
+
+#include "lantern/support/log.h"
+#include "lantern/support/strings.h"
+
+void lantern_client_format_root_hex(const LanternRoot *root, char *out, size_t out_len) {
+    if (!out || out_len == 0) {
+        return;
+    }
+    if (!root) {
+        out[0] = '\0';
+        return;
+    }
+    if (lantern_bytes_to_hex(root->bytes, LANTERN_ROOT_SIZE, out, out_len, 1) != 0) {
+        out[0] = '\0';
+    }
+}
+
+bool lantern_client_lock_state(struct lantern_client *client) {
+    if (!client || !client->state_lock_initialized) {
+        return false;
+    }
+    if (pthread_mutex_lock(&client->state_lock) != 0) {
+        lantern_log_warn(
+            "state",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to lock state mutex");
+        return false;
+    }
+    return true;
+}
+
+void lantern_client_unlock_state(struct lantern_client *client, bool locked) {
+    if (!client || !locked || !client->state_lock_initialized) {
+        return;
+    }
+    pthread_mutex_unlock(&client->state_lock);
+}
+
+bool lantern_client_lock_pending(struct lantern_client *client) {
+    if (!client || !client->pending_lock_initialized) {
+        return false;
+    }
+    if (pthread_mutex_lock(&client->pending_lock) != 0) {
+        lantern_log_warn(
+            "state",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to lock pending block mutex");
+        return false;
+    }
+    return true;
+}
+
+void lantern_client_unlock_pending(struct lantern_client *client, bool locked) {
+    if (!client || !locked || !client->pending_lock_initialized) {
+        return;
+    }
+    pthread_mutex_unlock(&client->pending_lock);
+}
+
+uint64_t lantern_client_wall_time_seconds(void) {
+#if defined(CLOCK_REALTIME)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+        return (uint64_t)ts.tv_sec;
+    }
+#endif
+    time_t now = time(NULL);
+    return now > 0 ? (uint64_t)now : 0;
+}

--- a/src/core/client/common.h
+++ b/src/core/client/common.h
@@ -1,0 +1,16 @@
+#ifndef LANTERN_CORE_CLIENT_COMMON_H
+#define LANTERN_CORE_CLIENT_COMMON_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "lantern/core/client.h"
+
+void lantern_client_format_root_hex(const LanternRoot *root, char *out, size_t out_len);
+bool lantern_client_lock_state(struct lantern_client *client);
+void lantern_client_unlock_state(struct lantern_client *client, bool locked);
+bool lantern_client_lock_pending(struct lantern_client *client);
+void lantern_client_unlock_pending(struct lantern_client *client, bool locked);
+uint64_t lantern_client_wall_time_seconds(void);
+
+#endif /* LANTERN_CORE_CLIENT_COMMON_H */

--- a/src/core/client/http_handlers.c
+++ b/src/core/client/http_handlers.c
@@ -1,0 +1,129 @@
+#include "core/client/http_handlers.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+#include "core/client/common.h"
+#include "lantern/metrics/lean_metrics.h"
+#include "lantern/support/log.h"
+
+static int find_local_validator_index(const struct lantern_client *client, uint64_t global_index, size_t *out_index) {
+    if (!client || !client->local_validators || client->local_validator_count == 0 || !out_index) {
+        return -1;
+    }
+    for (size_t i = 0; i < client->local_validator_count; ++i) {
+        const struct lantern_local_validator *validator = &client->local_validators[i];
+        if (validator->global_index == global_index) {
+            *out_index = i;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+int lantern_client_http_snapshot_head(void *context, struct lantern_http_head_snapshot *out_snapshot) {
+    if (!context || !out_snapshot) {
+        return -1;
+    }
+    struct lantern_client *client = context;
+    if (!client->has_state) {
+        return -1;
+    }
+    memset(out_snapshot, 0, sizeof(*out_snapshot));
+    out_snapshot->slot = client->state.slot;
+    if (lantern_hash_tree_root_block_header(&client->state.latest_block_header, &out_snapshot->head_root) != 0) {
+        return -1;
+    }
+    out_snapshot->justified = client->state.latest_justified;
+    out_snapshot->finalized = client->state.latest_finalized;
+    return 0;
+}
+
+size_t lantern_client_http_validator_count_cb(void *context) {
+    const struct lantern_client *client = context;
+    if (!client) {
+        return 0;
+    }
+    return client->local_validator_count;
+}
+
+int lantern_client_http_validator_info_cb(void *context, size_t index, struct lantern_http_validator_info *out_info) {
+    if (!context || !out_info) {
+        return -1;
+    }
+    struct lantern_client *client = context;
+    if (index >= client->local_validator_count || !client->local_validators) {
+        return -1;
+    }
+    memset(out_info, 0, sizeof(*out_info));
+    out_info->global_index = client->local_validators[index].global_index;
+
+    bool enabled = true;
+    if (client->validator_lock_initialized) {
+        if (pthread_mutex_lock(&client->validator_lock) != 0) {
+            return -1;
+        }
+        if (client->validator_enabled && index < client->local_validator_count) {
+            enabled = client->validator_enabled[index];
+        }
+        pthread_mutex_unlock(&client->validator_lock);
+    } else if (client->validator_enabled && index < client->local_validator_count) {
+        enabled = client->validator_enabled[index];
+    }
+    out_info->enabled = enabled;
+
+    const char *base = client->node_id ? client->node_id : "validator";
+    int written = snprintf(out_info->label, sizeof(out_info->label), "%s#%" PRIu64, base, out_info->global_index);
+    if (written < 0 || (size_t)written >= sizeof(out_info->label)) {
+        strncpy(out_info->label, base, sizeof(out_info->label));
+        out_info->label[sizeof(out_info->label) - 1] = '\0';
+    }
+    return 0;
+}
+
+int lantern_client_http_set_validator_status_cb(void *context, uint64_t global_index, bool enabled) {
+    if (!context) {
+        return -1;
+    }
+    struct lantern_client *client = context;
+    if (!client->validator_lock_initialized || !client->validator_enabled) {
+        return -1;
+    }
+    if (pthread_mutex_lock(&client->validator_lock) != 0) {
+        return -1;
+    }
+    size_t local_index = 0;
+    if (find_local_validator_index(client, global_index, &local_index) != 0
+        || local_index >= client->local_validator_count) {
+        pthread_mutex_unlock(&client->validator_lock);
+        return -1;
+    }
+    client->validator_enabled[local_index] = enabled;
+    pthread_mutex_unlock(&client->validator_lock);
+
+    lantern_log_info(
+        "validator",
+        &(const struct lantern_log_metadata){.validator = client->node_id},
+        "validator %" PRIu64 " %s",
+        global_index,
+        enabled ? "enabled" : "disabled");
+    return 0;
+}
+
+int lantern_client_metrics_snapshot_cb(void *context, struct lantern_metrics_snapshot *out_snapshot) {
+    if (!context || !out_snapshot) {
+        return -1;
+    }
+    struct lantern_client *client = context;
+    if (!client->has_state) {
+        return -1;
+    }
+    bool state_locked = lantern_client_lock_state(client);
+    if (!state_locked) {
+        return -1;
+    }
+    out_snapshot->state = client->state;
+    lantern_client_unlock_state(client, state_locked);
+    lean_metrics_snapshot(&out_snapshot->lean_metrics);
+    return 0;
+}

--- a/src/core/client/http_handlers.h
+++ b/src/core/client/http_handlers.h
@@ -1,0 +1,15 @@
+#ifndef LANTERN_CORE_CLIENT_HTTP_HANDLERS_H
+#define LANTERN_CORE_CLIENT_HTTP_HANDLERS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lantern/core/client.h"
+
+int lantern_client_http_snapshot_head(void *context, struct lantern_http_head_snapshot *out_snapshot);
+size_t lantern_client_http_validator_count_cb(void *context);
+int lantern_client_http_validator_info_cb(void *context, size_t index, struct lantern_http_validator_info *out_info);
+int lantern_client_http_set_validator_status_cb(void *context, uint64_t global_index, bool enabled);
+int lantern_client_metrics_snapshot_cb(void *context, struct lantern_metrics_snapshot *out_snapshot);
+
+#endif /* LANTERN_CORE_CLIENT_HTTP_HANDLERS_H */

--- a/src/core/client/options.c
+++ b/src/core/client/options.c
@@ -1,0 +1,43 @@
+#include "lantern/core/client/options.h"
+
+#include "lantern/support/string_list.h"
+
+void lantern_client_options_init(struct lantern_client_options *options) {
+    if (!options) {
+        return;
+    }
+
+    options->data_dir = LANTERN_DEFAULT_DATA_DIR;
+    options->genesis_config_path = LANTERN_DEFAULT_GENESIS_CONFIG;
+    options->validator_registry_path = LANTERN_DEFAULT_VALIDATOR_REGISTRY;
+    options->nodes_path = LANTERN_DEFAULT_NODES_FILE;
+    options->genesis_state_path = LANTERN_DEFAULT_GENESIS_STATE;
+    options->validator_config_path = LANTERN_DEFAULT_VALIDATOR_CONFIG;
+    options->node_id = LANTERN_DEFAULT_NODE_ID;
+    options->node_key_hex = NULL;
+    options->node_key_path = NULL;
+    options->listen_address = LANTERN_DEFAULT_LISTEN_ADDR;
+    options->http_port = LANTERN_DEFAULT_HTTP_PORT;
+    options->metrics_port = LANTERN_DEFAULT_METRICS_PORT;
+    options->devnet = LANTERN_DEFAULT_DEVNET;
+    lantern_string_list_init(&options->bootnodes);
+    options->hash_sig_key_dir = NULL;
+    options->hash_sig_public_path = NULL;
+    options->hash_sig_secret_path = NULL;
+    options->hash_sig_public_template = NULL;
+    options->hash_sig_secret_template = NULL;
+}
+
+void lantern_client_options_free(struct lantern_client_options *options) {
+    if (!options) {
+        return;
+    }
+    lantern_string_list_reset(&options->bootnodes);
+}
+
+int lantern_client_options_add_bootnode(struct lantern_client_options *options, const char *bootnode) {
+    if (!options || !bootnode) {
+        return -1;
+    }
+    return lantern_string_list_append(&options->bootnodes, bootnode);
+}

--- a/src/core/client/validator_service.c
+++ b/src/core/client/validator_service.c
@@ -1,0 +1,456 @@
+#include "core/client/validator_service.h"
+
+#include <inttypes.h>
+#include <string.h>
+#include <time.h>
+
+#include "core/client/common.h"
+#include "lantern/consensus/hash.h"
+#include "lantern/consensus/signature.h"
+#include "lantern/storage/storage.h"
+#include "lantern/support/log.h"
+#include "lantern/support/secure_mem.h"
+
+static void validator_duty_state_reset(struct lantern_validator_duty_state *state) {
+    if (!state) {
+        return;
+    }
+    memset(state, 0, sizeof(*state));
+}
+
+static void validator_sleep_ms(uint32_t ms) {
+    struct timespec ts;
+    ts.tv_sec = ms / 1000u;
+    ts.tv_nsec = (long)(ms % 1000u) * 1000000L;
+    nanosleep(&ts, NULL);
+}
+
+static bool validator_service_should_run(const struct lantern_client *client) {
+    if (!client) {
+        return false;
+    }
+    if (!client->has_state || !client->has_runtime || !client->has_fork_choice) {
+        return false;
+    }
+    if (!client->gossip_running || client->local_validator_count == 0) {
+        return false;
+    }
+    return true;
+}
+
+static bool validator_is_enabled(const struct lantern_client *client, size_t local_index) {
+    if (!client || local_index >= client->local_validator_count) {
+        return false;
+    }
+    if (!client->validator_enabled) {
+        return true;
+    }
+    if (!client->validator_lock_initialized) {
+        return client->validator_enabled[local_index];
+    }
+    if (pthread_mutex_lock((pthread_mutex_t *)&client->validator_lock) != 0) {
+        return client->validator_enabled[local_index];
+    }
+    bool enabled = client->validator_enabled[local_index];
+    pthread_mutex_unlock((pthread_mutex_t *)&client->validator_lock);
+    return enabled;
+}
+
+static uint64_t validator_global_index(const struct lantern_client *client, size_t local_index) {
+    if (!client || !client->local_validators || local_index >= client->local_validator_count) {
+        return UINT64_MAX;
+    }
+    return client->local_validators[local_index].global_index;
+}
+
+static int validator_sign_vote(struct lantern_local_validator *validator, uint64_t slot, LanternSignedVote *vote) {
+    if (!validator || !vote || !validator->secret_key) {
+        return -1;
+    }
+    LanternRoot vote_root;
+    if (lantern_hash_tree_root_vote(&vote->data, &vote_root) != 0) {
+        return -1;
+    }
+    if (!lantern_signature_sign(
+            validator->secret_key,
+            slot,
+            vote_root.bytes,
+            sizeof(vote_root.bytes),
+            &vote->signature)) {
+        return -1;
+    }
+    return 0;
+}
+
+static int validator_store_vote(struct lantern_client *client, const LanternSignedVote *vote) {
+    if (!client || !vote) {
+        return -1;
+    }
+    if (!client->has_state) {
+        return -1;
+    }
+    bool state_locked = lantern_client_lock_state(client);
+    if (!state_locked) {
+        return -1;
+    }
+    int rc = lantern_state_set_signed_validator_vote(
+        &client->state,
+        (size_t)vote->data.validator_id,
+        vote);
+    lantern_client_unlock_state(client, state_locked);
+    if (rc != 0) {
+        lantern_log_warn(
+            "state",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to cache validator vote validator=%" PRIu64 " slot=%" PRIu64,
+            vote->data.validator_id,
+            vote->data.slot);
+        return -1;
+    }
+    if (client->data_dir) {
+        if (lantern_storage_save_votes(client->data_dir, &client->state) != 0) {
+            lantern_log_warn(
+                "storage",
+                &(const struct lantern_log_metadata){.validator = client->node_id},
+                "failed to persist local votes");
+        }
+    }
+    return 0;
+}
+
+static int validator_publish_vote(struct lantern_client *client, const LanternSignedVote *vote) {
+    if (!client || !vote) {
+        return -1;
+    }
+    if (!client->gossip_running) {
+        return -1;
+    }
+    if (lantern_gossipsub_service_publish_vote(&client->gossip, vote) != 0) {
+        lantern_log_warn(
+            "validator",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to broadcast vote validator=%" PRIu64 " slot=%" PRIu64,
+            vote->data.validator_id,
+            vote->data.slot);
+        return -1;
+    }
+    return 0;
+}
+
+static int validator_build_block(
+    struct lantern_client *client,
+    uint64_t slot,
+    struct lantern_local_validator *validator,
+    LanternSignedBlock *out_block) {
+    if (!client || !client->has_state || !client->has_runtime || !validator || !out_block) {
+        return -1;
+    }
+    if (!client->has_fork_choice) {
+        return -1;
+    }
+    LanternRoot parent_root;
+    if (lantern_fork_choice_current_head(&client->fork_choice, &parent_root) != 0) {
+        return -1;
+    }
+    LanternRoot parent_state_root;
+    if (lantern_fork_choice_state_root(&client->fork_choice, &parent_root, &parent_state_root) != 0) {
+        return -1;
+    }
+    LanternRoot parent_body_root;
+    if (lantern_fork_choice_body_root(&client->fork_choice, &parent_root, &parent_body_root) != 0) {
+        return -1;
+    }
+    LanternSignedBlock block;
+    memset(&block, 0, sizeof(block));
+    block.message.block.slot = slot;
+    block.message.block.parent_root = parent_root;
+    block.message.block.state_root = parent_state_root;
+    block.message.block.body_root = parent_body_root;
+    block.message.block.proposer_index = validator->global_index;
+    lantern_block_body_init(&block.message.block.body);
+
+    bool state_locked = lantern_client_lock_state(client);
+    if (!state_locked) {
+        lantern_block_body_reset(&block.message.block.body);
+        return -1;
+    }
+    int rc = lantern_consensus_runtime_build_block(
+        &client->runtime,
+        &client->state,
+        slot,
+        validator->global_index,
+        &block);
+    lantern_client_unlock_state(client, state_locked);
+    if (rc != 0) {
+        lantern_block_body_reset(&block.message.block.body);
+        return -1;
+    }
+    *out_block = block;
+    return 0;
+}
+
+static int validator_propose_block(struct lantern_client *client, uint64_t slot, size_t local_index) {
+    if (!client || local_index >= client->local_validator_count) {
+        return -1;
+    }
+    struct lantern_local_validator *local = &client->local_validators[local_index];
+    if (!validator_is_enabled(client, local_index)) {
+        return 0;
+    }
+    if (local->last_proposed_slot == slot) {
+        return 0;
+    }
+
+    LanternSignedBlock block;
+    memset(&block, 0, sizeof(block));
+    if (validator_build_block(client, slot, local, &block) != 0) {
+        return -1;
+    }
+    local->last_proposed_slot = slot;
+    int rc = lantern_client_publish_block(client, &block);
+    lantern_signed_block_with_attestation_reset(&block);
+    return rc;
+}
+
+static int validator_publish_attestations(struct lantern_client *client, uint64_t slot) {
+    if (!client) {
+        return -1;
+    }
+    if (!client->has_state || !client->has_runtime) {
+        return -1;
+    }
+
+    LanternCheckpoint head_cp;
+    LanternCheckpoint target_cp;
+    LanternCheckpoint source_cp;
+    memset(&head_cp, 0, sizeof(head_cp));
+    memset(&target_cp, 0, sizeof(target_cp));
+    memset(&source_cp, 0, sizeof(source_cp));
+
+    bool state_locked = lantern_client_lock_state(client);
+    if (!state_locked) {
+        return -1;
+    }
+    if (lantern_state_current_checkpoints(&client->state, &head_cp, &target_cp, &source_cp) != 0) {
+        lantern_client_unlock_state(client, state_locked);
+        return -1;
+    }
+    if (lantern_state_compute_vote_checkpoints(&client->state, &head_cp, &target_cp, &source_cp) != 0) {
+        lantern_client_unlock_state(client, state_locked);
+        return -1;
+    }
+    lantern_client_unlock_state(client, state_locked);
+
+    bool have_lock = false;
+    if (client->validator_lock_initialized) {
+        if (pthread_mutex_lock(&client->validator_lock) != 0) {
+            return -1;
+        }
+        have_lock = true;
+    }
+
+    for (size_t i = 0; i < client->local_validator_count; ++i) {
+        bool enabled = client->validator_enabled ? client->validator_enabled[i] : true;
+        if (!enabled) {
+            continue;
+        }
+        struct lantern_local_validator *validator = &client->local_validators[i];
+        if (validator->last_attested_slot == slot) {
+            continue;
+        }
+        LanternSignedVote vote;
+        if (validator->has_pending_attestation && validator->pending_attestation_slot == slot) {
+            vote = validator->pending_attestation;
+        } else {
+            memset(&vote, 0, sizeof(vote));
+            vote.data.validator_id = validator->global_index;
+            vote.data.slot = slot;
+            vote.data.head = head_cp;
+            vote.data.target = target_cp;
+            vote.data.source = source_cp;
+            if (validator_sign_vote(validator, slot, &vote) != 0) {
+                continue;
+            }
+        }
+        validator->last_attested_slot = slot;
+        validator->has_pending_attestation = false;
+
+        (void)validator_store_vote(client, &vote);
+        (void)validator_publish_vote(client, &vote);
+    }
+
+    if (have_lock) {
+        pthread_mutex_unlock(&client->validator_lock);
+    }
+    return 0;
+}
+
+static void *validator_thread(void *arg) {
+    struct lantern_client *client = arg;
+    if (!client) {
+        return NULL;
+    }
+
+    while (__atomic_load_n(&client->validator_stop_flag, __ATOMIC_RELAXED) == 0) {
+        if (!validator_service_should_run(client)) {
+            validator_sleep_ms(200);
+            continue;
+        }
+
+        uint64_t now = lantern_client_wall_time_seconds();
+        if (client->has_runtime) {
+            if (lantern_consensus_runtime_update_time(&client->runtime, now) != 0) {
+                validator_sleep_ms(50);
+                continue;
+            }
+        }
+
+        const struct lantern_slot_timepoint *tp = lantern_consensus_runtime_current_timepoint(&client->runtime);
+        if (!tp) {
+            validator_sleep_ms(50);
+            continue;
+        }
+
+        struct lantern_validator_duty_state *duty = &client->validator_duty;
+        if (!duty->have_timepoint || duty->last_slot != tp->slot) {
+            duty->have_timepoint = true;
+            duty->last_slot = tp->slot;
+            duty->slot_proposed = false;
+            duty->slot_attested = false;
+            duty->pending_local_proposal = false;
+            duty->pending_local_index = 0;
+
+            bool is_local = false;
+            uint64_t local_index = 0;
+            if (lantern_consensus_runtime_local_proposer(&client->runtime, tp->slot, &is_local, &local_index) == 0
+                && is_local
+                && local_index < client->local_validator_count) {
+                duty->pending_local_proposal = true;
+                duty->pending_local_index = local_index;
+            }
+        }
+        duty->last_interval = tp->interval_index;
+
+        if (client->has_fork_choice) {
+            bool has_proposal = duty->slot_proposed;
+            (void)lantern_fork_choice_advance_time(&client->fork_choice, now, has_proposal);
+        }
+
+        switch (tp->phase) {
+        case LANTERN_DUTY_PHASE_PROPOSAL:
+            if (duty->pending_local_proposal && !duty->slot_proposed) {
+                if (validator_propose_block(client, tp->slot, (size_t)duty->pending_local_index) == 0) {
+                    duty->slot_proposed = true;
+                }
+            }
+            break;
+        case LANTERN_DUTY_PHASE_VOTE:
+            if (!duty->slot_attested) {
+                if (validator_publish_attestations(client, tp->slot) == 0) {
+                    duty->slot_attested = true;
+                }
+            }
+            break;
+        default:
+            break;
+        }
+
+        validator_sleep_ms(50);
+    }
+    return NULL;
+}
+
+int lantern_client_start_validator_service(struct lantern_client *client) {
+    if (!client) {
+        return -1;
+    }
+    if (client->validator_thread_started) {
+        return 0;
+    }
+    if (client->local_validator_count == 0 || !client->has_runtime) {
+        return 0;
+    }
+    validator_duty_state_reset(&client->validator_duty);
+    __atomic_store_n(&client->validator_stop_flag, 0, __ATOMIC_RELAXED);
+    if (pthread_create(&client->validator_thread, NULL, validator_thread, client) != 0) {
+        lantern_log_warn(
+            "validator",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to start validator service thread");
+        return -1;
+    }
+    client->validator_thread_started = true;
+    lantern_log_info(
+        "validator",
+        &(const struct lantern_log_metadata){.validator = client->node_id},
+        "validator service started");
+    return 0;
+}
+
+void lantern_client_stop_validator_service(struct lantern_client *client) {
+    if (!client || !client->validator_thread_started) {
+        return;
+    }
+    __atomic_store_n(&client->validator_stop_flag, 1, __ATOMIC_RELAXED);
+    (void)pthread_join(client->validator_thread, NULL);
+    client->validator_thread_started = false;
+    lantern_log_info(
+        "validator",
+        &(const struct lantern_log_metadata){.validator = client->node_id},
+        "validator service stopped");
+}
+
+size_t lantern_client_local_validator_count(const struct lantern_client *client) {
+    if (!client) {
+        return 0;
+    }
+    return client->local_validator_count;
+}
+
+const struct lantern_local_validator *lantern_client_local_validator(
+    const struct lantern_client *client,
+    size_t index) {
+    if (!client || index >= client->local_validator_count) {
+        return NULL;
+    }
+    return &client->local_validators[index];
+}
+
+int lantern_client_publish_block(struct lantern_client *client, const LanternSignedBlock *block) {
+    if (!client || !block) {
+        return -1;
+    }
+    if (!client->gossip_running) {
+        lantern_log_error(
+            "gossip",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "cannot publish block at slot %" PRIu64 ": gossip service inactive",
+            block->message.block.slot);
+        return -1;
+    }
+    if (lantern_gossipsub_service_publish_block(&client->gossip, block) != 0) {
+        lantern_log_error(
+            "gossip",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to publish block at slot %" PRIu64,
+            block->message.block.slot);
+        return -1;
+    }
+
+    LanternRoot block_root;
+    char root_hex[2 * LANTERN_ROOT_SIZE + 3];
+    if (lantern_hash_tree_root_signed_block(block, &block_root) == 0) {
+        lantern_client_format_root_hex(&block_root, root_hex, sizeof(root_hex));
+    } else {
+        root_hex[0] = '\0';
+    }
+
+    lantern_log_info(
+        "gossip",
+        &(const struct lantern_log_metadata){.validator = client->node_id},
+        "published block slot=%" PRIu64 " root=%s attestations=%zu",
+        block->message.block.slot,
+        root_hex[0] ? root_hex : "0x0",
+        block->message.block.body.attestations.length);
+    return 0;
+}

--- a/src/core/client/validator_service.h
+++ b/src/core/client/validator_service.h
@@ -1,0 +1,9 @@
+#ifndef LANTERN_CORE_CLIENT_VALIDATOR_SERVICE_H
+#define LANTERN_CORE_CLIENT_VALIDATOR_SERVICE_H
+
+#include "lantern/core/client.h"
+
+int lantern_client_start_validator_service(struct lantern_client *client);
+void lantern_client_stop_validator_service(struct lantern_client *client);
+
+#endif /* LANTERN_CORE_CLIENT_VALIDATOR_SERVICE_H */


### PR DESCRIPTION
## Summary
- split client options/types declarations into dedicated headers
- introduce shared helper, http handler, and validator service translation units
- wire the library/CMake build to the new modules and keep behaviour unchanged

## Testing
- Usage

  ctest [options]
