### PR TITLE
fix: remove empty message sent on unavailable block

### DIFF
--- a/src/networking/reqresp_service.c
+++ b/src/networking/reqresp_service.c
@@ -2276,26 +2276,6 @@ static void *blocks_worker(void *arg) {
             &meta,
             "blocks_by_root response has zero blocks for peer=%s",
             peer_text[0] ? peer_text : "-");
-        if (send_response_chunk(
-                stream,
-                &meta,
-                protocol_id,
-                "blocks_by_root response (empty)",
-                peer_text[0] ? peer_text : NULL,
-                true,
-                LANTERN_REQRESP_RESPONSE_SUCCESS,
-                use_legacy_len,
-                NULL,
-                0,
-                0)
-            != 0) {
-            lantern_signed_block_list_reset(&response);
-            log_stream_error("write", protocol_id, peer_text[0] ? peer_text : NULL);
-            close_stream(stream);
-            free(ssz_buffer);
-            free(snappy_buffer);
-            return NULL;
-        }
     }
 
     for (size_t i = 0; i < block_count; ++i) {


### PR DESCRIPTION
@uink45 

``` c
if (block_count == 0) {
        lantern_log_debug(
            "reqresp",
            &meta,
            "blocks_by_root response has zero blocks for peer=%s",
            peer_text[0] ? peer_text : "-");
        if (send_response_chunk(
                stream,
                &meta,
                protocol_id,
                "blocks_by_root response (empty)",
                peer_text[0] ? peer_text : NULL,
                true,
                LANTERN_REQRESP_RESPONSE_SUCCESS,
                use_legacy_len,
                NULL,
                0,
                0)
            != 0) {
            lantern_signed_block_list_reset(&response);
            log_stream_error("write", protocol_id, peer_text[0] ? peer_text : NULL);
            close_stream(stream);
            free(ssz_buffer);
            free(snappy_buffer);
            return NULL;
        }
    }
```

In reqresp_service.c on line 2279 you are sending an empty response when you don't have the requested block. According to the spec you should be sending nothing that and just close the stream. This is the cause of some of the ssz decoding failed logs on ream when trying to fetch blocks lantern doesn't have. We are flooded by the logs below as this is unexpected. I will add a check for this in Ream as well but I think it is worthwhile to not send the empty message to comply with spec.

```
026-03-04T19:26:41.374372Z  WARN ream_p2p::network::lean: Failed to parse req/resp message from peer: Outbound { request_id: 33, err: InvalidData("Failed to decode ssz: InvalidLengthPrefix { len: 0, expected: 4 }") } 
```

Relevant portion of spec: https://github.com/leanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/networking/reqresp/handler.py#L174-L222

Feel free to merge, request changes or close this PR. 