### PR TITLE
Bump target-cpu to x86-64-v4 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN LANTERN_BOOTSTRAP_SKIP_SUBMODULE_SYNC=1 ./scripts/bootstrap.sh
 RUN if [ "${LANTERN_RUST_PROFILE}" = "1" ]; then \
         printf '[target."cfg(target_arch = \\"x86_64\\")"]\nrustflags = ["-C", "target-cpu=native", "-C", "force-frame-pointers=yes", "-C", "debuginfo=2"]\n' > external/c-leanvm-xmss/.cargo/config.toml; \
     else \
-        printf '[target."cfg(target_arch = \\"x86_64\\")"]\nrustflags = ["-C", "target-cpu=x86-64-v3"]\n' > external/c-leanvm-xmss/.cargo/config.toml; \
+        printf '[target."cfg(target_arch = \\"x86_64\\")"]\nrustflags = ["-C", "target-cpu=x86-64-v4"]\n' > external/c-leanvm-xmss/.cargo/config.toml; \
     fi \
     && echo "LANTERN_RUST_PROFILE=${LANTERN_RUST_PROFILE}" \
     && cat external/c-leanvm-xmss/.cargo/config.toml


### PR DESCRIPTION
Update the generated external/c-leanvm-xmss/.cargo/config.toml in the Dockerfile to set rustc target-cpu to x86-64-v4 (was x86-64-v3) for the non-native LANTERN_RUST_PROFILE path. The branch for LANTERN_RUST_PROFILE=1 continues to use target-cpu=native with additional rustflags. This change adjusts the build target to a newer x86-64 microarchitecture level.