### PR TITLE
Split Type-2 attestation proofs from block proofs

### DIFF
--- a/include/lantern/consensus/signature.h
+++ b/include/lantern/consensus/signature.h
@@ -73,4 +73,10 @@ bool lantern_signature_verify_block_type2_proof(
     const LanternState *state,
     const LanternBlock *block,
     const LanternByteList *encoded_proof);
+bool lantern_signature_split_block_type2_attestation_proof(
+    const LanternState *state,
+    const LanternBlock *block,
+    const LanternByteList *encoded_proof,
+    size_t attestation_index,
+    LanternAggregatedSignatureProof *out_proof);
 #endif /* LANTERN_CONSENSUS_SIGNATURE_H */

--- a/include/lantern/consensus/store.h
+++ b/include/lantern/consensus/store.h
@@ -118,6 +118,10 @@ int lantern_store_add_known_aggregated_payload(
     const LanternAttestationData *data,
     const LanternAggregatedSignatureProof *proof,
     uint64_t target_slot);
+bool lantern_store_aggregated_payloads_cover_participants(
+    const LanternStore *store,
+    const LanternRoot *data_root,
+    const struct lantern_bitlist *participants);
 int lantern_store_add_attestation_data(
     LanternStore *store,
     const LanternRoot *data_root,

--- a/src/consensus/signature.c
+++ b/src/consensus/signature.c
@@ -1378,3 +1378,140 @@ cleanup:
     free(work);
     return ok;
 }
+
+bool lantern_signature_split_block_type2_attestation_proof(
+    const LanternState *state,
+    const LanternBlock *block,
+    const LanternByteList *encoded_proof,
+    size_t attestation_index,
+    LanternAggregatedSignatureProof *out_proof) {
+    if (!state || !block || !encoded_proof || !out_proof) {
+        return false;
+    }
+    size_t attestation_count = block->body.attestations.length;
+    if (attestation_count == 0u
+        || attestation_index >= attestation_count
+        || !block->body.attestations.data) {
+        return false;
+    }
+
+    const LanternAggregatedAttestation *attestation =
+        &block->body.attestations.data[attestation_index];
+    if (attestation->aggregation_bits.bit_length == 0u
+        || !attestation->aggregation_bits.bytes) {
+        return false;
+    }
+
+    size_t component_count = attestation_count + 1u;
+    struct lantern_type2_component_work *work =
+        calloc(component_count, sizeof(*work));
+    struct PQTypeTwoComponent *components =
+        calloc(component_count, sizeof(*components));
+    LanternByteList raw_type2;
+    lantern_byte_list_init(&raw_type2);
+    LanternAggregatedSignatureProof recovered;
+    lantern_aggregated_signature_proof_init(&recovered);
+
+    bool ok = false;
+    if (!work || !components) {
+        goto cleanup;
+    }
+    if (!lantern_signature_unwrap_type2_proof(encoded_proof, &raw_type2)) {
+        goto cleanup;
+    }
+    if (!build_type2_merge_component_set_for_block(
+            state,
+            block,
+            work,
+            components,
+            component_count)) {
+        goto cleanup;
+    }
+
+    LanternRoot message;
+    if (lantern_hash_tree_root_attestation_data(&attestation->data, &message) != SSZ_SUCCESS) {
+        goto cleanup;
+    }
+
+    size_t bit_bytes = (attestation->aggregation_bits.bit_length + 7u) / 8u;
+    if (lantern_bitlist_resize(&recovered.participants, attestation->aggregation_bits.bit_length) != 0) {
+        goto cleanup;
+    }
+    if (bit_bytes > 0u) {
+        if (!recovered.participants.bytes) {
+            goto cleanup;
+        }
+        memcpy(recovered.participants.bytes, attestation->aggregation_bits.bytes, bit_bytes);
+    }
+
+    if (lantern_byte_list_resize(&recovered.proof_data, LANTERN_AGG_PROOF_MAX_BYTES) != 0) {
+        goto cleanup;
+    }
+
+    double setup_started_seconds = get_time_seconds();
+    ensure_xmss_prover_setup();
+    log_pq_prover_setup_error_if_any();
+    double setup_finished_seconds = get_time_seconds();
+    if (g_stage_timings) {
+        signature_add_stage_seconds(
+            &g_stage_timings->other_prover_setup_seconds,
+            signature_elapsed_seconds(setup_started_seconds, setup_finished_seconds));
+    }
+
+    uintptr_t written_len = 0u;
+    double split_started_seconds = get_time_seconds();
+    enum PQSigningError split_rc = pq_split_type_2_by_message(
+        components,
+        component_count,
+        raw_type2.data,
+        raw_type2.length,
+        message.bytes,
+        LANTERN_ROOT_SIZE,
+        LANTERN_AGGREGATED_SIGNATURE_PROOF_INVERSE_PROOF_SIZE,
+        recovered.proof_data.data,
+        recovered.proof_data.length,
+        &written_len);
+    double split_finished_seconds = get_time_seconds();
+    if (g_stage_timings) {
+        signature_add_stage_seconds(
+            &g_stage_timings->pq_aggregate_seconds,
+            signature_elapsed_seconds(split_started_seconds, split_finished_seconds));
+    }
+    if (split_rc != Success || written_len == 0u || written_len > recovered.proof_data.length) {
+        char *detail = pq_take_last_error_message();
+        lantern_log_debug(
+            "signature",
+            NULL,
+            "block Type-2 split failed err=%d component=%zu components=%zu written=%zu detail=%s",
+            (int)split_rc,
+            attestation_index,
+            component_count,
+            (size_t)written_len,
+            pq_error_detail_or_dash(detail));
+        pq_string_free(detail);
+        goto cleanup;
+    }
+    double copy_started_seconds = get_time_seconds();
+    if (lantern_byte_list_resize(&recovered.proof_data, (size_t)written_len) != 0) {
+        goto cleanup;
+    }
+    if (lantern_aggregated_signature_proof_copy(out_proof, &recovered) != 0) {
+        goto cleanup;
+    }
+    double copy_finished_seconds = get_time_seconds();
+    if (g_stage_timings) {
+        signature_add_stage_seconds(
+            &g_stage_timings->proof_copy_seconds,
+            signature_elapsed_seconds(copy_started_seconds, copy_finished_seconds));
+    }
+    ok = true;
+    shadow_sleep_merge(component_count);
+
+cleanup:
+    lantern_aggregated_signature_proof_reset(&recovered);
+    lantern_byte_list_reset(&raw_type2);
+    reset_type2_component_set(work, component_count);
+    free(components);
+    free(work);
+    return ok;
+}

--- a/src/consensus/store.c
+++ b/src/consensus/store.c
@@ -291,35 +291,86 @@ static void aggregated_payload_pool_remove_index(
     cache->length -= 1u;
 }
 
-static bool aggregated_payload_pool_covers_proof_participants(
+static void aggregated_payload_pool_mark_participants_covered(
     const struct lantern_aggregated_payload_pool *cache,
     const LanternRoot *data_root,
-    const LanternAggregatedSignatureProof *proof) {
-    if (!cache || !data_root || !proof || !proof->participants.bytes) {
+    bool covered[LANTERN_VALIDATOR_REGISTRY_LIMIT]) {
+    if (!cache || !data_root || !covered) {
+        return;
+    }
+    for (size_t i = 0; i < cache->length; ++i) {
+        if (!root_equals(&cache->entries[i].data_root, data_root)) {
+            continue;
+        }
+        const struct lantern_bitlist *participants = &cache->entries[i].proof.participants;
+        if (!participants->bytes) {
+            continue;
+        }
+        size_t limit = participants->bit_length;
+        if (limit > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+            limit = LANTERN_VALIDATOR_REGISTRY_LIMIT;
+        }
+        for (size_t validator = 0; validator < limit; ++validator) {
+            if (lantern_bitlist_get(participants, validator)) {
+                covered[validator] = true;
+            }
+        }
+    }
+}
+
+static bool bitlist_participants_covered(
+    const struct lantern_bitlist *participants,
+    const bool covered[LANTERN_VALIDATOR_REGISTRY_LIMIT]) {
+    if (!participants || !participants->bytes || !covered) {
         return false;
     }
-    size_t limit = proof_participant_limit(proof);
+    size_t limit = participants->bit_length;
+    if (limit > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+        limit = LANTERN_VALIDATOR_REGISTRY_LIMIT;
+    }
     bool has_participant = false;
     for (size_t validator = 0; validator < limit; ++validator) {
-        if (!lantern_bitlist_get(&proof->participants, validator)) {
+        if (!lantern_bitlist_get(participants, validator)) {
             continue;
         }
         has_participant = true;
-        bool covered = false;
-        for (size_t i = 0; i < cache->length; ++i) {
-            if (!root_equals(&cache->entries[i].data_root, data_root)) {
-                continue;
-            }
-            if (lantern_bitlist_get(&cache->entries[i].proof.participants, validator)) {
-                covered = true;
-                break;
-            }
-        }
-        if (!covered) {
+        if (!covered[validator]) {
             return false;
         }
     }
     return has_participant;
+}
+
+static bool aggregated_payload_pool_covers_proof_participants(
+    const struct lantern_aggregated_payload_pool *cache,
+    const LanternRoot *data_root,
+    const LanternAggregatedSignatureProof *proof) {
+    bool covered[LANTERN_VALIDATOR_REGISTRY_LIMIT] = {false};
+    if (!proof) {
+        return false;
+    }
+    aggregated_payload_pool_mark_participants_covered(cache, data_root, covered);
+    return bitlist_participants_covered(&proof->participants, covered);
+}
+
+bool lantern_store_aggregated_payloads_cover_participants(
+    const LanternStore *store,
+    const LanternRoot *data_root,
+    const struct lantern_bitlist *participants) {
+    bool covered[LANTERN_VALIDATOR_REGISTRY_LIMIT] = {false};
+    if (!store || !data_root || !participants
+        || participants->bit_length > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+        return false;
+    }
+    aggregated_payload_pool_mark_participants_covered(
+        &store->new_aggregated_payloads,
+        data_root,
+        covered);
+    aggregated_payload_pool_mark_participants_covered(
+        &store->known_aggregated_payloads,
+        data_root,
+        covered);
+    return bitlist_participants_covered(participants, covered);
 }
 
 static void aggregated_payload_pool_prune_subsets_of_entry(

--- a/src/core/client_sync_blocks.c
+++ b/src/core/client_sync_blocks.c
@@ -46,6 +46,7 @@
 enum
 {
     ROOT_HEX_BUFFER_LEN = (LANTERN_ROOT_SIZE * 2u) + 3u,
+    BLOCK_AGGREGATE_SPLIT_LIMIT = 4u,
 };
 
 static void adopt_state_locked(struct lantern_client *client, LanternState *state);
@@ -210,37 +211,87 @@ static void update_network_view_after_import(
     }
 }
 
-
 void lantern_client_cache_block_aggregated_proofs_locked(
     struct lantern_client *client,
     const LanternSignedBlock *block)
 {
-    if (!client || !block) {
+    if (!client || !block)
+    {
         return;
     }
     const LanternAggregatedAttestations *attestations = &block->block.body.attestations;
-    if (attestations->length == 0u) {
-        return;
-    }
-    if (!attestations->data) {
-        return;
-    }
-
-    if (block->proof.length == 0u || !block->proof.data) {
+    if (attestations->length == 0u || !attestations->data)
+    {
         return;
     }
 
-    for (size_t i = 0; i < attestations->length; ++i) {
+    LanternState parent_scratch;
+    lantern_state_init(&parent_scratch);
+    const LanternState *parent_state = NULL;
+    bool parent_state_lookup_done = false;
+    size_t split_attempts = 0u;
+
+    for (size_t i = 0; i < attestations->length; ++i)
+    {
+        const LanternAggregatedAttestation *attestation = &attestations->data[i];
         LanternRoot data_root;
-        if (lantern_hash_tree_root_attestation_data(&attestations->data[i].data, &data_root) != SSZ_SUCCESS) {
+        if (lantern_hash_tree_root_attestation_data(&attestation->data, &data_root) != SSZ_SUCCESS)
+        {
             continue;
         }
         (void)lantern_store_add_attestation_data(
             &client->store,
             &data_root,
-            &attestations->data[i].data,
-            attestations->data[i].data.target.slot);
+            &attestation->data,
+            attestation->data.target.slot);
+
+        if (block->proof.length == 0u || !block->proof.data
+            || split_attempts >= BLOCK_AGGREGATE_SPLIT_LIMIT
+            || lantern_store_aggregated_payloads_cover_participants(
+                &client->store,
+                &data_root,
+                &attestation->aggregation_bits))
+        {
+            continue;
+        }
+
+        if (!parent_state_lookup_done)
+        {
+            parent_state = lantern_client_state_for_root_locked(
+                client,
+                &block->block.parent_root,
+                &parent_scratch,
+                NULL);
+            parent_state_lookup_done = true;
+        }
+        if (!parent_state)
+        {
+            continue;
+        }
+
+        LanternAggregatedSignatureProof recovered;
+        lantern_aggregated_signature_proof_init(&recovered);
+        split_attempts += 1u;
+        if (!lantern_signature_split_block_type2_attestation_proof(
+                parent_state,
+                &block->block,
+                &block->proof,
+                i,
+                &recovered))
+        {
+            lantern_aggregated_signature_proof_reset(&recovered);
+            continue;
+        }
+        (void)lantern_store_add_new_aggregated_payload(
+            &client->store,
+            &data_root,
+            &attestation->data,
+            &recovered,
+            attestation->data.target.slot);
+        lantern_aggregated_signature_proof_reset(&recovered);
     }
+
+    lantern_state_reset(&parent_scratch);
 }
 
 static bool sync_validator_votes_from_preview_locked(

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -548,6 +548,51 @@ cleanup:
     return rc;
 }
 
+static int expect_recovered_block_payload(
+    const LanternStore *store,
+    const LanternSignedBlock *block,
+    bool may_be_known,
+    const char *context)
+{
+    if (!store || !block || block->block.body.attestations.length == 0u
+        || !block->block.body.attestations.data) {
+        return -1;
+    }
+    const struct lantern_aggregated_payload_entry *payload = NULL;
+    if (may_be_known) {
+        size_t count =
+            store->new_aggregated_payloads.length + store->known_aggregated_payloads.length;
+        if (count != 1u) {
+            fprintf(stderr, "%s should recover one block-body proof into payload pools\n", context);
+            return -1;
+        }
+        payload = store->new_aggregated_payloads.length != 0u
+            ? &store->new_aggregated_payloads.entries[0]
+            : &store->known_aggregated_payloads.entries[0];
+    } else {
+        if (store->new_aggregated_payloads.length != 1u
+            || store->known_aggregated_payloads.length != 0u) {
+            fprintf(stderr, "%s should stage one recovered block-body proof in new payloads\n", context);
+            return -1;
+        }
+        payload = &store->new_aggregated_payloads.entries[0];
+    }
+
+    LanternRoot data_root;
+    if (lantern_hash_tree_root_attestation_data(
+            &block->block.body.attestations.data[0].data,
+            &data_root)
+        != SSZ_SUCCESS) {
+        return -1;
+    }
+    if (memcmp(payload->data_root.bytes, data_root.bytes, LANTERN_ROOT_SIZE) != 0
+        || !lantern_bitlist_get(&payload->proof.participants, 0u)) {
+        fprintf(stderr, "%s recovered payload does not match block attestation\n", context);
+        return -1;
+    }
+    return 0;
+}
+
 static int test_pending_block_queue(void) {
     struct lantern_client client;
     memset(&client, 0, sizeof(client));
@@ -1652,12 +1697,8 @@ static int test_import_block_accepts_complete_proof(void)
         fprintf(stderr, "state slot did not advance after importing block with complete proof\n");
         goto cleanup;
     }
-    if (fixture.client.store.new_aggregated_payloads.length != 0u) {
-        fprintf(stderr, "canonical import should not stage block-body proofs in new payloads\n");
-        goto cleanup;
-    }
-    if (fixture.client.store.known_aggregated_payloads.length != 0u) {
-        fprintf(stderr, "canonical import should not cache block-body proofs directly in known payloads\n");
+    if (expect_recovered_block_payload(&fixture.client.store, &block, false, "canonical import")
+        != 0) {
         goto cleanup;
     }
     if (fixture.client.store.attestation_data_by_root.length == 0u) {
@@ -2028,12 +2069,8 @@ static int test_restore_persisted_blocks_caches_known_attestation_proofs(void)
         fprintf(stderr, "restore_persisted_blocks failed for known proofs test\n");
         goto cleanup;
     }
-    if (fixture.client.store.new_aggregated_payloads.length != 0u) {
-        fprintf(stderr, "restored blocks should not stage block-body proofs in new payloads\n");
-        goto cleanup;
-    }
-    if (fixture.client.store.known_aggregated_payloads.length != 0u) {
-        fprintf(stderr, "restored blocks should not cache block-body proofs directly in known payloads\n");
+    if (expect_recovered_block_payload(&fixture.client.store, &block, true, "restored blocks")
+        != 0) {
         goto cleanup;
     }
     if (fixture.client.store.attestation_data_by_root.length == 0u) {

--- a/tests/unit/test_signature.c
+++ b/tests/unit/test_signature.c
@@ -160,6 +160,18 @@ static bool set_participants(
     return true;
 }
 
+static void init_attestation_data(
+    LanternAttestationData *data,
+    uint64_t slot,
+    uint8_t seed) {
+    assert(data);
+    memset(data, 0, sizeof(*data));
+    data->slot = slot;
+    init_checkpoint(&data->head, slot, seed);
+    init_checkpoint(&data->target, slot, (uint8_t)(seed + 0x20u));
+    init_checkpoint(&data->source, slot > 0u ? slot - 1u : 0u, (uint8_t)(seed + 0x40u));
+}
+
 static bool expect_aggregated_build_metrics(
     uint64_t total,
     uint64_t attestations,
@@ -668,6 +680,281 @@ fail:
     return 1;
 }
 
+static int test_block_type2_attestation_split_roundtrip(void) {
+    enum { kValidatorCount = 3 };
+    struct PQSignatureSchemePublicKey *pubkeys[kValidatorCount];
+    struct PQSignatureSchemeSecretKey *secrets[kValidatorCount];
+    uint8_t serialized_pubkeys[kValidatorCount][LANTERN_VALIDATOR_PUBKEY_SIZE];
+    uint8_t flattened_pubkeys[kValidatorCount * LANTERN_VALIDATOR_PUBKEY_SIZE];
+    LanternSignature attestation_signatures[kValidatorCount];
+    LanternSignature proposer_signature;
+    LanternRoot attestation_roots[2];
+    LanternRoot block_root;
+    LanternState state;
+    LanternSignedBlock signed_block;
+    LanternAttestationSignatures block_attestation_proofs;
+    LanternAggregatedSignatureProof attestation_proof_0;
+    LanternAggregatedSignatureProof attestation_proof_1;
+    LanternAggregatedSignatureProof proposer_proof;
+    LanternAggregatedSignatureProof recovered;
+    struct lantern_bitlist proposer_participants;
+    int rc = 1;
+
+    memset(pubkeys, 0, sizeof(pubkeys));
+    memset(secrets, 0, sizeof(secrets));
+    memset(serialized_pubkeys, 0, sizeof(serialized_pubkeys));
+    memset(flattened_pubkeys, 0, sizeof(flattened_pubkeys));
+    memset(attestation_signatures, 0, sizeof(attestation_signatures));
+    memset(&proposer_signature, 0, sizeof(proposer_signature));
+    memset(attestation_roots, 0, sizeof(attestation_roots));
+    memset(&block_root, 0, sizeof(block_root));
+
+    lantern_state_init(&state);
+    lantern_signed_block_init(&signed_block);
+    lantern_attestation_signatures_init(&block_attestation_proofs);
+    lantern_aggregated_signature_proof_init(&attestation_proof_0);
+    lantern_aggregated_signature_proof_init(&attestation_proof_1);
+    lantern_aggregated_signature_proof_init(&proposer_proof);
+    lantern_aggregated_signature_proof_init(&recovered);
+    lantern_bitlist_init(&proposer_participants);
+
+    for (size_t i = 0; i < kValidatorCount; ++i) {
+        if (generate_test_keypair(&pubkeys[i], &secrets[i]) != 0) {
+            fprintf(stderr, "block split: keygen failed index=%zu\n", i);
+            goto cleanup;
+        }
+        uintptr_t written = 0;
+        enum PQSigningError serr = pq_public_key_serialize(
+            pubkeys[i],
+            serialized_pubkeys[i],
+            sizeof(serialized_pubkeys[i]),
+            &written);
+        if (serr != Success || written != sizeof(serialized_pubkeys[i])) {
+            fprintf(stderr, "block split: pubkey serialize failed index=%zu err=%d written=%zu\n", i, (int)serr, (size_t)written);
+            goto cleanup;
+        }
+        memcpy(
+            flattened_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
+            serialized_pubkeys[i],
+            LANTERN_VALIDATOR_PUBKEY_SIZE);
+    }
+
+    if (lantern_state_set_validator_pubkeys(&state, flattened_pubkeys, kValidatorCount) != 0) {
+        fprintf(stderr, "block split: state pubkey setup failed\n");
+        goto cleanup;
+    }
+
+    signed_block.block.slot = 3u;
+    signed_block.block.proposer_index = 0u;
+    fill_root(&signed_block.block.parent_root, 0x91);
+    fill_root(&signed_block.block.state_root, 0xB3);
+
+    if (lantern_aggregated_attestations_resize(&signed_block.block.body.attestations, 2u) != 0) {
+        fprintf(stderr, "block split: attestation list setup failed\n");
+        goto cleanup;
+    }
+    {
+        const size_t attestation_0_indices[2] = {0u, 1u};
+        const size_t attestation_1_indices[1] = {2u};
+        LanternAggregatedAttestation *attestation_0 =
+            &signed_block.block.body.attestations.data[0];
+        LanternAggregatedAttestation *attestation_1 =
+            &signed_block.block.body.attestations.data[1];
+
+        init_attestation_data(&attestation_0->data, 2u, 0x21);
+        if (!set_participants(
+                &attestation_0->aggregation_bits,
+                kValidatorCount,
+                attestation_0_indices,
+                2u)) {
+            fprintf(stderr, "block split: attestation 0 participant setup failed\n");
+            goto cleanup;
+        }
+        init_attestation_data(&attestation_1->data, 2u, 0x41);
+        if (!set_participants(
+                &attestation_1->aggregation_bits,
+                kValidatorCount,
+                attestation_1_indices,
+                1u)) {
+            fprintf(stderr, "block split: attestation 1 participant setup failed\n");
+            goto cleanup;
+        }
+    }
+
+    for (size_t i = 0; i < signed_block.block.body.attestations.length; ++i) {
+        LanternAggregatedAttestation *attestation =
+            &signed_block.block.body.attestations.data[i];
+        if (lantern_hash_tree_root_attestation_data(&attestation->data, &attestation_roots[i])
+            != SSZ_SUCCESS) {
+            fprintf(stderr, "block split: attestation root failed index=%zu\n", i);
+            goto cleanup;
+        }
+    }
+    if (!lantern_signature_sign(
+            secrets[0],
+            signed_block.block.body.attestations.data[0].data.slot,
+            &attestation_roots[0],
+            &attestation_signatures[0])
+        || !lantern_signature_sign(
+            secrets[1],
+            signed_block.block.body.attestations.data[0].data.slot,
+            &attestation_roots[0],
+            &attestation_signatures[1])
+        || !lantern_signature_sign(
+            secrets[2],
+            signed_block.block.body.attestations.data[1].data.slot,
+            &attestation_roots[1],
+            &attestation_signatures[2])) {
+        fprintf(stderr, "block split: attestation signing failed\n");
+        goto cleanup;
+    }
+
+    {
+        LanternRawXmssSignature inputs[2] = {
+            {.pubkey = serialized_pubkeys[0], .signature = &attestation_signatures[0]},
+            {.pubkey = serialized_pubkeys[1], .signature = &attestation_signatures[1]},
+        };
+        if (!lantern_aggregated_signature_proof_aggregate(
+                NULL,
+                &signed_block.block.body.attestations.data[0].aggregation_bits,
+                NULL,
+                0u,
+                inputs,
+                2u,
+                &attestation_roots[0],
+                signed_block.block.body.attestations.data[0].data.slot,
+                &attestation_proof_0)) {
+            fprintf(stderr, "block split: attestation 0 proof build failed\n");
+            goto cleanup;
+        }
+    }
+    {
+        LanternRawXmssSignature inputs[1] = {
+            {.pubkey = serialized_pubkeys[2], .signature = &attestation_signatures[2]},
+        };
+        if (!lantern_aggregated_signature_proof_aggregate(
+                NULL,
+                &signed_block.block.body.attestations.data[1].aggregation_bits,
+                NULL,
+                0u,
+                inputs,
+                1u,
+                &attestation_roots[1],
+                signed_block.block.body.attestations.data[1].data.slot,
+                &attestation_proof_1)) {
+            fprintf(stderr, "block split: attestation 1 proof build failed\n");
+            goto cleanup;
+        }
+    }
+    if (lantern_attestation_signatures_append(&block_attestation_proofs, &attestation_proof_0) != 0
+        || lantern_attestation_signatures_append(&block_attestation_proofs, &attestation_proof_1) != 0) {
+        fprintf(stderr, "block split: block proof list setup failed\n");
+        goto cleanup;
+    }
+
+    if (lantern_hash_tree_root_block(&signed_block.block, &block_root) != SSZ_SUCCESS
+        || !lantern_signature_sign(
+            secrets[0],
+            signed_block.block.slot,
+            &block_root,
+            &proposer_signature)) {
+        fprintf(stderr, "block split: proposer signing failed\n");
+        goto cleanup;
+    }
+    {
+        const size_t proposer_index[1] = {0u};
+        LanternRawXmssSignature input = {
+            .pubkey = serialized_pubkeys[0],
+            .signature = &proposer_signature,
+        };
+        if (!set_participants(&proposer_participants, 1u, proposer_index, 1u)
+            || !lantern_aggregated_signature_proof_aggregate(
+                NULL,
+                &proposer_participants,
+                NULL,
+                0u,
+                &input,
+                1u,
+                &block_root,
+                signed_block.block.slot,
+                &proposer_proof)) {
+            fprintf(stderr, "block split: proposer proof build failed\n");
+            goto cleanup;
+        }
+    }
+
+    if (!lantern_signature_merge_block_type2_proof(
+            &state,
+            &signed_block.block,
+            &block_attestation_proofs,
+            &proposer_proof,
+            &signed_block.proof)) {
+        fprintf(stderr, "block split: type-2 merge failed\n");
+        goto cleanup;
+    }
+    if (!lantern_signature_verify_block_type2_proof(
+            &state,
+            &signed_block.block,
+            &signed_block.proof)) {
+        fprintf(stderr, "block split: type-2 verify failed\n");
+        goto cleanup;
+    }
+    if (!lantern_signature_split_block_type2_attestation_proof(
+            &state,
+            &signed_block.block,
+            &signed_block.proof,
+            0u,
+            &recovered)) {
+        fprintf(stderr, "block split: attestation proof recovery failed\n");
+        goto cleanup;
+    }
+
+    if (recovered.participants.bit_length
+            != signed_block.block.body.attestations.data[0].aggregation_bits.bit_length
+        || !lantern_bitlist_get(&recovered.participants, 0u)
+        || !lantern_bitlist_get(&recovered.participants, 1u)
+        || lantern_bitlist_get(&recovered.participants, 2u)) {
+        fprintf(stderr, "block split: recovered participants mismatch\n");
+        goto cleanup;
+    }
+    {
+        const uint8_t *recovered_pubkeys[2] = {
+            serialized_pubkeys[0],
+            serialized_pubkeys[1],
+        };
+        if (!lantern_signature_verify_aggregated(
+                recovered_pubkeys,
+                2u,
+                &attestation_roots[0],
+                &recovered.proof_data,
+                signed_block.block.body.attestations.data[0].data.slot)) {
+            fprintf(stderr, "block split: recovered proof verification failed\n");
+            goto cleanup;
+        }
+    }
+
+    rc = 0;
+
+cleanup:
+    for (size_t i = 0; i < kValidatorCount; ++i) {
+        if (secrets[i]) {
+            pq_secret_key_free(secrets[i]);
+        }
+        if (pubkeys[i]) {
+            pq_public_key_free(pubkeys[i]);
+        }
+    }
+    lantern_bitlist_reset(&proposer_participants);
+    lantern_aggregated_signature_proof_reset(&recovered);
+    lantern_aggregated_signature_proof_reset(&proposer_proof);
+    lantern_aggregated_signature_proof_reset(&attestation_proof_1);
+    lantern_aggregated_signature_proof_reset(&attestation_proof_0);
+    lantern_attestation_signatures_reset(&block_attestation_proofs);
+    lantern_signed_block_reset(&signed_block);
+    lantern_state_reset(&state);
+    return rc;
+}
+
 static int test_signature_helpers(void) {
     LanternSignature signature;
     memset(&signature, 0xA5, sizeof(signature));
@@ -697,6 +984,9 @@ int main(void) {
         return 1;
     }
     if (test_recursive_aggregated_signature_roundtrip() != 0) {
+        return 1;
+    }
+    if (test_block_type2_attestation_split_roundtrip() != 0) {
         return 1;
     }
     puts("lantern_signature_test OK");


### PR DESCRIPTION
Add functionality to extract individual attestation proofs from merged Type-2 block proofs. This enables caching of individual attestation proofs separately, with participant coverage checks to avoid redundant processing. Includes new `lantern_signature_split_block_type2_attestation_proof()` function to recover attestation proofs and `lantern_store_aggregated_payloads_cover_participants()` to check coverage, with comprehensive test coverage and client-side integration.