### PR TITLE
Remove req/resp connection registry; use host lookup

### DIFF
--- a/include/lantern/networking/reqresp_service.h
+++ b/include/lantern/networking/reqresp_service.h
@@ -29,7 +29,6 @@
 #define LANTERN_REQRESP_RESPONSE_INVALID_REQUEST 1u
 #define LANTERN_REQRESP_RESPONSE_SERVER_ERROR 2u
 #define LANTERN_REQRESP_RESPONSE_RESOURCE_UNAVAILABLE 3u
-#define LANTERN_REQRESP_MAX_TRACKED_CONNECTIONS 64u
 
 /**
  * Reqresp service error codes.
@@ -136,12 +135,6 @@ struct lantern_reqresp_protocol_context {
     enum lantern_reqresp_protocol_kind kind;
 };
 
-struct lantern_reqresp_conn_entry {
-    struct lantern_peer_id peer;
-    libp2p_host_conn_t *conn;
-    int inbound;
-};
-
 struct lantern_reqresp_service {
     struct lantern_libp2p_host *network;
     struct lantern_reqresp_service_callbacks callbacks;
@@ -151,8 +144,6 @@ struct lantern_reqresp_service {
     struct lantern_reqresp_protocol_context status_context;
     struct lantern_reqresp_protocol_context blocks_context;
     struct lantern_reqresp_protocol_context blocks_by_range_context;
-    struct lantern_reqresp_conn_entry conns[LANTERN_REQRESP_MAX_TRACKED_CONNECTIONS];
-    size_t conn_count;
     struct lantern_reqresp_exchange *exchanges;
     int lock_initialized;
     pthread_mutex_t lock;

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -2409,7 +2409,7 @@ static lantern_client_error client_start_protocols(
 
     /*
      * This handler may immediately send Status on CONN_ESTABLISHED. Register
-     * it after reqresp so reqresp has already cached the connection.
+     * it after reqresp so the req/resp protocols and event handler are ready.
      */
     if (lantern_libp2p_host_register_event_handler(&client->network, connection_events_cb, client) != 0)
     {

--- a/src/core/client_network.c
+++ b/src/core/client_network.c
@@ -960,16 +960,14 @@ void redial_peer_on_timeout(struct lantern_client *client, const struct lantern_
         "peer not in genesis ENRs, skipping redial");
 }
 
-/*
- * Redial a peer by its text peer id even while it appears connected. Used
- * when req/resp streams to the peer keep failing: the existing connection may
- * be a zombie that still carries gossip, so the connected-peer guard in
- * redial_peer_on_timeout would skip the redial that repopulates the req/resp
- * connection registry. The dial layer dedupes duplicate connections.
- */
+/* Redial a peer by text peer id after req/resp observes that it is disconnected. */
 void lantern_client_redial_peer_by_text(struct lantern_client *client, const char *peer_id_text)
 {
     if (!client || !client->network.host || !peer_id_text || !peer_id_text[0])
+    {
+        return;
+    }
+    if (lantern_client_is_peer_connected(client, peer_id_text))
     {
         return;
     }

--- a/src/core/client_network_internal.h
+++ b/src/core/client_network_internal.h
@@ -418,10 +418,7 @@ void redial_peer_on_timeout(struct lantern_client *client, const struct lantern_
 
 
 /**
- * Redial a peer by text peer id, bypassing the connected-peer guard. Used by
- * the req/resp layer to recover when stream opens keep failing against a peer
- * whose registry entry was lost while a zombie connection keeps the peer
- * looking connected.
+ * Redial a peer by text peer id after req/resp observes that it is disconnected.
  *
  * @param client        Client instance
  * @param peer_id_text  Text form of the peer id to redial

--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -1372,7 +1372,8 @@ void reqresp_status_failure(void *context, const char *peer_id, int error)
     bool first_failure = record_status_failure_peer_id(client, peer_copy);
     log_status_failure(client, peer_copy, error, first_failure);
 
-    if (peer_copy[0] != '\0' && error == LANTERN_REQRESP_ERR_STREAM_WRITE)
+    if (peer_copy[0] != '\0' && error == LANTERN_REQRESP_ERR_STREAM_WRITE
+        && !lantern_client_is_peer_connected(client, peer_copy))
     {
         lantern_client_redial_peer_by_text(client, peer_copy);
     }

--- a/src/networking/reqresp_service.c
+++ b/src/networking/reqresp_service.c
@@ -575,117 +575,22 @@ static int peer_from_conn(libp2p_host_conn_t *conn, struct lantern_peer_id *out_
     return 0;
 }
 
-static int reqresp_peer_id_cmp_bytes(
-    const uint8_t *left,
-    size_t left_len,
-    const uint8_t *right,
-    size_t right_len) {
-    size_t min_len = left_len < right_len ? left_len : right_len;
-    int cmp = memcmp(left, right, min_len);
-    if (cmp != 0) {
-        return cmp;
-    }
-    if (left_len < right_len) {
-        return -1;
-    }
-    if (left_len > right_len) {
-        return 1;
-    }
-    return 0;
-}
-
-static int reqresp_service_prefers_inbound_conn(
-    const struct lantern_reqresp_service *service,
-    const struct lantern_peer_id *peer) {
-    if (!service || !service->network || !peer || service->network->local_peer_id_len == 0) {
-        return 0;
-    }
-    return reqresp_peer_id_cmp_bytes(
-               service->network->local_peer_id,
-               service->network->local_peer_id_len,
-               peer->bytes,
-               peer->len) > 0;
-}
-
 static libp2p_host_conn_t *service_find_conn(
     struct lantern_reqresp_service *service,
     const struct lantern_peer_id *peer) {
-    if (!service || !peer) {
+    if (!service || !service->network || !service->network->host || !peer) {
         return NULL;
     }
-    libp2p_host_conn_t *conn = NULL;
-    if (service->lock_initialized) {
-        pthread_mutex_lock(&service->lock);
+    libp2p_host_conn_t *host_conn = NULL;
+    if (libp2p_host_conn_for_peer_id(
+            service->network->host,
+            peer->bytes,
+            peer->len,
+            &host_conn)
+        == LIBP2P_HOST_OK) {
+        return host_conn;
     }
-    for (size_t i = 0; i < service->conn_count; ++i) {
-        if (lantern_peer_id_equal(&service->conns[i].peer, peer)) {
-            conn = service->conns[i].conn;
-            break;
-        }
-    }
-    if (service->lock_initialized) {
-        pthread_mutex_unlock(&service->lock);
-    }
-    return conn;
-}
-
-static void service_record_conn(struct lantern_reqresp_service *service, libp2p_host_conn_t *conn, int inbound) {
-    if (!service || !conn) {
-        return;
-    }
-    struct lantern_peer_id peer;
-    if (peer_from_conn(conn, &peer) != 0) {
-        return;
-    }
-    int prefer_inbound = reqresp_service_prefers_inbound_conn(service, &peer) ? 1 : 0;
-    int new_preferred = (inbound ? 1 : 0) == prefer_inbound;
-    if (service->lock_initialized) {
-        pthread_mutex_lock(&service->lock);
-    }
-    for (size_t i = 0; i < service->conn_count; ++i) {
-        if (lantern_peer_id_equal(&service->conns[i].peer, &peer)) {
-            int existing_preferred = (service->conns[i].inbound ? 1 : 0) == prefer_inbound;
-            if (new_preferred || !existing_preferred) {
-                service->conns[i].conn = conn;
-                service->conns[i].inbound = inbound ? 1 : 0;
-            }
-            if (service->lock_initialized) {
-                pthread_mutex_unlock(&service->lock);
-            }
-            return;
-        }
-    }
-    if (service->conn_count < LANTERN_REQRESP_MAX_TRACKED_CONNECTIONS) {
-        service->conns[service->conn_count].peer = peer;
-        service->conns[service->conn_count].conn = conn;
-        service->conns[service->conn_count].inbound = inbound ? 1 : 0;
-        service->conn_count++;
-    }
-    if (service->lock_initialized) {
-        pthread_mutex_unlock(&service->lock);
-    }
-}
-
-static void service_remove_conn(struct lantern_reqresp_service *service, libp2p_host_conn_t *conn) {
-    if (!service || !conn) {
-        return;
-    }
-    if (service->lock_initialized) {
-        pthread_mutex_lock(&service->lock);
-    }
-    for (size_t i = 0; i < service->conn_count; ++i) {
-        if (service->conns[i].conn == conn) {
-            size_t last = service->conn_count - 1u;
-            if (i != last) {
-                service->conns[i] = service->conns[last];
-            }
-            service->conn_count = last;
-            break;
-        }
-    }
-    if (service->lock_initialized) {
-        pthread_mutex_unlock(&service->lock);
-    }
+    return NULL;
 }
 
 static void exchange_set_peer_text_from_conn(struct lantern_reqresp_exchange *exchange, libp2p_host_conn_t *conn) {
@@ -1351,11 +1256,7 @@ static void reqresp_host_event(
     if (!service || !event) {
         return;
     }
-    if (event->type == LIBP2P_HOST_EVENT_CONN_ESTABLISHED && event->conn) {
-        service_record_conn(service, event->conn, event->dial == NULL);
-    } else if (event->type == LIBP2P_HOST_EVENT_CONN_CLOSED && event->conn) {
-        service_remove_conn(service, event->conn);
-    } else if (event->type == LIBP2P_HOST_EVENT_STREAM_OPEN_FAILED && event->user_data) {
+    if (event->type == LIBP2P_HOST_EVENT_STREAM_OPEN_FAILED && event->user_data) {
         struct lantern_reqresp_exchange *exchange = (struct lantern_reqresp_exchange *)event->user_data;
         if (!service_remove_exchange(service, exchange)) {
             return;


### PR DESCRIPTION
Stop tracking per-peer req/resp connections in the reqresp service and rely on the libp2p host to resolve connections. Removed LANTERN_REQRESP_MAX_TRACKED_CONNECTIONS and associated conn entry struct and bookkeeping functions. service_find_conn now uses libp2p_host_conn_for_peer_id; event handling was simplified (no conn established/closed tracking). Also added a connected-check before redialing on stream write failures and tightened related comments. Includes submodule update and small client comment/behavior tweaks.