### PR TITLE
Remove proposal justified divergence check

### DIFF
--- a/src/core/client_validator.c
+++ b/src/core/client_validator.c
@@ -1767,25 +1767,6 @@ static lantern_client_error validator_prepare_block_proposal_job(
     }
     job->block.block.state_root = computed_state_root;
 
-    const LanternCheckpoint *store_justified = client->has_fork_choice
-        ? lantern_fork_choice_latest_justified(&client->fork_choice)
-        : &client->state.latest_justified;
-    if (store_justified
-        && job->post_state.latest_justified.slot < store_justified->slot)
-    {
-        lantern_log_warn(
-            "propose",
-            &(const struct lantern_log_metadata){.validator = client->node_id},
-            "slot %" PRIu64 ", skipped, reason: proposal_justified_divergence_not_closed"
-            ", block_justified_slot %" PRIu64 ", store_justified_slot %" PRIu64,
-            job->slot,
-            job->post_state.latest_justified.slot,
-            store_justified->slot);
-        result = LANTERN_CLIENT_ERR_IGNORED;
-        lantern_client_unlock_state(client, state_locked);
-        goto cleanup;
-    }
-
     if (lantern_state_clone(&client->state, &job->proof_state) != 0)
     {
         result = LANTERN_CLIENT_ERR_ALLOC;

--- a/tests/unit/test_fork_choice.c
+++ b/tests/unit/test_fork_choice.c
@@ -947,6 +947,27 @@ static int test_fork_choice_checkpoint_progression(void) {
     assert(latest_justified->slot == block_one.slot);
     assert(roots_equal(&latest_justified->root, &block_one_root));
 
+    LanternBlock block_two;
+    init_block(&block_two, 2, 0, &block_one_root, 0x22);
+    LanternRoot block_two_root;
+    assert(lantern_hash_tree_root_block(&block_two, &block_two_root) == SSZ_SUCCESS);
+    assert(
+        lantern_fork_choice_add_block(
+            &store,
+            &block_two,
+            &genesis_cp,
+            &genesis_cp,
+            &block_two_root)
+        == 0);
+    latest_justified = lantern_fork_choice_latest_justified(&store);
+    latest_finalized = lantern_fork_choice_latest_finalized(&store);
+    assert(latest_justified);
+    assert(latest_finalized);
+    assert(latest_justified->slot == block_one.slot);
+    assert(roots_equal(&latest_justified->root, &block_one_root));
+    assert(latest_finalized->slot == genesis.slot);
+    assert(roots_equal(&latest_finalized->root, &genesis_root));
+
     assert(lantern_fork_choice_update_checkpoints(&store, &block_one_cp, &block_one_cp) == 0);
     latest_finalized = lantern_fork_choice_latest_finalized(&store);
     assert(latest_finalized);
@@ -956,10 +977,11 @@ static int test_fork_choice_checkpoint_progression(void) {
     LanternRoot head;
     assert(lantern_fork_choice_recompute_head(&store) == 0);
     assert(lantern_fork_choice_current_head(&store, &head) == 0);
-    assert(roots_equal(&head, &block_one_root));
+    assert(roots_equal(&head, &block_two_root));
 
     lantern_store_reset(&backing_store);
     lantern_fork_choice_reset(&store);
+    reset_block(&block_two);
     reset_block(&block_one);
     reset_block(&genesis);
     return 0;


### PR DESCRIPTION
Remove the check in validator_prepare_block_proposal_job that skipped block proposals when the store's latest_justified checkpoint was ahead of the job's post_state.latest_justified. This prevents proposals from being incorrectly ignored due to justified checkpoint divergence. Update test_fork_choice_checkpoint_progression to add a second block (block_two), assert the recomputed head is block_two_root, and reset block_two to match the new behavior.