### PR TITLE
Fetch and persist checkpoint sync anchor block

### DIFF
--- a/src/consensus/ssz.c
+++ b/src/consensus/ssz.c
@@ -872,6 +872,10 @@ static ssz_error_t decode_validators_list(
             data + (i * LANTERN_VALIDATOR_SSZ_SIZE),
             LANTERN_VALIDATOR_SSZ_SIZE);
         if (err == SSZ_SUCCESS) {
+            if (decoded.index != (uint64_t)i) {
+                err = SSZ_ERR_ENCODING_INVALID;
+                break;
+            }
             memcpy(attestation_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
                    decoded.attestation_pubkey,
                    LANTERN_VALIDATOR_PUBKEY_SIZE);
@@ -887,19 +891,6 @@ static ssz_error_t decode_validators_list(
             attestation_pubkeys,
             proposal_pubkeys,
             count));
-    }
-    if (err == SSZ_SUCCESS) {
-        for (size_t i = 0u; i < count; ++i) {
-            memset(&decoded, 0, sizeof(decoded));
-            err = lantern_ssz_decode_validator(
-                &decoded,
-                data + (i * LANTERN_VALIDATOR_SSZ_SIZE),
-                LANTERN_VALIDATOR_SSZ_SIZE);
-            if (err != SSZ_SUCCESS) {
-                break;
-            }
-            state->validators[i].index = decoded.index;
-        }
     }
     if (err == SSZ_SUCCESS) {
         state->config.num_validators = count;

--- a/src/consensus/state.c
+++ b/src/consensus/state.c
@@ -1708,13 +1708,16 @@ static int lantern_state_prune_justification_roots(
             start_slot,
             &latest_slot);
         if (find_rc != 0) {
-            if (meta) {
-                lantern_log_warn(
-                    "state",
-                    meta,
-                    "justification root missing from history during pruning");
+            if (lantern_state_remove_justification_root(state, (int)i, validator_count) != 0) {
+                if (meta) {
+                    lantern_log_warn(
+                        "state",
+                        meta,
+                        "failed to prune off-chain justification root");
+                }
+                return -1;
             }
-            return -1;
+            continue;
         }
         if (latest_slot <= finalized_slot) {
             if (lantern_state_remove_justification_root(state, (int)i, validator_count) != 0) {

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -60,8 +60,11 @@ static const size_t CHECKPOINT_SYNC_MAX_RESPONSE_BYTES =
     + (LANTERN_VALIDATOR_REGISTRY_LIMIT * 52u)
     + (LANTERN_HISTORICAL_ROOTS_LIMIT * 32u)
     + (LANTERN_JUSTIFICATION_VALIDATORS_LIMIT / 8u);
+static const size_t CHECKPOINT_SYNC_MAX_BLOCK_RESPONSE_BYTES = 64u * 1024u * 1024u;
 static const size_t LANTERN_DEFAULT_ATTESTATION_COMMITTEE_COUNT = 1u;
 static const uint64_t LANTERN_CHECKPOINT_SYNC_STALE_PERSISTED_STATE_SLOT_THRESHOLD = 2u * 32u;
+static const char CHECKPOINT_SYNC_FINALIZED_STATE_PATH[] = "/lean/v0/states/finalized";
+static const char CHECKPOINT_SYNC_FINALIZED_BLOCK_PATH[] = "/lean/v0/blocks/finalized";
 
 static void log_aggregated_payload_interval_transition(
     const struct lantern_client *client,
@@ -1515,6 +1518,187 @@ static lantern_client_error client_finalize_genesis_state(struct lantern_client 
  * Checkpoint Sync Helpers
  * ============================================================================ */
 
+static char *checkpoint_sync_endpoint_url(const char *checkpoint_sync_url, const char *endpoint_path)
+{
+    if (!checkpoint_sync_url || checkpoint_sync_url[0] == '\0'
+        || !endpoint_path || endpoint_path[0] != '/')
+    {
+        return NULL;
+    }
+
+    size_t url_len = strlen(checkpoint_sync_url);
+    size_t endpoint_len = strlen(endpoint_path);
+    while (url_len > 0u && checkpoint_sync_url[url_len - 1u] == '/')
+    {
+        --url_len;
+    }
+
+    const char *known_endpoints[] = {
+        CHECKPOINT_SYNC_FINALIZED_STATE_PATH,
+        CHECKPOINT_SYNC_FINALIZED_BLOCK_PATH,
+    };
+
+    for (size_t i = 0; i < sizeof(known_endpoints) / sizeof(known_endpoints[0]); ++i)
+    {
+        size_t known_len = strlen(known_endpoints[i]);
+        if (url_len < known_len
+            || strncmp(
+                   checkpoint_sync_url + url_len - known_len,
+                   known_endpoints[i],
+                   known_len)
+                   != 0)
+        {
+            continue;
+        }
+        url_len -= known_len;
+        break;
+    }
+
+    size_t out_len = url_len + endpoint_len;
+    char *out = malloc(out_len + 1u);
+    if (!out)
+    {
+        return NULL;
+    }
+    memcpy(out, checkpoint_sync_url, url_len);
+    memcpy(out + url_len, endpoint_path, endpoint_len);
+    out[out_len] = '\0';
+    return out;
+}
+
+static lantern_client_error client_fetch_checkpoint_anchor_block(
+    struct lantern_client *client,
+    const char *checkpoint_sync_url,
+    LanternSignedBlock *out_block,
+    LanternRoot *out_root)
+{
+    if (!client || !checkpoint_sync_url || !out_block || !out_root)
+    {
+        return LANTERN_CLIENT_ERR_INVALID_PARAM;
+    }
+
+    struct lantern_log_metadata meta = {.validator = client->node_id};
+    char *block_url = checkpoint_sync_endpoint_url(
+        checkpoint_sync_url,
+        CHECKPOINT_SYNC_FINALIZED_BLOCK_PATH);
+    if (!block_url)
+    {
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "failed to build finalized block URL from %s",
+            checkpoint_sync_url);
+        return LANTERN_CLIENT_ERR_NETWORK;
+    }
+
+    lantern_log_info(
+        "checkpoint_sync",
+        &meta,
+        "fetching finalized checkpoint block from %s",
+        block_url);
+
+    struct lantern_http_fetch_result fetch_result;
+    int fetch_rc = lantern_http_get_bytes(
+        block_url,
+        "application/octet-stream",
+        CHECKPOINT_SYNC_MAX_BLOCK_RESPONSE_BYTES,
+        &fetch_result);
+    if (fetch_rc != 0)
+    {
+        if (fetch_rc == LANTERN_HTTP_CLIENT_STATUS_ERROR)
+        {
+            lantern_log_error(
+                "checkpoint_sync",
+                &meta,
+                "checkpoint block endpoint returned HTTP %d",
+                fetch_result.status_code);
+        }
+        else
+        {
+            lantern_log_error(
+                "checkpoint_sync",
+                &meta,
+                "failed to fetch checkpoint block from %s",
+                block_url);
+        }
+        lantern_http_fetch_result_reset(&fetch_result);
+        free(block_url);
+        return LANTERN_CLIENT_ERR_NETWORK;
+    }
+
+    free(block_url);
+
+    if (!fetch_result.body || fetch_result.body_len == 0)
+    {
+        lantern_http_fetch_result_reset(&fetch_result);
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "checkpoint block endpoint returned an empty block payload");
+        return LANTERN_CLIENT_ERR_NETWORK;
+    }
+
+    if (lantern_ssz_decode_signed_block(out_block, fetch_result.body, fetch_result.body_len)
+        != SSZ_SUCCESS)
+    {
+        lantern_http_fetch_result_reset(&fetch_result);
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "failed to decode checkpoint block SSZ (bytes=%zu)",
+            fetch_result.body_len);
+        return LANTERN_CLIENT_ERR_GENESIS;
+    }
+    lantern_http_fetch_result_reset(&fetch_result);
+
+    if (lantern_hash_tree_root_block(&out_block->block, out_root) != SSZ_SUCCESS)
+    {
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "failed to compute checkpoint block root");
+        return LANTERN_CLIENT_ERR_GENESIS;
+    }
+
+    return LANTERN_CLIENT_OK;
+}
+
+static bool checkpoint_anchor_block_matches_state_header(
+    const LanternSignedBlock *anchor_block,
+    const LanternState *state,
+    const LanternRoot *state_root)
+{
+    if (!anchor_block || !state || !state_root)
+    {
+        return false;
+    }
+
+    const LanternBlockHeader *header = &state->latest_block_header;
+    if (anchor_block->block.slot != header->slot
+        || anchor_block->block.proposer_index != header->proposer_index
+        || memcmp(
+               anchor_block->block.parent_root.bytes,
+               header->parent_root.bytes,
+               LANTERN_ROOT_SIZE)
+            != 0)
+    {
+        return false;
+    }
+
+    if (!lantern_root_is_zero(&header->state_root)
+        && memcmp(header->state_root.bytes, state_root->bytes, LANTERN_ROOT_SIZE) != 0)
+    {
+        return false;
+    }
+
+    LanternRoot body_root;
+    if (lantern_hash_tree_root_block_body(&anchor_block->block.body, &body_root) != SSZ_SUCCESS)
+    {
+        return false;
+    }
+    return memcmp(body_root.bytes, header->body_root.bytes, LANTERN_ROOT_SIZE) == 0;
+}
+
 static lantern_client_error client_load_state_from_checkpoint(
     struct lantern_client *client,
     const char *checkpoint_sync_url)
@@ -1525,15 +1709,43 @@ static lantern_client_error client_load_state_from_checkpoint(
     }
 
     struct lantern_log_metadata meta = {.validator = client->node_id};
+    LanternSignedBlock anchor_signed_block;
+    lantern_signed_block_init(&anchor_signed_block);
+    LanternRoot anchor_root = {0};
+    lantern_client_error block_rc = client_fetch_checkpoint_anchor_block(
+        client,
+        checkpoint_sync_url,
+        &anchor_signed_block,
+        &anchor_root);
+    if (block_rc != LANTERN_CLIENT_OK)
+    {
+        lantern_signed_block_reset(&anchor_signed_block);
+        return block_rc;
+    }
+
+    char *state_url = checkpoint_sync_endpoint_url(
+        checkpoint_sync_url,
+        CHECKPOINT_SYNC_FINALIZED_STATE_PATH);
+    if (!state_url)
+    {
+        lantern_signed_block_reset(&anchor_signed_block);
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "failed to build finalized state URL from %s",
+            checkpoint_sync_url);
+        return LANTERN_CLIENT_ERR_NETWORK;
+    }
+
     lantern_log_info(
         "checkpoint_sync",
         &meta,
         "fetching finalized checkpoint state from %s",
-        checkpoint_sync_url);
+        state_url);
 
     struct lantern_http_fetch_result fetch_result;
     int fetch_rc = lantern_http_get_bytes(
-        checkpoint_sync_url,
+        state_url,
         "application/octet-stream",
         CHECKPOINT_SYNC_MAX_RESPONSE_BYTES,
         &fetch_result);
@@ -1553,9 +1765,11 @@ static lantern_client_error client_load_state_from_checkpoint(
                 "checkpoint_sync",
                 &meta,
                 "failed to fetch checkpoint state from %s",
-                checkpoint_sync_url);
+                state_url);
         }
         lantern_http_fetch_result_reset(&fetch_result);
+        free(state_url);
+        lantern_signed_block_reset(&anchor_signed_block);
         return LANTERN_CLIENT_ERR_NETWORK;
     }
 
@@ -1566,14 +1780,13 @@ static lantern_client_error client_load_state_from_checkpoint(
             "checkpoint_sync",
             &meta,
             "checkpoint sync endpoint returned an empty state payload");
+        free(state_url);
+        lantern_signed_block_reset(&anchor_signed_block);
         return LANTERN_CLIENT_ERR_NETWORK;
     }
 
     LanternState decoded;
     lantern_state_init(&decoded);
-    LanternBlock anchor_block;
-    memset(&anchor_block, 0, sizeof(anchor_block));
-    bool anchor_block_initialized = false;
     bool decoded_owned = true;
     lantern_client_error result = LANTERN_CLIENT_OK;
 
@@ -1656,20 +1869,31 @@ static lantern_client_error client_load_state_from_checkpoint(
         goto cleanup;
     }
 
-    anchor_block.slot = decoded.latest_block_header.slot;
-    anchor_block.proposer_index = decoded.latest_block_header.proposer_index;
-    anchor_block.parent_root = decoded.latest_block_header.parent_root;
-    anchor_block.state_root = state_root;
-    lantern_block_body_init(&anchor_block.body);
-    anchor_block_initialized = true;
+    if (memcmp(anchor_signed_block.block.state_root.bytes, state_root.bytes, LANTERN_ROOT_SIZE) != 0)
+    {
+        char block_state_root_hex[(LANTERN_ROOT_SIZE * 2u) + 3u];
+        char state_root_hex[(LANTERN_ROOT_SIZE * 2u) + 3u];
+        format_root_hex(
+            &anchor_signed_block.block.state_root,
+            block_state_root_hex,
+            sizeof(block_state_root_hex));
+        format_root_hex(&state_root, state_root_hex, sizeof(state_root_hex));
+        lantern_log_error(
+            "checkpoint_sync",
+            &meta,
+            "checkpoint anchor block/state mismatch block_state_root=%s state_root=%s",
+            block_state_root_hex[0] ? block_state_root_hex : "0x0",
+            state_root_hex[0] ? state_root_hex : "0x0");
+        result = LANTERN_CLIENT_ERR_GENESIS;
+        goto cleanup;
+    }
 
-    LanternRoot anchor_root;
-    if (lantern_hash_tree_root_block(&anchor_block, &anchor_root) != SSZ_SUCCESS)
+    if (!checkpoint_anchor_block_matches_state_header(&anchor_signed_block, &decoded, &state_root))
     {
         lantern_log_error(
             "checkpoint_sync",
             &meta,
-            "failed to compute checkpoint anchor block root");
+            "checkpoint anchor block/header mismatch");
         result = LANTERN_CLIENT_ERR_GENESIS;
         goto cleanup;
     }
@@ -1678,6 +1902,42 @@ static lantern_client_error client_load_state_from_checkpoint(
     char anchor_root_hex[(LANTERN_ROOT_SIZE * 2u) + 3u];
     format_root_hex(&state_root, state_root_hex, sizeof(state_root_hex));
     format_root_hex(&anchor_root, anchor_root_hex, sizeof(anchor_root_hex));
+
+    if (!client->data_dir)
+    {
+        lantern_log_error(
+            "storage",
+            &meta,
+            "checkpoint sync requires a data directory for the anchor block");
+        result = LANTERN_CLIENT_ERR_STORAGE;
+        goto cleanup;
+    }
+    if (lantern_storage_store_block_for_root(
+            client->data_dir,
+            &anchor_root,
+            &anchor_signed_block)
+        != 0)
+    {
+        lantern_log_error(
+            "storage",
+            &meta,
+            "failed to persist checkpoint anchor block");
+        result = LANTERN_CLIENT_ERR_STORAGE;
+        goto cleanup;
+    }
+    if (lantern_storage_store_state_for_root(
+            client->data_dir,
+            &anchor_root,
+            &decoded)
+        != 0)
+    {
+        lantern_log_error(
+            "storage",
+            &meta,
+            "failed to persist checkpoint anchor state alias");
+        result = LANTERN_CLIENT_ERR_STORAGE;
+        goto cleanup;
+    }
 
     lantern_state_reset(&client->state);
     client->state = decoded;
@@ -1699,10 +1959,8 @@ static lantern_client_error client_load_state_from_checkpoint(
 
 cleanup:
     lantern_http_fetch_result_reset(&fetch_result);
-    if (anchor_block_initialized)
-    {
-        lantern_block_body_reset(&anchor_block.body);
-    }
+    free(state_url);
+    lantern_signed_block_reset(&anchor_signed_block);
     if (decoded_owned)
     {
         lantern_state_reset(&decoded);

--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -1093,6 +1093,18 @@ void persist_anchor_block(
     block->proposer_index = anchor_block->proposer_index;
     block->parent_root = anchor_block->parent_root;
     block->state_root = anchor_block->state_root;
+    if (lantern_aggregated_attestations_copy(
+            &block->body.attestations,
+            &anchor_block->body.attestations)
+        != 0)
+    {
+        lantern_signed_block_with_attestation_reset(&stored_anchor);
+        lantern_log_warn(
+            "storage",
+            &(const struct lantern_log_metadata){.validator = client->node_id},
+            "failed to copy anchor block body for persistence");
+        return;
+    }
 
     LanternRoot computed_root;
     const LanternRoot *root_to_log = anchor_root;
@@ -1118,7 +1130,7 @@ void persist_anchor_block(
         lantern_log_warn(
             "storage",
             &meta,
-            "failed to persist genesis anchor block root=%s",
+            "failed to persist anchor block root=%s",
             root_hex[0] ? root_hex : "0x0");
     }
     else
@@ -1126,7 +1138,7 @@ void persist_anchor_block(
         lantern_log_debug(
             "storage",
             &meta,
-            "persisted genesis anchor block root=%s",
+            "persisted anchor block root=%s",
             root_hex[0] ? root_hex : "0x0");
     }
     lantern_signed_block_with_attestation_reset(&stored_anchor);
@@ -1137,13 +1149,129 @@ void persist_anchor_block(
  * Fork Choice Initialization
  * ============================================================================ */
 
+static bool load_persisted_checkpoint_anchor_block(
+    struct lantern_client *client,
+    const struct lantern_log_metadata *meta,
+    const LanternRoot *state_root,
+    LanternBlock *out_anchor_block,
+    LanternRoot *out_anchor_root)
+{
+    if (!client || !meta || !state_root || !out_anchor_block || !out_anchor_root
+        || !client->data_dir
+        || lantern_root_is_zero(&client->state.latest_finalized.root))
+    {
+        return false;
+    }
+
+    uint8_t *block_bytes = NULL;
+    size_t block_len = 0;
+    int load_rc = lantern_storage_load_block_bytes_for_root(
+        client->data_dir,
+        &client->state.latest_finalized.root,
+        &block_bytes,
+        &block_len);
+    if (load_rc != 0)
+    {
+        if (load_rc < 0)
+        {
+            lantern_log_warn(
+                "forkchoice",
+                meta,
+                "failed to load persisted checkpoint anchor block");
+        }
+        return false;
+    }
+
+    LanternSignedBlock signed_anchor;
+    lantern_signed_block_with_attestation_init(&signed_anchor);
+    bool loaded = false;
+    if (lantern_ssz_decode_signed_block(&signed_anchor, block_bytes, block_len) != SSZ_SUCCESS)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "failed to decode persisted checkpoint anchor block");
+        goto cleanup;
+    }
+
+    LanternRoot computed_root;
+    if (lantern_hash_tree_root_block(&signed_anchor.block, &computed_root) != SSZ_SUCCESS)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "failed to hash persisted checkpoint anchor block");
+        goto cleanup;
+    }
+
+    if (memcmp(
+            computed_root.bytes,
+            client->state.latest_finalized.root.bytes,
+            LANTERN_ROOT_SIZE)
+        != 0)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "persisted checkpoint anchor block root does not match state finalized root");
+        goto cleanup;
+    }
+
+    if (memcmp(signed_anchor.block.state_root.bytes, state_root->bytes, LANTERN_ROOT_SIZE) != 0)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "persisted checkpoint anchor block state_root does not match checkpoint state");
+        goto cleanup;
+    }
+
+    if (signed_anchor.block.slot != client->state.latest_block_header.slot)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "persisted checkpoint anchor block slot mismatch block=%" PRIu64
+            " header=%" PRIu64,
+            signed_anchor.block.slot,
+            client->state.latest_block_header.slot);
+        goto cleanup;
+    }
+
+    out_anchor_block->slot = signed_anchor.block.slot;
+    out_anchor_block->proposer_index = signed_anchor.block.proposer_index;
+    out_anchor_block->parent_root = signed_anchor.block.parent_root;
+    out_anchor_block->state_root = signed_anchor.block.state_root;
+    lantern_block_body_init(&out_anchor_block->body);
+    if (lantern_aggregated_attestations_copy(
+            &out_anchor_block->body.attestations,
+            &signed_anchor.block.body.attestations)
+        != 0)
+    {
+        lantern_block_body_reset(&out_anchor_block->body);
+        memset(out_anchor_block, 0, sizeof(*out_anchor_block));
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "failed to copy persisted checkpoint anchor block body");
+        goto cleanup;
+    }
+    *out_anchor_root = computed_root;
+    loaded = true;
+
+cleanup:
+    free(block_bytes);
+    lantern_signed_block_with_attestation_reset(&signed_anchor);
+    return loaded;
+}
+
 /**
- * @brief Compute genesis anchor roots for fork choice initialization.
+ * @brief Compute anchor roots for fork choice initialization.
  *
  * @param client             Client instance
  * @param meta               Logging metadata
  * @param out_state_root     Output computed state root
- * @param out_anchor_block   Output anchor block (state_root updated, empty body)
+ * @param out_anchor_block   Output anchor block
  * @param out_anchor_root    Output computed anchor root
  * @return LANTERN_CLIENT_OK on success
  * @return LANTERN_CLIENT_ERR_INVALID_PARAM if any parameter is NULL
@@ -1192,6 +1320,16 @@ static int compute_fork_choice_anchor_roots(
     }
 
     memset(out_anchor_block, 0, sizeof(*out_anchor_block));
+    if (load_persisted_checkpoint_anchor_block(
+            client,
+            meta,
+            out_state_root,
+            out_anchor_block,
+            out_anchor_root))
+    {
+        return LANTERN_CLIENT_OK;
+    }
+
     out_anchor_block->slot = client->state.latest_block_header.slot;
     out_anchor_block->proposer_index = client->state.latest_block_header.proposer_index;
     out_anchor_block->parent_root = client->state.latest_block_header.parent_root;
@@ -1210,7 +1348,7 @@ static int compute_fork_choice_anchor_roots(
 
 
 /**
- * @brief Log genesis anchor roots for debugging mismatches.
+ * @brief Log anchor roots for debugging mismatches.
  *
  * @param meta         Logging metadata
  * @param anchor_root  Anchor block root
@@ -1220,7 +1358,7 @@ static int compute_fork_choice_anchor_roots(
  *
  * @note Thread safety: This function is thread-safe
  */
-static void log_genesis_anchor_roots(
+static void log_anchor_roots(
     const struct lantern_log_metadata *meta,
     const LanternRoot *anchor_root,
     const LanternRoot *state_root,
@@ -1238,7 +1376,7 @@ static void log_genesis_anchor_roots(
     lantern_log_info(
         "forkchoice",
         meta,
-        "genesis anchor_root=%s state_root=%s body_root=%s slot=%" PRIu64,
+        "anchor_root=%s state_root=%s body_root=%s slot=%" PRIu64,
         anchor_root_hex[0] ? anchor_root_hex : "0x0",
         state_root_hex[0] ? state_root_hex : "0x0",
         body_root_hex[0] ? body_root_hex : "0x0",
@@ -1252,14 +1390,13 @@ static void log_genesis_anchor_roots(
  *
  * Initializes the fork choice store from the genesis state:
  * 1. Configures fork choice with consensus parameters
- * 2. Computes anchor block with actual state_root (not zero)
+ * 2. Loads the checkpoint anchor block, or reconstructs a genesis anchor
  * 3. Sets fork choice anchor with anchor checkpoints
  * 4. Persists anchor block to storage
  *
- * According to leanSpec's checkpoint-sync path, the anchor block used for
- * fork choice MUST have state_root = hash_tree_root(state) and an empty body.
- * Store.from_anchor then seeds the head, justified checkpoint, and finalized
- * checkpoint from hash_tree_root(anchor_block).
+ * Current leanSpec checkpoint sync seeds Store.from_anchor with the fetched
+ * finalized block paired with the fetched finalized state. Genesis bootstrap
+ * still reconstructs an empty-body anchor from the embedded header.
  *
  * @param client  Client instance
  * @return LANTERN_CLIENT_OK on success
@@ -1277,12 +1414,6 @@ int initialize_fork_choice(struct lantern_client *client)
 
     const struct lantern_log_metadata meta = {.validator = client->node_id};
 
-    /* Create a reconstructed anchor block for computing anchor_root.
-     *
-     * leanSpec create_anchor_block() uses latest_block_header slot,
-     * proposer_index, and parent_root, fills state_root with the state hash,
-     * and supplies an empty body before Store.from_anchor() hashes it.
-     */
     lantern_store_attach_fork_choice(&client->store, &client->fork_choice);
     lantern_fork_choice_reset(&client->fork_choice);
     if (lantern_fork_choice_configure(&client->fork_choice, &client->state.config) != 0)
@@ -1326,7 +1457,7 @@ int initialize_fork_choice(struct lantern_client *client)
         anchor_root_hex,
         sizeof(anchor_root_hex));
 
-    log_genesis_anchor_roots(
+    log_anchor_roots(
         &meta,
         &anchor_root,
         &anchor_state_root,

--- a/tests/integration/test_ssz_vectors.c
+++ b/tests/integration/test_ssz_vectors.c
@@ -2855,6 +2855,29 @@ static int run_decode_rejection_fixture(
             sizeof(uint8_t),
             decoded,
             sizeof(decoded));
+    } else if (strcmp(type_name, "Validators") == 0) {
+        if (bytes.len % LANTERN_VALIDATOR_SSZ_SIZE != 0u) {
+            decode_status = SSZ_ERR_ENCODING_INVALID;
+        } else if (bytes.len / LANTERN_VALIDATOR_SSZ_SIZE > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+            decode_status = SSZ_ERR_LIMIT_EXCEEDED;
+        } else {
+            decode_status = SSZ_SUCCESS;
+            for (size_t i = 0u; i < bytes.len / LANTERN_VALIDATOR_SSZ_SIZE; ++i) {
+                LanternValidator decoded;
+                memset(&decoded, 0, sizeof(decoded));
+                decode_status = lantern_ssz_decode_validator(
+                    &decoded,
+                    bytes.data + (i * LANTERN_VALIDATOR_SSZ_SIZE),
+                    LANTERN_VALIDATOR_SSZ_SIZE);
+                if (decode_status != SSZ_SUCCESS) {
+                    break;
+                }
+                if (decoded.index != (uint64_t)i) {
+                    decode_status = SSZ_ERR_ENCODING_INVALID;
+                    break;
+                }
+            }
+        }
     } else {
         size_t bit_count = 0u;
         if (parse_size_suffix(type_name, "DecodeBitvector", &bit_count) == 0


### PR DESCRIPTION
Enhance checkpoint sync to fetch the finalized block separately from the state, validate consistency between them, and persist both to storage. During fork choice initialization, attempt to load the persisted checkpoint anchor block instead of always reconstructing a genesis anchor. This ensures the anchor block accurately reflects the checkpoint sync data rather than being approximated from the state header.