### PR TITLE
Fix persisted checkpoint anchor handling

### DIFF
--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -1157,9 +1157,21 @@ static bool load_persisted_checkpoint_anchor_block(
     LanternRoot *out_anchor_root)
 {
     if (!client || !meta || !state_root || !out_anchor_block || !out_anchor_root
-        || !client->data_dir
-        || lantern_root_is_zero(&client->state.latest_finalized.root))
+        || !client->data_dir)
     {
+        return false;
+    }
+
+    LanternBlockHeader expected_anchor_header = client->state.latest_block_header;
+    expected_anchor_header.state_root = *state_root;
+    LanternRoot expected_anchor_root;
+    if (lantern_hash_tree_root_block_header(&expected_anchor_header, &expected_anchor_root)
+        != SSZ_SUCCESS)
+    {
+        lantern_log_warn(
+            "forkchoice",
+            meta,
+            "failed to hash checkpoint state latest block header");
         return false;
     }
 
@@ -1167,7 +1179,7 @@ static bool load_persisted_checkpoint_anchor_block(
     size_t block_len = 0;
     int load_rc = lantern_storage_load_block_bytes_for_root(
         client->data_dir,
-        &client->state.latest_finalized.root,
+        &expected_anchor_root,
         &block_bytes,
         &block_len);
     if (load_rc != 0)
@@ -1206,35 +1218,14 @@ static bool load_persisted_checkpoint_anchor_block(
 
     if (memcmp(
             computed_root.bytes,
-            client->state.latest_finalized.root.bytes,
+            expected_anchor_root.bytes,
             LANTERN_ROOT_SIZE)
         != 0)
     {
         lantern_log_warn(
             "forkchoice",
             meta,
-            "persisted checkpoint anchor block root does not match state finalized root");
-        goto cleanup;
-    }
-
-    if (memcmp(signed_anchor.block.state_root.bytes, state_root->bytes, LANTERN_ROOT_SIZE) != 0)
-    {
-        lantern_log_warn(
-            "forkchoice",
-            meta,
-            "persisted checkpoint anchor block state_root does not match checkpoint state");
-        goto cleanup;
-    }
-
-    if (signed_anchor.block.slot != client->state.latest_block_header.slot)
-    {
-        lantern_log_warn(
-            "forkchoice",
-            meta,
-            "persisted checkpoint anchor block slot mismatch block=%" PRIu64
-            " header=%" PRIu64,
-            signed_anchor.block.slot,
-            client->state.latest_block_header.slot);
+            "persisted checkpoint anchor block root does not match checkpoint header");
         goto cleanup;
     }
 
@@ -1256,7 +1247,7 @@ static bool load_persisted_checkpoint_anchor_block(
             "failed to copy persisted checkpoint anchor block body");
         goto cleanup;
     }
-    *out_anchor_root = computed_root;
+    *out_anchor_root = expected_anchor_root;
     loaded = true;
 
 cleanup:
@@ -1328,6 +1319,26 @@ static int compute_fork_choice_anchor_roots(
             out_anchor_root))
     {
         return LANTERN_CLIENT_OK;
+    }
+
+    LanternBlockBody empty_body;
+    lantern_block_body_init(&empty_body);
+    LanternRoot empty_body_root;
+    bool empty_body_root_ok =
+        lantern_hash_tree_root_block_body(&empty_body, &empty_body_root) == SSZ_SUCCESS;
+    lantern_block_body_reset(&empty_body);
+    if (!empty_body_root_ok
+        || memcmp(
+               empty_body_root.bytes,
+               client->state.latest_block_header.body_root.bytes,
+               LANTERN_ROOT_SIZE)
+               != 0)
+    {
+        lantern_log_error(
+            "forkchoice",
+            meta,
+            "missing persisted checkpoint anchor block for non-empty checkpoint header body");
+        return LANTERN_CLIENT_ERR_RUNTIME;
     }
 
     out_anchor_block->slot = client->state.latest_block_header.slot;
@@ -1936,13 +1947,14 @@ int restore_persisted_blocks(struct lantern_client *client)
             lantern_log_info(
                 "forkchoice",
                 &(const struct lantern_log_metadata){.validator = client->node_id},
-                "aliasing restored justified checkpoint slot=%" PRIu64
+                "rebasing restored justified checkpoint slot=%" PRIu64
                 " original_root=%s anchor_slot=%" PRIu64 " anchor_root=%s",
                 restored_justified.slot,
                 original_justified_hex[0] ? original_justified_hex : "0x0",
                 restore_anchor_slot,
                 anchor_hex[0] ? anchor_hex : "0x0");
             restored_justified.root = *restore_anchor_root;
+            restored_justified.slot = restore_anchor_slot;
         }
         if (!restored_finalized_known && restored_finalized.slot <= restore_anchor_slot)
         {
@@ -1959,13 +1971,14 @@ int restore_persisted_blocks(struct lantern_client *client)
             lantern_log_info(
                 "forkchoice",
                 &(const struct lantern_log_metadata){.validator = client->node_id},
-                "aliasing restored finalized checkpoint slot=%" PRIu64
+                "rebasing restored finalized checkpoint slot=%" PRIu64
                 " original_root=%s anchor_slot=%" PRIu64 " anchor_root=%s",
                 restored_finalized.slot,
                 original_finalized_hex[0] ? original_finalized_hex : "0x0",
                 restore_anchor_slot,
                 anchor_hex[0] ? anchor_hex : "0x0");
             restored_finalized.root = *restore_anchor_root;
+            restored_finalized.slot = restore_anchor_slot;
         }
     }
 

--- a/tests/unit/test_genesis_anchor.c
+++ b/tests/unit/test_genesis_anchor.c
@@ -787,6 +787,7 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
     LanternRoot canonical_state_root = {0};
     LanternRoot expected_anchor_root = {0};
     LanternRoot actual_head = {0};
+    LanternSignedBlock persisted_anchor;
     int rc = 1;
 
     memset(&client, 0, sizeof(client));
@@ -794,6 +795,7 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
     client.has_state = true;
     lantern_state_init(&client.state);
     lantern_store_init(&client.store);
+    lantern_signed_block_with_attestation_init(&persisted_anchor);
 
     if (lantern_state_generate_genesis(&client.state, UINT64_C(1761717362), 5u) != 0)
     {
@@ -839,26 +841,80 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
     }
     client.data_dir = data_dir;
 
+    persisted_anchor.block.slot = client.state.latest_block_header.slot;
+    persisted_anchor.block.proposer_index = client.state.latest_block_header.proposer_index;
+    persisted_anchor.block.parent_root = client.state.latest_block_header.parent_root;
+    if (lantern_aggregated_attestations_resize(
+            &persisted_anchor.block.body.attestations,
+            1u)
+        != 0)
+    {
+        fprintf(stderr, "failed to build checkpoint anchor block body\n");
+        goto cleanup;
+    }
+    LanternAggregatedAttestation *anchor_attestation =
+        &persisted_anchor.block.body.attestations.data[0];
+    if (lantern_bitlist_resize(&anchor_attestation->aggregation_bits, 5u) != 0
+        || lantern_bitlist_set(&anchor_attestation->aggregation_bits, 2u, true) != 0)
+    {
+        fprintf(stderr, "failed to build checkpoint anchor aggregation bits\n");
+        goto cleanup;
+    }
+    anchor_attestation->data.slot = client.state.latest_block_header.slot - 1u;
+    anchor_attestation->data.head = remote_justified;
+    anchor_attestation->data.target = remote_justified;
+    anchor_attestation->data.source = remote_finalized;
+
+    LanternRoot anchor_body_root = {0};
+    if (lantern_hash_tree_root_block_body(&persisted_anchor.block.body, &anchor_body_root)
+        != SSZ_SUCCESS)
+    {
+        fprintf(stderr, "failed to hash checkpoint anchor block body\n");
+        goto cleanup;
+    }
+    client.state.latest_block_header.body_root = anchor_body_root;
+
     if (lantern_hash_tree_root_state(&client.state, &canonical_state_root) != SSZ_SUCCESS)
     {
         fprintf(stderr, "failed to hash checkpoint anchor restore regression state\n");
         goto cleanup;
     }
+    persisted_anchor.block.state_root = canonical_state_root;
 
-    LanternBlock expected_anchor_block;
-    memset(&expected_anchor_block, 0, sizeof(expected_anchor_block));
-    expected_anchor_block.slot = client.state.latest_block_header.slot;
-    expected_anchor_block.proposer_index = client.state.latest_block_header.proposer_index;
-    expected_anchor_block.parent_root = client.state.latest_block_header.parent_root;
-    expected_anchor_block.state_root = canonical_state_root;
-    lantern_block_body_init(&expected_anchor_block.body);
-    if (lantern_hash_tree_root_block(&expected_anchor_block, &expected_anchor_root) != SSZ_SUCCESS)
+    if (lantern_hash_tree_root_block(&persisted_anchor.block, &expected_anchor_root)
+        != SSZ_SUCCESS)
     {
-        lantern_block_body_reset(&expected_anchor_block.body);
         fprintf(stderr, "failed to hash checkpoint anchor restore regression anchor block\n");
         goto cleanup;
     }
-    lantern_block_body_reset(&expected_anchor_block.body);
+    LanternBlockHeader expected_anchor_header = client.state.latest_block_header;
+    expected_anchor_header.state_root = canonical_state_root;
+    LanternRoot expected_header_root = {0};
+    if (lantern_hash_tree_root_block_header(&expected_anchor_header, &expected_header_root)
+        != SSZ_SUCCESS)
+    {
+        fprintf(stderr, "failed to hash checkpoint anchor restore regression header\n");
+        goto cleanup;
+    }
+    if (!roots_equal(&expected_anchor_root, &expected_header_root))
+    {
+        fprintf(stderr, "checkpoint anchor block/header root mismatch in test setup\n");
+        goto cleanup;
+    }
+    if (roots_equal(&expected_anchor_root, &remote_finalized.root))
+    {
+        fprintf(stderr, "test setup failed to create distinct checkpoint anchor root\n");
+        goto cleanup;
+    }
+    if (lantern_storage_store_block_for_root(
+            client.data_dir,
+            &expected_anchor_root,
+            &persisted_anchor)
+        != 0)
+    {
+        fprintf(stderr, "failed to persist checkpoint anchor block for restore regression\n");
+        goto cleanup;
+    }
 
     if (initialize_fork_choice(&client) != LANTERN_CLIENT_OK)
     {
@@ -1014,6 +1070,7 @@ cleanup:
     lantern_fork_choice_reset(&client.fork_choice);
     lantern_store_reset(&client.store);
     lantern_state_reset(&client.state);
+    lantern_signed_block_with_attestation_reset(&persisted_anchor);
     return rc;
 }
 


### PR DESCRIPTION
Use the checkpoint header (latest_block_header with supplied state_root) to compute the expected anchor root and load the persisted block by that root (rather than using latest_finalized.root). Verify header/body roots and error when a persisted anchor is missing for a non-empty header body. Return the expected anchor root to callers. Update restore logs from "aliasing" to "rebasing" and ensure restored checkpoint slots are rebased to the anchor slot. Update unit test setup to create, store and clean up a persisted signed anchor block (including body attestations and body_root) to match the new loading behavior.