### PR TITLE
fix reqresp status_now peer resolution

### DIFF
--- a/src/core/client_network.c
+++ b/src/core/client_network.c
@@ -690,7 +690,15 @@ void request_status_now(struct lantern_client *client, const struct lantern_peer
             "status guard disabled; allowing concurrent request");
     }
 
-    int status_rc = lantern_reqresp_service_request_status(&client->reqresp, peer, status_peer);
+    struct lantern_peer_id resolved_peer;
+    const struct lantern_peer_id *peer_arg = peer;
+    if (!peer_arg && status_peer
+        && lantern_peer_id_from_text(status_peer, &resolved_peer) == 0)
+    {
+        peer_arg = &resolved_peer;
+    }
+
+    int status_rc = lantern_reqresp_service_request_status(&client->reqresp, peer_arg, status_peer);
     if (status_peer)
     {
         const char *msg = (status_rc == 0)


### PR DESCRIPTION
Request_status_now was passing NULL for the struct peer ID when the caller only had text, so service_open_exchange rejected the call and 96% of periodic status requests silently  failed with -1004. I resolve the peer ID from the text via lantern_peer_id_from_text  before the call  same pattern already in client_reqresp_blocks.c:33.  