### PR TITLE
Refactor HTTP, storage, and YAML subsystems with libevent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
           path: tools/leanSpec/fixtures/consensus
           key: ${{ steps.consensus-fixtures-cache-key.outputs.key }}
 
+      - name: Install system dependencies
+        if: steps.consensus-fixtures-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libcurl4-openssl-dev libevent-dev libyaml-dev
+
       - name: Install uv
         if: steps.consensus-fixtures-cache.outputs.cache-hit != 'true'
         run: |
@@ -111,7 +117,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build pkg-config
+          sudo apt-get install -y ninja-build pkg-config libcurl4-openssl-dev libevent-dev libyaml-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ set(SECP256K1_BUILD_CTIME_TESTS OFF CACHE BOOL "" FORCE)
 set(SECP256K1_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 find_package(Threads REQUIRED)
+find_package(CURL REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBYAML REQUIRED IMPORTED_TARGET yaml-0.1)
+pkg_check_modules(LIBEVENT REQUIRED IMPORTED_TARGET libevent_extra libevent_pthreads)
 
 set(LANTERN_LIBRARY_SOURCES
     src/consensus/containers.c
@@ -95,7 +99,13 @@ function(lantern_define_library target_name wrapper_target)
             _POSIX_C_SOURCE=200809L
     )
     lantern_configure_dependencies(${target_name} ${wrapper_target})
-    target_link_libraries(${target_name} PRIVATE Threads::Threads)
+    target_link_libraries(${target_name} PRIVATE Threads::Threads CURL::libcurl PkgConfig::LIBYAML PkgConfig::LIBEVENT)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Keep vendored AWS-LC from interposing on libcurl's OpenSSL backend.
+        target_link_options(${target_name} INTERFACE
+            "LINKER:--exclude-libs,libssl.a"
+            "LINKER:--exclude-libs,libcrypto.a")
+    endif()
 endfunction()
 
 lantern_define_library(lantern lantern_c_leanvm_xmss)

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-${TARGE
         git \
         ninja-build \
         pkg-config \
+        libcurl4-openssl-dev \
+        libevent-dev \
+        libyaml-dev \
         flex \
         python3 \
         python3-pip \
@@ -146,6 +149,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-${TARGE
         ca-certificates \
         libssl3 \
         libstdc++6 \
+        libcurl4 \
+        libevent-2.1-7 \
+        libevent-extra-2.1-7 \
+        libevent-pthreads-2.1-7 \
+        libyaml-0-2 \
         zlib1g \
     && if [ "$INCLUDE_DEBUG_TOOLS" = "true" ]; then \
         apt-get install -y --no-install-recommends gdb linux-tools-generic valgrind \

--- a/include/lantern/consensus/state.h
+++ b/include/lantern/consensus/state.h
@@ -69,15 +69,6 @@ bool lantern_state_slot_in_justified_window(const LanternState *state, uint64_t 
 int lantern_state_get_justified_slot_bit(const LanternState *state, uint64_t slot, bool *out_value);
 int lantern_state_mark_justified_slot(LanternState *state, uint64_t slot);
 int lantern_state_transition(LanternState *state, const LanternSignedBlock *signed_block);
-int lantern_state_set_validator_pubkeys(LanternState *state, const uint8_t *pubkeys, size_t count);
-int lantern_state_set_validator_pubkeys_dual(
-    LanternState *state,
-    const uint8_t *attestation_pubkeys,
-    const uint8_t *proposal_pubkeys,
-    size_t count);
-size_t lantern_state_validator_count(const LanternState *state);
-const uint8_t *lantern_state_validator_attestation_pubkey(const LanternState *state, size_t index);
-const uint8_t *lantern_state_validator_proposal_pubkey(const LanternState *state, size_t index);
 int lantern_state_select_block_parent(
     LanternState *state,
     const LanternStore *store,

--- a/include/lantern/core/client.h
+++ b/include/lantern/core/client.h
@@ -17,6 +17,7 @@
 #include "lantern/networking/libp2p.h"
 #include "lantern/networking/gossipsub_service.h"
 #include "lantern/networking/reqresp_service.h"
+#include "lantern/storage/storage.h"
 #include "lantern/support/string_list.h"
 
 #include "pq-bindings-c-rust.h"
@@ -173,6 +174,7 @@ struct lantern_local_validator {
 
 struct lantern_client {
     char *data_dir;
+    struct lantern_storage storage;
     char *node_id;
     char *listen_address;
     uint16_t http_port;

--- a/include/lantern/http/client.h
+++ b/include/lantern/http/client.h
@@ -15,20 +15,11 @@ enum
     LANTERN_HTTP_CLIENT_ERR = -1,
 };
 
-struct lantern_http_url {
-    char *host;
-    uint16_t port;
-    char *path;
-};
-
 struct lantern_http_fetch_result {
     int status_code;
     uint8_t *body;
     size_t body_len;
 };
-
-int lantern_http_url_parse(const char *url, struct lantern_http_url *out_url);
-void lantern_http_url_reset(struct lantern_http_url *url);
 
 int lantern_http_get_bytes(
     const char *url,

--- a/include/lantern/http/core.h
+++ b/include/lantern/http/core.h
@@ -2,7 +2,6 @@
 #define LANTERN_HTTP_CORE_H
 
 #include <pthread.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -10,37 +9,24 @@
 extern "C" {
 #endif
 
-#define LANTERN_HTTP_CORE_METHOD_CAP 8u
-#define LANTERN_HTTP_CORE_PATH_CAP 256u
-#define LANTERN_HTTP_CORE_READ_BUFFER_SIZE 4096u
-#define LANTERN_HTTP_CORE_LISTEN_BACKLOG 16
+struct event_base;
+struct evhttp;
+struct evhttp_request;
 
 enum
 {
     LANTERN_HTTP_CORE_OK = 0,
     LANTERN_HTTP_CORE_ERR_INVALID_PARAM = -1,
     LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY = -2,
-    LANTERN_HTTP_CORE_ERR_OVERFLOW = -3,
-    LANTERN_HTTP_CORE_ERR_IO = -4,
-    LANTERN_HTTP_CORE_ERR_FORMATTING = -5,
-    LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST = -6,
-};
-
-struct lantern_http_buffer {
-    char *data;
-    size_t len;
-    size_t cap;
+    LANTERN_HTTP_CORE_ERR_IO = -3,
 };
 
 struct lantern_http_request {
-    int client_fd;
+    struct evhttp_request *transport;
     const char *method;
     const char *path;
-    const char *raw;
-    size_t raw_len;
     const char *body;
     size_t body_len;
-    bool has_body;
     const char *peer;
 };
 
@@ -58,7 +44,6 @@ struct lantern_http_core_config {
     uint16_t port;
     const char *log_module;
     const char *listen_label;
-    const char *malformed_json;
     const char *unknown_json;
     void *context;
     const struct lantern_http_route *routes;
@@ -68,8 +53,9 @@ struct lantern_http_core_config {
 struct lantern_http_core_server {
     int listen_fd;
     pthread_t thread;
-    int running;
     int thread_started;
+    struct event_base *event_base;
+    struct evhttp *http;
     struct lantern_http_core_config config;
 };
 
@@ -79,40 +65,18 @@ int lantern_http_core_start(
     const struct lantern_http_core_config *config);
 void lantern_http_core_stop(struct lantern_http_core_server *server);
 
-int lantern_http_send_all(int fd, const char *data, size_t length);
 int lantern_http_send_response(
-    int fd,
+    const struct lantern_http_request *request,
     int status_code,
     const char *status_text,
     const char *content_type,
     const char *body,
     size_t body_len);
 int lantern_http_send_json_error(
-    int fd,
+    const struct lantern_http_request *request,
     int status_code,
     const char *status_text,
     const char *json_body);
-
-int lantern_http_buffer_init(struct lantern_http_buffer *buf, size_t initial_cap);
-void lantern_http_buffer_free(struct lantern_http_buffer *buf);
-int lantern_http_buffer_reserve(struct lantern_http_buffer *buf, size_t extra);
-int lantern_http_buffer_appendf(struct lantern_http_buffer *buf, const char *fmt, ...);
-
-bool lantern_http_locate_body(
-    const char *buffer,
-    size_t buffer_len,
-    const char **out_body,
-    size_t *out_body_len);
-int lantern_http_parse_content_length(
-    const char *buffer,
-    size_t buffer_len,
-    size_t *out_content_length);
-
-int lantern_http_request_read_body(
-    const struct lantern_http_request *request,
-    size_t max_body_size,
-    char **out_body,
-    size_t *out_body_len);
 
 #ifdef __cplusplus
 }

--- a/include/lantern/networking/reqresp_service.h
+++ b/include/lantern/networking/reqresp_service.h
@@ -88,12 +88,8 @@ struct lantern_reqresp_protocol_context {
 struct lantern_reqresp_service {
     struct lantern_libp2p_host *network;
     struct lantern_reqresp_service_callbacks callbacks;
-    libp2p_host_protocol_t status_protocol;
-    libp2p_host_protocol_t blocks_protocol;
-    libp2p_host_protocol_t blocks_by_range_protocol;
-    struct lantern_reqresp_protocol_context status_context;
-    struct lantern_reqresp_protocol_context blocks_context;
-    struct lantern_reqresp_protocol_context blocks_by_range_context;
+    libp2p_host_protocol_t protocols[LANTERN_REQRESP_PROTOCOL_KIND_COUNT];
+    struct lantern_reqresp_protocol_context protocol_contexts[LANTERN_REQRESP_PROTOCOL_KIND_COUNT];
     struct lantern_reqresp_exchange *exchanges;
     int lock_initialized;
     pthread_mutex_t lock;

--- a/include/lantern/storage/storage.h
+++ b/include/lantern/storage/storage.h
@@ -17,40 +17,45 @@ typedef int (*lantern_storage_block_visitor_fn)(
     const LanternRoot *root,
     void *context);
 
-int lantern_storage_prepare(const char *data_dir);
-int lantern_storage_save_state(const char *data_dir, const LanternState *state);
-int lantern_storage_load_state(const char *data_dir, LanternState *state);
-int lantern_storage_store_block(const char *data_dir, const LanternSignedBlock *block);
+struct lantern_storage {
+    void *backend;
+};
+
+int lantern_storage_open(struct lantern_storage *storage, const char *data_dir);
+void lantern_storage_close(struct lantern_storage *storage);
+int lantern_storage_save_state(const struct lantern_storage *storage, const LanternState *state);
+int lantern_storage_load_state(const struct lantern_storage *storage, LanternState *state);
+int lantern_storage_store_block(const struct lantern_storage *storage, const LanternSignedBlock *block);
 int lantern_storage_store_block_for_root(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     const LanternRoot *root,
     const LanternSignedBlock *block);
 int lantern_storage_store_state_for_root(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     const LanternRoot *root,
     const LanternState *state);
 int lantern_storage_load_state_bytes_for_root(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     const LanternRoot *root,
     uint8_t **out_data,
     size_t *out_len);
 int lantern_storage_load_block_bytes_for_root(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     const LanternRoot *root,
     uint8_t **out_data,
     size_t *out_len);
 int lantern_storage_prune_before_slot(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     uint64_t slot,
     const LanternRoot *keep_roots,
     size_t keep_root_count);
 int lantern_storage_collect_blocks(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     const LanternRoot *roots,
     size_t root_count,
     LanternSignedBlockList *out_blocks);
 int lantern_storage_iterate_blocks(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     lantern_storage_block_visitor_fn visitor,
     void *context);
 

--- a/src/consensus/signature.c
+++ b/src/consensus/signature.c
@@ -177,7 +177,7 @@ static bool prepare_recursive_child(
         return false;
     }
 
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
     size_t pubkey_index = 0u;
     for (size_t validator_index = 0; validator_index < proof->participants.bit_length; ++validator_index) {
         if (!lantern_bitlist_get(&proof->participants, validator_index)) {
@@ -187,8 +187,7 @@ static bool prepare_recursive_child(
             return false;
         }
 
-        const uint8_t *pubkey =
-            lantern_state_validator_attestation_pubkey(state, validator_index);
+        const uint8_t *pubkey = state->validators[validator_index].attestation_pubkey;
         if (!pubkey || lantern_validator_pubkey_is_zero(pubkey)) {
             return false;
         }
@@ -394,7 +393,7 @@ static bool build_type2_attestation_component(
     if (!state || !participants || !work || !component) {
         return false;
     }
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
     if (participants->bit_length > validator_count) {
         return false;
     }
@@ -411,7 +410,7 @@ static bool build_type2_attestation_component(
         if (!lantern_bitlist_get(participants, i)) {
             continue;
         }
-        const uint8_t *pubkey = lantern_state_validator_attestation_pubkey(state, i);
+        const uint8_t *pubkey = state->validators[i].attestation_pubkey;
         if (!pubkey || lantern_validator_pubkey_is_zero(pubkey)) {
             free(pubkeys);
             return false;
@@ -431,11 +430,11 @@ static bool build_type2_proposer_component(
     if (!state || !work || !component) {
         return false;
     }
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
     if (proposer_index >= validator_count) {
         return false;
     }
-    const uint8_t *pubkey = lantern_state_validator_proposal_pubkey(state, (size_t)proposer_index);
+    const uint8_t *pubkey = state->validators[proposer_index].proposal_pubkey;
     return type2_component_init_from_pubkeys(&pubkey, 1u, work, component);
 }
 

--- a/src/consensus/state.c
+++ b/src/consensus/state.c
@@ -621,7 +621,7 @@ static lantern_state_aggregate_result state_append_selected_group(
     lantern_aggregated_signature_proof_init(&proof);
 
     lantern_state_aggregate_result rc = LANTERN_STATE_AGGREGATE_OK;
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
 
     if (raw_count > 0u) {
         if (highest_raw_id >= validator_count
@@ -653,8 +653,7 @@ static lantern_state_aggregate_result state_append_selected_group(
                 goto cleanup;
             }
 
-            const uint8_t *pubkey =
-                lantern_state_validator_attestation_pubkey(state, (size_t)validator_id);
+            const uint8_t *pubkey = state->validators[validator_id].attestation_pubkey;
             if (!pubkey || lantern_validator_pubkey_is_zero(pubkey)) {
                 rc = LANTERN_STATE_AGGREGATE_RUNTIME;
                 goto cleanup;
@@ -1570,61 +1569,6 @@ static int lantern_state_prune_justification_roots(
         }
     }
     return 0;
-}
-
-int lantern_state_set_validator_pubkeys_dual(
-    LanternState *state,
-    const uint8_t *attestation_pubkeys,
-    const uint8_t *proposal_pubkeys,
-    size_t count) {
-    if (!state) {
-        return -1;
-    }
-    if (count > (size_t)LANTERN_VALIDATOR_REGISTRY_LIMIT) {
-        return -1;
-    }
-    if (count != state->validator_count) {
-        return -1;
-    }
-    if (count > 0 && (!state->validators || !attestation_pubkeys || !proposal_pubkeys)) {
-        return -1;
-    }
-    for (size_t i = 0; i < count; ++i) {
-        memcpy(
-            state->validators[i].attestation_pubkey,
-            attestation_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
-            LANTERN_VALIDATOR_PUBKEY_SIZE);
-        memcpy(
-            state->validators[i].proposal_pubkey,
-            proposal_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
-            LANTERN_VALIDATOR_PUBKEY_SIZE);
-    }
-    return 0;
-}
-
-int lantern_state_set_validator_pubkeys(LanternState *state, const uint8_t *pubkeys, size_t count) {
-    return lantern_state_set_validator_pubkeys_dual(state, pubkeys, pubkeys, count);
-}
-
-size_t lantern_state_validator_count(const LanternState *state) {
-    if (!state || !state->validators) {
-        return 0;
-    }
-    return state->validator_count;
-}
-
-const uint8_t *lantern_state_validator_attestation_pubkey(const LanternState *state, size_t index) {
-    if (!state || !state->validators || index >= state->validator_count) {
-        return NULL;
-    }
-    return state->validators[index].attestation_pubkey;
-}
-
-const uint8_t *lantern_state_validator_proposal_pubkey(const LanternState *state, size_t index) {
-    if (!state || !state->validators || index >= state->validator_count) {
-        return NULL;
-    }
-    return state->validators[index].proposal_pubkey;
 }
 
 void lantern_state_init(LanternState *state) {

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -965,9 +965,9 @@ static lantern_client_error client_init_locks(struct lantern_client *client)
 
 
 /**
- * @brief Prepare storage directories and load genesis artifacts.
+ * @brief Open persistent storage and load genesis artifacts.
  *
- * Ensures the data directory exists, copies bootnodes and path configuration,
+ * Opens the data store, copies bootnodes and path configuration,
  * loads genesis configuration, and validates validator assignment coverage.
  *
  * @param client   Client being prepared
@@ -984,7 +984,7 @@ static lantern_client_error client_prepare_storage_and_genesis(
     struct lantern_client *client,
     const struct lantern_client_options *options)
 {
-    if (lantern_storage_prepare(client->data_dir) != 0)
+    if (lantern_storage_open(&client->storage, client->data_dir) != 0)
     {
         lantern_log_error(
             "storage",
@@ -1479,7 +1479,7 @@ static lantern_client_error client_load_state_from_checkpoint(
         goto cleanup;
     }
     if (lantern_storage_store_block_for_root(
-            client->data_dir,
+            &client->storage,
             &anchor_root,
             &anchor_signed_block)
         != 0)
@@ -1492,7 +1492,7 @@ static lantern_client_error client_load_state_from_checkpoint(
         goto cleanup;
     }
     if (lantern_storage_store_state_for_root(
-            client->data_dir,
+            &client->storage,
             &anchor_root,
             &decoded)
         != 0)
@@ -1579,7 +1579,7 @@ static lantern_client_error client_load_or_build_state(
     const struct lantern_log_metadata meta = {.validator = client ? client->node_id : NULL};
     bool from_storage = false;
     bool should_attempt_checkpoint_sync = false;
-    int storage_state_rc = lantern_storage_load_state(client->data_dir, &client->state);
+    int storage_state_rc = lantern_storage_load_state(&client->storage, &client->state);
     if (storage_state_rc == 0)
     {
         from_storage = true;
@@ -1670,7 +1670,7 @@ static lantern_client_error client_load_or_build_state(
 
     if (client->state.validator_count > 0u && !from_storage)
     {
-        if (lantern_storage_save_state(client->data_dir, &client->state) != 0)
+        if (lantern_storage_save_state(&client->storage, &client->state) != 0)
         {
             lantern_log_warn(
                 "storage",
@@ -2527,6 +2527,7 @@ void lantern_shutdown(struct lantern_client *client)
     lantern_log_reset_node_id();
 
     lantern_string_list_reset(&client->bootnodes);
+    lantern_storage_close(&client->storage);
     free(client->data_dir);
     free(client->node_id);
     free(client->listen_address);

--- a/src/core/client_http.c
+++ b/src/core/client_http.c
@@ -319,7 +319,7 @@ static int load_finalized_ssz(
     void *context,
     uint8_t **out_bytes,
     size_t *out_len,
-    int (*load)(const char *, const LanternRoot *, uint8_t **, size_t *))
+    int (*load)(const struct lantern_storage *, const LanternRoot *, uint8_t **, size_t *))
 {
     if (!context || !out_bytes || !out_len || !load)
     {
@@ -330,7 +330,7 @@ static int load_finalized_ssz(
     *out_len = 0;
 
     struct lantern_client *client = context;
-    if (!client->data_dir || client->store.block_len == 0u)
+    if (!client->storage.backend || client->store.block_len == 0u)
     {
         return LANTERN_HTTP_CB_ERR_INVALID_STATE;
     }
@@ -345,7 +345,7 @@ static int load_finalized_ssz(
         return LANTERN_HTTP_CB_ERR_NOT_FOUND;
     }
 
-    int load_rc = load(client->data_dir, &finalized.root, out_bytes, out_len);
+    int load_rc = load(&client->storage, &finalized.root, out_bytes, out_len);
     return load_rc == 0
         ? LANTERN_HTTP_CB_OK
         : (load_rc > 0 ? LANTERN_HTTP_CB_ERR_NOT_FOUND : LANTERN_HTTP_CB_ERR_IO);

--- a/src/core/client_keys.c
+++ b/src/core/client_keys.c
@@ -210,32 +210,6 @@ static void xmss_manifest_reset(struct xmss_manifest *manifest)
 
 
 /**
- * Get a string value from a YAML object.
- *
- * @param object  YAML object
- * @param key     Key to look up
- * @return Value string or NULL if not found
- *
- * @note Thread safety: This function is thread-safe
- */
-static const char *xmss_yaml_value(const LanternYamlObject *object, const char *key)
-{
-    if (!object || !key || !object->pairs)
-    {
-        return NULL;
-    }
-    for (size_t i = 0; i < object->num_pairs; ++i)
-    {
-        if (object->pairs[i].key && strcmp(object->pairs[i].key, key) == 0)
-        {
-            return object->pairs[i].value;
-        }
-    }
-    return NULL;
-}
-
-
-/**
  * Parse a uint64 from text.
  *
  * @param text       Text to parse
@@ -352,8 +326,7 @@ static int xmss_manifest_load_annotated(
     struct xmss_manifest *manifest)
 {
     int result = LANTERN_CLIENT_ERR_CONFIG;
-    LanternYamlObject *objects = NULL;
-    size_t count = 0;
+    struct lantern_yaml_document document = {0};
     struct xmss_manifest_entry *entries = NULL;
     size_t entry_count = 0;
 
@@ -363,10 +336,17 @@ static int xmss_manifest_load_annotated(
     }
     xmss_manifest_reset(manifest);
 
-    objects = lantern_yaml_read_array(path, node_id, &count);
-    if (!objects || count == 0)
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
-        result = LANTERN_CLIENT_ERR_CONFIG;
+        goto cleanup;
+    }
+    const yaml_node_t *objects = lantern_yaml_mapping_get(
+        &document,
+        lantern_yaml_root(&document),
+        node_id);
+    size_t count = lantern_yaml_sequence_length(objects);
+    if (count == 0u)
+    {
         goto cleanup;
     }
 
@@ -384,9 +364,13 @@ static int xmss_manifest_load_annotated(
 
     for (size_t i = 0; i < count; ++i)
     {
-        const char *index_text = xmss_yaml_value(&objects[i], "index");
-        const char *pubkey_hex = xmss_yaml_value(&objects[i], "pubkey_hex");
-        const char *secret_file = xmss_yaml_value(&objects[i], "privkey_file");
+        const yaml_node_t *object = lantern_yaml_sequence_get(&document, objects, i);
+        const char *index_text = lantern_yaml_scalar(
+            lantern_yaml_mapping_get(&document, object, "index"));
+        const char *pubkey_hex = lantern_yaml_scalar(
+            lantern_yaml_mapping_get(&document, object, "pubkey_hex"));
+        const char *secret_file = lantern_yaml_scalar(
+            lantern_yaml_mapping_get(&document, object, "privkey_file"));
         if (!index_text || !pubkey_hex || !secret_file)
         {
             result = LANTERN_CLIENT_ERR_CONFIG;
@@ -457,7 +441,7 @@ static int xmss_manifest_load_annotated(
     result = LANTERN_CLIENT_OK;
 
 cleanup:
-    lantern_yaml_free_objects(objects, count);
+    lantern_yaml_document_reset(&document);
     if (entries)
     {
         struct xmss_manifest tmp = {.entries = entries, .count = entry_count};

--- a/src/core/client_network.c
+++ b/src/core/client_network.c
@@ -64,11 +64,18 @@ static lean_metrics_direction_t metrics_direction_from_inbound(bool inbound)
     return inbound ? LEAN_METRICS_DIR_INBOUND : LEAN_METRICS_DIR_OUTBOUND;
 }
 
-static lean_metrics_disconnection_reason_t metrics_disconnection_reason_from_code(int reason)
+static lean_metrics_disconnection_reason_t metrics_disconnection_reason_from_close(
+    int reason,
+    bool locally_initiated,
+    uint64_t transport_error_code)
 {
-    if (reason == LIBP2P_HOST_OK)
+    if (locally_initiated)
     {
         return LEAN_METRICS_DISCONNECT_LOCAL_CLOSE;
+    }
+    if (transport_error_code != 0U)
+    {
+        return LEAN_METRICS_DISCONNECT_ERROR;
     }
     if (reason == LIBP2P_HOST_ERR_CLOSED)
     {
@@ -456,6 +463,8 @@ void connection_counter_reset(struct lantern_client *client)
  * @param peer     Peer ID (may be NULL)
  * @param inbound  True if inbound connection
  * @param reason   Connection close reason code
+ * @param locally_initiated  True if the local host requested the close
+ * @param transport_error_code  Transport-specific close error code
  *
  * @note Thread safety: This function acquires connection_lock
  */
@@ -465,7 +474,9 @@ void connection_counter_update(
     const void *conn,
     const struct lantern_peer_id *peer,
     bool inbound,
-    int reason)
+    int reason,
+    bool locally_initiated,
+    uint64_t transport_error_code)
 {
     if (!client || !client->connection_lock_initialized)
     {
@@ -573,7 +584,10 @@ void connection_counter_update(
     {
         lean_metrics_record_peer_disconnection(
             metrics_direction_from_inbound(was_inbound),
-            metrics_disconnection_reason_from_code(reason));
+            metrics_disconnection_reason_from_close(
+                reason,
+                locally_initiated,
+                transport_error_code));
     }
 }
 
@@ -1243,7 +1257,7 @@ static void handle_connection_opened_event(
         return;
     }
 
-    connection_counter_update(client, 1, conn, peer, inbound, 0);
+    connection_counter_update(client, 1, conn, peer, inbound, 0, false, 0U);
 
     if (!peer)
     {
@@ -1288,6 +1302,7 @@ static void handle_connection_closed_event(
     const void *conn,
     const struct lantern_peer_id *peer,
     int reason,
+    bool locally_initiated,
     uint64_t app_error_code,
     uint64_t transport_error_code)
 {
@@ -1296,7 +1311,15 @@ static void handle_connection_closed_event(
         return;
     }
 
-    connection_counter_update(client, -1, conn, peer, false, reason);
+    connection_counter_update(
+        client,
+        -1,
+        conn,
+        peer,
+        false,
+        reason,
+        locally_initiated,
+        transport_error_code);
 
     if (!peer)
     {
@@ -1310,12 +1333,23 @@ static void handle_connection_closed_event(
         .validator = client->node_id,
         .peer = peer_text[0] ? peer_text : NULL,
     };
-    if (reason == LIBP2P_HOST_OK && peer_still_connected)
+    if (locally_initiated && peer_still_connected)
     {
         lantern_log_debug(
             "network",
             &meta,
             "duplicate connection closed reason=%d (%s) app_error=%" PRIu64 " transport_error=%" PRIu64,
+            reason,
+            connection_reason_text(reason),
+            app_error_code,
+            transport_error_code);
+    }
+    else if (locally_initiated)
+    {
+        lantern_log_debug(
+            "network",
+            &meta,
+            "local connection closed reason=%d (%s) app_error=%" PRIu64 " transport_error=%" PRIu64,
             reason,
             connection_reason_text(reason),
             app_error_code,
@@ -1333,10 +1367,15 @@ static void handle_connection_closed_event(
             transport_error_code);
     }
 
-    if (reason != LIBP2P_HOST_OK)
+    if (connection_close_should_redial(reason, locally_initiated))
     {
         redial_peer(client, peer);
     }
+}
+
+bool connection_close_should_redial(int reason, bool locally_initiated)
+{
+    return !locally_initiated && reason != LIBP2P_HOST_OK;
 }
 
 
@@ -1447,6 +1486,7 @@ void connection_events_cb(
                 evt->conn,
                 peer_ptr,
                 (int)evt->reason,
+                evt->locally_initiated != 0U,
                 evt->app_error_code,
                 evt->transport_error_code);
             break;

--- a/src/core/client_network_internal.h
+++ b/src/core/client_network_internal.h
@@ -210,6 +210,8 @@ void connection_counter_reset(struct lantern_client *client);
  * @param peer     Peer ID (may be NULL)
  * @param inbound  True if inbound connection
  * @param reason   Connection close reason code
+ * @param locally_initiated  True if the local host requested the close
+ * @param transport_error_code  Transport-specific close error code
  *
  * @note Thread safety: This function acquires connection_lock
  */
@@ -219,7 +221,12 @@ void connection_counter_update(
     const void *conn,
     const struct lantern_peer_id *peer,
     bool inbound,
-    int reason);
+    int reason,
+    bool locally_initiated,
+    uint64_t transport_error_code);
+
+/** Return whether a close event should trigger reactive peer recovery. */
+bool connection_close_should_redial(int reason, bool locally_initiated);
 
 bool connection_tie_break_prefers_inbound(
     const uint8_t *local_peer_id,

--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -1691,10 +1691,10 @@ int reqresp_collect_blocks(
     }
 
     LanternSignedBlockList storage_blocks = {0};
-    if (client->data_dir && client->data_dir[0] != '\0')
+    if (client->storage.backend)
     {
         if (lantern_storage_collect_blocks(
-                client->data_dir,
+                &client->storage,
                 roots,
                 root_count,
                 &storage_blocks)

--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -159,7 +159,7 @@ static bool backfill_import_connected_chain(struct lantern_client *client, const
     for (size_t i = 0; i < root_count; ++i)
     {
         LanternSignedBlockList blocks = {0};
-        if (lantern_storage_collect_blocks(client->data_dir, &roots[i], 1u, &blocks) != 0
+        if (lantern_storage_collect_blocks(&client->storage, &roots[i], 1u, &blocks) != 0
             || blocks.length == 0)
         {
             lantern_signed_block_list_reset(&blocks);
@@ -309,7 +309,7 @@ bool lantern_client_backfill_process_block(
         return false;
     }
 
-    if (lantern_storage_store_block_for_root(client->data_dir, root, block) != 0)
+    if (lantern_storage_store_block_for_root(&client->storage, root, block) != 0)
     {
         char root_hex[ROOT_HEX_BUFFER_LEN];
         format_root_hex(root, root_hex, sizeof(root_hex));
@@ -635,7 +635,7 @@ static bool verify_and_cache_aggregated_attestation_locked(
         return false;
     }
 
-    size_t validator_count = lantern_state_validator_count(sig_state);
+    size_t validator_count = sig_state->validators ? sig_state->validator_count : 0u;
     size_t bit_length = attestation->proof.participants.bit_length;
     if (bit_length > validator_count) {
         return false;
@@ -659,7 +659,7 @@ static bool verify_and_cache_aggregated_attestation_locked(
         if (!lantern_bitlist_get(&attestation->proof.participants, i)) {
             continue;
         }
-        const uint8_t *pubkey = lantern_state_validator_attestation_pubkey(sig_state, i);
+        const uint8_t *pubkey = sig_state->validators[i].attestation_pubkey;
         if (!pubkey || lantern_validator_pubkey_is_zero(pubkey)) {
             free(pubkeys);
             return false;
@@ -806,8 +806,8 @@ void persist_anchor_block(
 
     struct lantern_log_metadata meta = {.validator = client->node_id};
     if (root_to_log
-        ? lantern_storage_store_block_for_root(client->data_dir, root_to_log, &stored_anchor) != 0
-        : lantern_storage_store_block(client->data_dir, &stored_anchor) != 0)
+        ? lantern_storage_store_block_for_root(&client->storage, root_to_log, &stored_anchor) != 0
+        : lantern_storage_store_block(&client->storage, &stored_anchor) != 0)
     {
         lantern_log_warn(
             "storage",
@@ -859,7 +859,7 @@ static bool load_persisted_checkpoint_anchor_block(
     uint8_t *block_bytes = NULL;
     size_t block_len = 0;
     int load_rc = lantern_storage_load_block_bytes_for_root(
-        client->data_dir,
+        &client->storage,
         &expected_anchor_root,
         &block_bytes,
         &block_len);
@@ -1079,7 +1079,7 @@ int initialize_fork_choice(struct lantern_client *client)
     {
         LanternState anchor_state = client->state;
         if (lantern_storage_store_state_for_root(
-                client->data_dir,
+                &client->storage,
                 &anchor_root,
                 &anchor_state)
             != 0)
@@ -1160,7 +1160,7 @@ static bool load_restored_block_state(
     uint8_t *state_bytes = NULL;
     size_t state_len = 0;
     if (lantern_storage_load_state_bytes_for_root(
-            client->data_dir,
+            &client->storage,
             root,
             &state_bytes,
             &state_len)
@@ -1222,7 +1222,7 @@ static void restore_keep_roots_append(
 /**
  * Restore persisted blocks from storage into fork choice.
  *
- * @spec subspecs/storage/sqlite.py - Database.prune_before_slot()
+ * @spec node/storage/database.py - Database.prune_before_slot()
  *
  * Prunes persisted blocks/states strictly before the finalized slot, then
  * restores only the remaining finalized-or-newer block window into fork
@@ -1259,7 +1259,7 @@ int restore_persisted_blocks(struct lantern_client *client)
     uint64_t finalized_slot = client->state.latest_finalized.slot;
     if (finalized_slot > 0
         && lantern_storage_prune_before_slot(
-               client->data_dir,
+               &client->storage,
                finalized_slot,
                keep_roots,
                keep_root_count)
@@ -1275,7 +1275,7 @@ int restore_persisted_blocks(struct lantern_client *client)
     struct lantern_persisted_block_list list;
     persisted_block_list_init(&list);
     if (lantern_storage_iterate_blocks(
-            client->data_dir,
+            &client->storage,
             collect_block_visitor,
             &list)
         < 0)

--- a/src/core/client_sync_blocks.c
+++ b/src/core/client_sync_blocks.c
@@ -335,7 +335,7 @@ static void persist_block_after_import(
 
     struct lantern_log_metadata fallback = {.validator = client->node_id};
     const struct lantern_log_metadata *log_meta = meta ? meta : &fallback;
-    if (lantern_storage_store_block(client->data_dir, block) != 0)
+    if (lantern_storage_store_block(&client->storage, block) != 0)
     {
         lantern_log_debug(
             "storage",
@@ -632,7 +632,7 @@ const LanternState *lantern_client_state_for_root_locked(
     uint8_t *state_bytes = NULL;
     size_t state_len = 0;
     if (lantern_storage_load_state_bytes_for_root(
-            client->data_dir,
+            &client->storage,
             root,
             &state_bytes,
             &state_len)
@@ -1301,7 +1301,7 @@ static void prune_storage_if_finalized_advanced_locked(
         return;
     }
     if (lantern_storage_prune_before_slot(
-            client->data_dir,
+            &client->storage,
             current->slot,
             &current->root,
             1u)
@@ -1332,7 +1332,7 @@ static void persist_state_locked(
         return;
     }
 
-    if (lantern_storage_save_state(client->data_dir, &client->state) != 0)
+    if (lantern_storage_save_state(&client->storage, &client->state) != 0)
     {
         lantern_log_warn(
             "storage",
@@ -1363,7 +1363,7 @@ static void persist_post_state_locked(
         return;
     }
 
-    if (lantern_storage_store_state_for_root(client->data_dir, block_root, post_state) != 0)
+    if (lantern_storage_store_state_for_root(&client->storage, block_root, post_state) != 0)
     {
         lantern_log_warn(
             "storage",

--- a/src/core/client_sync_votes.c
+++ b/src/core/client_sync_votes.c
@@ -552,7 +552,8 @@ bool lantern_client_verify_vote_signature(
             context ? context : "vote");
         return false;
     }
-    size_t state_validator_count = lantern_state_validator_count(state_override);
+    size_t state_validator_count =
+        state_override->validators ? state_override->validator_count : 0u;
     if (state_validator_count == 0)
     {
         lantern_log_warn(
@@ -573,9 +574,8 @@ bool lantern_client_verify_vote_signature(
             state_validator_count);
         return false;
     }
-    const uint8_t *pubkey_bytes = lantern_state_validator_attestation_pubkey(
-        state_override,
-        (size_t)vote->data.validator_id);
+    const uint8_t *pubkey_bytes =
+        state_override->validators[vote->data.validator_id].attestation_pubkey;
     if (!pubkey_bytes || lantern_validator_pubkey_is_zero(pubkey_bytes))
     {
         lantern_log_warn(

--- a/src/core/client_validator.c
+++ b/src/core/client_validator.c
@@ -1087,9 +1087,13 @@ static lantern_client_error validator_build_block_merge_proof_with_state(
     lantern_bitlist_init(&proposer_participants);
 
     lantern_client_error result = LANTERN_CLIENT_OK;
-    const uint8_t *proposer_pubkey =
-        lantern_state_validator_proposal_pubkey(state, (size_t)proposer_index);
-    if (!proposer_pubkey || lantern_validator_pubkey_is_zero(proposer_pubkey))
+    if (!state->validators || proposer_index >= state->validator_count)
+    {
+        result = LANTERN_CLIENT_ERR_VALIDATOR;
+        goto cleanup;
+    }
+    const uint8_t *proposer_pubkey = state->validators[proposer_index].proposal_pubkey;
+    if (lantern_validator_pubkey_is_zero(proposer_pubkey))
     {
         result = LANTERN_CLIENT_ERR_VALIDATOR;
         goto cleanup;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1,15 +1,6 @@
-/**
- * @file main.c
- * @brief Lantern client entry point and command-line interface
- *
- * Provides the main entry point for the Lantern consensus client, handling:
- * - Command-line argument parsing
- * - Signal handling for graceful shutdown
- * - Client initialization and lifecycle management
- */
-
 #include "lantern/core/client.h"
 #include "lantern/support/log.h"
+#include "lantern/support/strings.h"
 #include "lantern/support/version.h"
 
 #include <ctype.h>
@@ -57,800 +48,451 @@ enum {
     OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE,
     OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE,
     OPT_SHADOW_XMSS_MERGE_RATE,
-    /* Deprecated: legacy file-path flags retained so pre-migration
-     * lean-quickstart wrappers keep working. Each resolves to the parent
-     * directory of the given file and feeds validator_config_dir. */
     OPT_LEGACY_VALIDATOR_REGISTRY_PATH,
     OPT_LEGACY_VALIDATOR_KEYS_PATH,
     OPT_LEGACY_VALIDATOR_CONFIG_PATH,
 };
 
-/* Return a heap-allocated copy of dirname(path). Program-lifetime allocation. */
-static const char *derive_parent_dir(const char *path)
-{
-    if (!path || !*path)
-    {
-        return NULL;
-    }
-    char *copy = strdup(path);
-    if (!copy)
-    {
-        return NULL;
-    }
-    char *dir = dirname(copy);
-    char *result = dir ? strdup(dir) : NULL;
-    free(copy);
-    return result;
-}
+static const struct option OPTIONS[] = {
+    {"data-dir", required_argument, NULL, 'd'},
+    {"genesis-config", required_argument, NULL, OPT_GENESIS_CONFIG},
+    {"nodes-path", required_argument, NULL, OPT_NODES_PATH},
+    {"genesis-state", required_argument, NULL, OPT_GENESIS_STATE},
+    {"use-genesis-state", no_argument, NULL, OPT_USE_GENESIS_STATE},
+    {"validator_config", required_argument, NULL, OPT_VALIDATOR_CONFIG},
+    {"validator-registry-path", required_argument, NULL, OPT_LEGACY_VALIDATOR_REGISTRY_PATH},
+    {"validator-keys-path", required_argument, NULL, OPT_LEGACY_VALIDATOR_KEYS_PATH},
+    {"validator-config", required_argument, NULL, OPT_LEGACY_VALIDATOR_CONFIG_PATH},
+    {"node-id", required_argument, NULL, OPT_NODE_ID},
+    {"node-key", required_argument, NULL, OPT_NODE_KEY},
+    {"node-key-path", required_argument, NULL, OPT_NODE_KEY_PATH},
+    {"listen-address", required_argument, NULL, OPT_LISTEN_ADDRESS},
+    {"checkpoint-sync-url", required_argument, NULL, OPT_CHECKPOINT_SYNC_URL},
+    {"http-port", required_argument, NULL, OPT_HTTP_PORT},
+    {"metrics-port", required_argument, NULL, OPT_METRICS_PORT},
+    {"bootnode", required_argument, NULL, OPT_BOOTNODE},
+    {"bootnodes", required_argument, NULL, OPT_BOOTNODES},
+    {"bootnodes-file", required_argument, NULL, OPT_BOOTNODE_FILE},
+    {"devnet", required_argument, NULL, OPT_DEVNET},
+    {"log-level", required_argument, NULL, OPT_LOG_LEVEL},
+    {"xmss-key-dir", required_argument, NULL, OPT_XMSS_KEY_DIR},
+    {"hash-sig-key-dir", required_argument, NULL, OPT_HASH_SIG_KEY_DIR},
+    {"xmss-secret", required_argument, NULL, OPT_XMSS_SECRET_PATH},
+    {"xmss-secret-template", required_argument, NULL, OPT_XMSS_SECRET_TEMPLATE},
+    {"is-aggregator", no_argument, NULL, OPT_IS_AGGREGATOR},
+    {"attestation-committee-count", required_argument, NULL, OPT_ATTESTATION_COMMITTEE_COUNT},
+    {"aggregate-subnet-ids", required_argument, NULL, OPT_AGGREGATE_SUBNET_IDS},
+    {"shadow-xmss-aggregate-signatures-rate", required_argument, NULL, OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE},
+    {"shadow-xmss-verify-aggregated-signatures-rate", required_argument, NULL, OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE},
+    {"shadow-xmss-merge-rate", required_argument, NULL, OPT_SHADOW_XMSS_MERGE_RATE},
+    {"help", no_argument, NULL, 'h'},
+    {"version", no_argument, NULL, 'v'},
+    {0, 0, 0, 0},
+};
 
-/* Forward declarations */
-static lantern_client_error configure_logging_from_env(void);
-static lantern_client_error register_signal_handlers(void);
-static lantern_client_error apply_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg,
-    bool *show_help,
-    bool *show_version);
-static lantern_client_error handle_port_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg);
-static lantern_client_error handle_bootnode_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg);
-static lantern_client_error handle_xmss_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg);
-static lantern_client_error handle_aggregate_subnet_ids_option(
-    struct lantern_client_options *options,
-    const char *optarg);
-static lantern_client_error handle_shadow_xmss_rate_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg);
-static lantern_client_error parse_arguments(
-    struct lantern_client_options *options,
-    int argc,
-    char **argv,
-    bool *show_help,
-    bool *show_version);
-static lantern_client_error validate_required_options(
-    const struct lantern_client_options *options);
-static lantern_client_error run_main_loop(struct lantern_client *client);
-static void print_usage(const char *prog);
-static lantern_client_error parse_double_value(const char *text, double *out_value);
-static lantern_client_error parse_u16(const char *text, uint16_t *out_value);
-static lantern_client_error parse_size_t_nonnegative(const char *text, size_t *out_value);
-static lantern_client_error parse_size_t_positive(const char *text, size_t *out_value);
+static volatile sig_atomic_t keep_running = 1;
 
-/** Flag indicating whether the main loop should continue running. */
-static volatile sig_atomic_t g_keep_running = 1;
-
-static void configure_allocator_from_env(void)
+static void configure_allocator(void)
 {
 #if defined(__GLIBC__) && defined(M_ARENA_MAX)
-    const char *arena_env = getenv("MALLOC_ARENA_MAX");
-    if (!arena_env || arena_env[0] == '\0')
+    const char *configured = getenv("MALLOC_ARENA_MAX");
+    if (!configured || !configured[0])
     {
         (void)mallopt(M_ARENA_MAX, 2);
     }
 #endif
 }
 
-
-/**
- * Handle termination signals (SIGINT, SIGTERM).
- *
- * Sets the global keep_running flag to false to trigger graceful shutdown.
- *
- * @param signo  Signal number (unused)
- *
- * @note Thread safety: Async-signal safe; only writes a sig_atomic_t flag.
- */
-static void lantern_handle_signal(int signo)
+static void stop_running(int signal_number)
 {
-    (void)signo;
-    g_keep_running = 0;
+    (void)signal_number;
+    keep_running = 0;
 }
 
-
-/**
- * Register signal handlers for graceful shutdown.
- *
- * @return 0 on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM if registration fails
- *
- * @note Thread safety: Must be called during single-threaded startup.
- */
-static lantern_client_error register_signal_handlers(void)
+static int register_signals(void)
 {
-    if (signal(SIGINT, lantern_handle_signal) == SIG_ERR
-        || signal(SIGTERM, lantern_handle_signal) == SIG_ERR)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){0},
-            "failed to register signal handlers");
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return LANTERN_CLIENT_OK;
+    return signal(SIGINT, stop_running) == SIG_ERR || signal(SIGTERM, stop_running) == SIG_ERR
+        ? -1
+        : 0;
 }
 
-
-/**
- * Configure logging from the LANTERN_LOG_LEVEL environment variable.
- *
- * @return LANTERN_CLIENT_OK on success or if the variable is unset
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM if the value is invalid
- *
- * @note Thread safety: Must be called during single-threaded startup.
- */
-static lantern_client_error configure_logging_from_env(void)
+static int parse_unsigned(const char *text, uint64_t maximum, bool allow_zero, uint64_t *out)
 {
-    const char *env_log_level = getenv("LANTERN_LOG_LEVEL");
-    if (!env_log_level)
+    if (!text || !out)
     {
-        return LANTERN_CLIENT_OK;
+        return -1;
     }
-
-    if (lantern_log_set_level_from_string(env_log_level, NULL) != 0)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){0},
-            "invalid LANTERN_LOG_LEVEL '%s'",
-            env_log_level);
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return LANTERN_CLIENT_OK;
-}
-
-
-/**
- * Apply a single parsed option to the client options structure.
- *
- * @param options       Options structure to update
- * @param opt           Parsed option identifier
- * @param optarg        Argument provided to the option (may be NULL)
- * @param show_help     Output flag indicating help request
- * @param show_version  Output flag indicating version request
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on invalid option or parse error
- * @return LANTERN_CLIENT_ERR_ALLOC on allocation failure
- *
- * @note Thread safety: Not thread-safe; mutates caller-owned options.
- */
-static lantern_client_error apply_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg,
-    bool *show_help,
-    bool *show_version)
-{
-    if (!options || !show_help || !show_version)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    switch (opt)
-    {
-    case 'd':
-        options->data_dir = optarg;
-        return LANTERN_CLIENT_OK;
-    case 'h':
-        *show_help = true;
-        return LANTERN_CLIENT_OK;
-    case 'v':
-        *show_version = true;
-        return LANTERN_CLIENT_OK;
-    case OPT_GENESIS_CONFIG:
-        options->genesis_config_path = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_NODES_PATH:
-        options->nodes_path = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_GENESIS_STATE:
-    case OPT_USE_GENESIS_STATE:
-        return LANTERN_CLIENT_OK;
-    case OPT_VALIDATOR_CONFIG:
-        options->validator_config_dir = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_LEGACY_VALIDATOR_REGISTRY_PATH:
-    case OPT_LEGACY_VALIDATOR_KEYS_PATH:
-    case OPT_LEGACY_VALIDATOR_CONFIG_PATH:
-    {
-        const char *parent = derive_parent_dir(optarg);
-        if (!parent)
-        {
-            return LANTERN_CLIENT_ERR_INVALID_PARAM;
-        }
-        options->validator_config_dir = parent;
-        return LANTERN_CLIENT_OK;
-    }
-    case OPT_NODE_ID:
-        options->node_id = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_NODE_KEY:
-        options->node_key_hex = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_NODE_KEY_PATH:
-        options->node_key_path = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_LISTEN_ADDRESS:
-        options->listen_address = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_CHECKPOINT_SYNC_URL:
-        options->checkpoint_sync_url = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_HTTP_PORT:
-    case OPT_METRICS_PORT:
-        return handle_port_option(options, opt, optarg);
-    case OPT_BOOTNODE:
-    case OPT_BOOTNODES:
-    case OPT_BOOTNODE_FILE:
-        return handle_bootnode_option(options, opt, optarg);
-    case OPT_DEVNET:
-        options->devnet = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_LOG_LEVEL:
-        if (lantern_log_set_level_from_string(optarg, NULL) != 0)
-        {
-            lantern_log_error(
-                "cli",
-                &(const struct lantern_log_metadata){.validator = options->node_id},
-                "invalid log-level '%s'",
-                optarg);
-            return LANTERN_CLIENT_ERR_INVALID_PARAM;
-        }
-        return LANTERN_CLIENT_OK;
-    case OPT_XMSS_KEY_DIR:
-    case OPT_HASH_SIG_KEY_DIR:
-    case OPT_XMSS_SECRET_PATH:
-    case OPT_XMSS_SECRET_TEMPLATE:
-        return handle_xmss_option(options, opt, optarg);
-    case OPT_IS_AGGREGATOR:
-        options->is_aggregator = true;
-        return LANTERN_CLIENT_OK;
-    case OPT_ATTESTATION_COMMITTEE_COUNT: {
-        size_t parsed_value = 0;
-        if (parse_size_t_positive(optarg, &parsed_value) != LANTERN_CLIENT_OK)
-        {
-            lantern_log_error(
-                "cli",
-                &(const struct lantern_log_metadata){.validator = options->node_id},
-                "invalid attestation-committee-count '%s'",
-                optarg ? optarg : "");
-            return LANTERN_CLIENT_ERR_INVALID_PARAM;
-        }
-        options->attestation_committee_count_override = (uint64_t)parsed_value;
-        return LANTERN_CLIENT_OK;
-    }
-    case OPT_AGGREGATE_SUBNET_IDS:
-        return handle_aggregate_subnet_ids_option(options, optarg);
-    case OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE:
-    case OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE:
-    case OPT_SHADOW_XMSS_MERGE_RATE:
-        return handle_shadow_xmss_rate_option(options, opt, optarg);
-    default:
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-}
-
-
-/**
- * Handle port-related CLI options.
- *
- * @param options  Options structure to update
- * @param opt      Parsed option identifier
- * @param optarg   Port value string
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on parse error or invalid option
- *
- * @note Thread safety: Not thread-safe; mutates caller-owned options.
- */
-static lantern_client_error handle_port_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg)
-{
-    if (!options || !optarg)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    uint16_t *target_port = (opt == OPT_HTTP_PORT) ? &options->http_port : &options->metrics_port;
-    const char *label = (opt == OPT_HTTP_PORT) ? "http-port" : "metrics-port";
-
-    if (parse_u16(optarg, target_port) != 0)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){.validator = options->node_id},
-            "invalid %s '%s'",
-            label,
-            optarg);
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return LANTERN_CLIENT_OK;
-}
-
-
-/**
- * Handle bootnode-related CLI options.
- *
- * @param options  Options structure to update
- * @param opt      Parsed option identifier
- * @param optarg   ENR value or path
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on error
- *
- * @note Thread safety: Not thread-safe; mutates caller-owned options.
- */
-static lantern_client_error handle_bootnode_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg)
-{
-    if (!options || !optarg)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    lantern_client_error result = LANTERN_CLIENT_ERR_INVALID_PARAM;
-    switch (opt)
-    {
-    case OPT_BOOTNODE:
-        result = lantern_client_options_add_bootnode(options, optarg);
-        break;
-    case OPT_BOOTNODES:
-        result = lantern_client_options_add_bootnodes_argument(options, optarg);
-        break;
-    case OPT_BOOTNODE_FILE:
-        result = lantern_client_options_add_bootnodes_from_file(options, optarg);
-        break;
-    default:
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return result;
-}
-
-
-/**
- * Handle hash signature configuration options.
- *
- * @param options  Options structure to update
- * @param opt      Parsed option identifier
- * @param optarg   Option argument string
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on invalid option
- *
- * @note Thread safety: Not thread-safe; mutates caller-owned options.
- */
-static lantern_client_error handle_xmss_option(
-    struct lantern_client_options *options,
-    int opt,
-    const char *optarg)
-{
-    if (!options)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    switch (opt)
-    {
-    case OPT_XMSS_KEY_DIR:
-    case OPT_HASH_SIG_KEY_DIR:
-        options->xmss_key_dir = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_XMSS_SECRET_PATH:
-        options->xmss_secret_path = optarg;
-        return LANTERN_CLIENT_OK;
-    case OPT_XMSS_SECRET_TEMPLATE:
-        options->xmss_secret_template = optarg;
-        return LANTERN_CLIENT_OK;
-    default:
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-}
-
-static char *trim_mutable(char *text)
-{
-    if (!text)
-    {
-        return NULL;
-    }
-    while (*text && isspace((unsigned char)*text))
+    while (isspace((unsigned char)*text))
     {
         ++text;
     }
-    char *end = text + strlen(text);
-    while (end > text && isspace((unsigned char)*(end - 1)))
+    if (!*text || *text == '-')
     {
-        --end;
+        return -1;
     }
-    *end = '\0';
-    return text;
+    errno = 0;
+    char *end = NULL;
+    unsigned long long value = strtoull(text, &end, 10);
+    while (end && isspace((unsigned char)*end))
+    {
+        ++end;
+    }
+    if (errno != 0 || end == text || (end && *end) || value > maximum
+        || (!allow_zero && value == 0u))
+    {
+        return -1;
+    }
+    *out = (uint64_t)value;
+    return 0;
 }
 
-static lantern_client_error handle_aggregate_subnet_ids_option(
-    struct lantern_client_options *options,
-    const char *optarg)
+static const char *parent_directory(const char *path)
 {
-    if (!options || !optarg)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    char *copy = strdup(optarg);
+    char *copy = path && path[0] ? strdup(path) : NULL;
     if (!copy)
     {
-        return LANTERN_CLIENT_ERR_ALLOC;
+        return NULL;
     }
+    char *directory = dirname(copy);
+    char *result = directory ? strdup(directory) : NULL;
+    free(copy);
+    return result;
+}
 
-    size_t added = 0;
-    char *cursor = copy;
-    lantern_client_error result = LANTERN_CLIENT_OK;
-    while (cursor)
+static lantern_client_error add_subnets(
+    struct lantern_client_options *options,
+    const char *argument)
+{
+    char *copy = argument ? strdup(argument) : NULL;
+    if (!copy)
     {
-        char *comma = strchr(cursor, ',');
+        return argument ? LANTERN_CLIENT_ERR_ALLOC : LANTERN_CLIENT_ERR_INVALID_PARAM;
+    }
+    size_t added = 0u;
+    lantern_client_error result = LANTERN_CLIENT_OK;
+    for (char *entry = copy; entry;)
+    {
+        char *comma = strchr(entry, ',');
         if (comma)
         {
             *comma = '\0';
         }
-        char *part = trim_mutable(cursor);
-        if (part && *part != '\0')
+        char *trimmed = lantern_trim_whitespace(entry);
+        uint64_t subnet = 0u;
+        if (trimmed && trimmed[0])
         {
-            size_t subnet_id = 0;
-            if (parse_size_t_nonnegative(part, &subnet_id) != LANTERN_CLIENT_OK)
+            if (parse_unsigned(trimmed, SIZE_MAX, true, &subnet) != 0)
             {
-                lantern_log_error(
-                    "cli",
-                    &(const struct lantern_log_metadata){.validator = options->node_id},
-                    "invalid aggregate-subnet-ids entry '%s'",
-                    part);
                 result = LANTERN_CLIENT_ERR_INVALID_PARAM;
                 break;
             }
-            result = lantern_client_options_add_aggregate_subnet_id(options, subnet_id);
+            result = lantern_client_options_add_aggregate_subnet_id(options, (size_t)subnet);
             if (result != LANTERN_CLIENT_OK)
             {
                 break;
             }
-            added += 1u;
+            ++added;
         }
-        cursor = comma ? comma + 1 : NULL;
+        entry = comma ? comma + 1 : NULL;
     }
-
     free(copy);
-    if (result != LANTERN_CLIENT_OK)
-    {
-        return result;
-    }
-    if (added == 0)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){.validator = options->node_id},
-            "--aggregate-subnet-ids requires at least one subnet id");
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    return LANTERN_CLIENT_OK;
+    return result == LANTERN_CLIENT_OK && added == 0u
+        ? LANTERN_CLIENT_ERR_INVALID_PARAM
+        : result;
 }
 
-static lantern_client_error handle_shadow_xmss_rate_option(
+static lantern_client_error set_shadow_rate(
     struct lantern_client_options *options,
-    int opt,
-    const char *optarg)
+    int option,
+    const char *argument)
 {
-    if (!options || !optarg)
+    if (!argument || isspace((unsigned char)argument[0]))
     {
         return LANTERN_CLIENT_ERR_INVALID_PARAM;
     }
-
+    char *end = NULL;
+    double value = strtod(argument, &end);
+    if (end == argument || (end && *end))
+    {
+        return LANTERN_CLIENT_ERR_INVALID_PARAM;
+    }
     LanternShadowOperation operation;
-    const char *label = NULL;
-    switch (opt)
+    switch (option)
     {
     case OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE:
         operation = LANTERN_SHADOW_AGGREGATE;
-        label = "shadow-xmss-aggregate-signatures-rate";
         break;
     case OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE:
         operation = LANTERN_SHADOW_VERIFY;
-        label = "shadow-xmss-verify-aggregated-signatures-rate";
         break;
     case OPT_SHADOW_XMSS_MERGE_RATE:
         operation = LANTERN_SHADOW_MERGE;
-        label = "shadow-xmss-merge-rate";
         break;
     default:
         return LANTERN_CLIENT_ERR_INVALID_PARAM;
     }
-
-    if (parse_double_value(optarg, &options->shadow_xmss_rates[operation]) != LANTERN_CLIENT_OK)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){.validator = options->node_id},
-            "invalid %s '%s'",
-            label,
-            optarg);
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
+    options->shadow_xmss_rates[operation] = value;
     options->shadow_xmss_rates_set |= (uint8_t)(1u << operation);
     return LANTERN_CLIENT_OK;
 }
 
+static lantern_client_error apply_option(
+    struct lantern_client_options *options,
+    int option,
+    const char *argument,
+    bool *help,
+    bool *version)
+{
+    uint64_t number = 0u;
+    switch (option)
+    {
+    case 'd':
+        options->data_dir = argument;
+        return LANTERN_CLIENT_OK;
+    case 'h':
+        *help = true;
+        return LANTERN_CLIENT_OK;
+    case 'v':
+        *version = true;
+        return LANTERN_CLIENT_OK;
+    case OPT_GENESIS_CONFIG:
+        options->genesis_config_path = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_NODES_PATH:
+        options->nodes_path = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_VALIDATOR_CONFIG:
+        options->validator_config_dir = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_NODE_ID:
+        options->node_id = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_NODE_KEY:
+        options->node_key_hex = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_NODE_KEY_PATH:
+        options->node_key_path = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_LISTEN_ADDRESS:
+        options->listen_address = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_CHECKPOINT_SYNC_URL:
+        options->checkpoint_sync_url = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_DEVNET:
+        options->devnet = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_XMSS_KEY_DIR:
+    case OPT_HASH_SIG_KEY_DIR:
+        options->xmss_key_dir = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_XMSS_SECRET_PATH:
+        options->xmss_secret_path = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_XMSS_SECRET_TEMPLATE:
+        options->xmss_secret_template = argument;
+        return LANTERN_CLIENT_OK;
+    case OPT_GENESIS_STATE:
+    case OPT_USE_GENESIS_STATE:
+        return LANTERN_CLIENT_OK;
+    case OPT_LEGACY_VALIDATOR_REGISTRY_PATH:
+    case OPT_LEGACY_VALIDATOR_KEYS_PATH:
+    case OPT_LEGACY_VALIDATOR_CONFIG_PATH:
+        options->validator_config_dir = parent_directory(argument);
+        return options->validator_config_dir ? LANTERN_CLIENT_OK : LANTERN_CLIENT_ERR_ALLOC;
+    case OPT_HTTP_PORT:
+    case OPT_METRICS_PORT:
+        if (parse_unsigned(argument, UINT16_MAX, true, &number) != 0)
+        {
+            return LANTERN_CLIENT_ERR_INVALID_PARAM;
+        }
+        if (option == OPT_HTTP_PORT)
+        {
+            options->http_port = (uint16_t)number;
+        }
+        else
+        {
+            options->metrics_port = (uint16_t)number;
+        }
+        return LANTERN_CLIENT_OK;
+    case OPT_BOOTNODE:
+        return lantern_client_options_add_bootnode(options, argument);
+    case OPT_BOOTNODES:
+        return lantern_client_options_add_bootnodes_argument(options, argument);
+    case OPT_BOOTNODE_FILE:
+        return lantern_client_options_add_bootnodes_from_file(options, argument);
+    case OPT_LOG_LEVEL:
+        return lantern_log_set_level_from_string(argument, NULL) == 0
+            ? LANTERN_CLIENT_OK
+            : LANTERN_CLIENT_ERR_INVALID_PARAM;
+    case OPT_IS_AGGREGATOR:
+        options->is_aggregator = true;
+        return LANTERN_CLIENT_OK;
+    case OPT_ATTESTATION_COMMITTEE_COUNT:
+        if (parse_unsigned(argument, SIZE_MAX, false, &number) != 0)
+        {
+            return LANTERN_CLIENT_ERR_INVALID_PARAM;
+        }
+        options->attestation_committee_count_override = number;
+        return LANTERN_CLIENT_OK;
+    case OPT_AGGREGATE_SUBNET_IDS:
+        return add_subnets(options, argument);
+    case OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE:
+    case OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE:
+    case OPT_SHADOW_XMSS_MERGE_RATE:
+        return set_shadow_rate(options, option, argument);
+    default:
+        return LANTERN_CLIENT_ERR_INVALID_PARAM;
+    }
+}
 
-/**
- * Parse CLI arguments and populate client options.
- *
- * @param options       Options structure to populate
- * @param argc          Argument count
- * @param argv          Argument vector
- * @param show_help     Output flag indicating help was requested
- * @param show_version  Output flag indicating version was requested
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on invalid input or parse failure
- *
- * @note Thread safety: Not thread-safe; mutates caller-owned options and
- *       relies on global getopt state.
- */
-static lantern_client_error parse_arguments(
+static int parse_arguments(
     struct lantern_client_options *options,
     int argc,
     char **argv,
-    bool *show_help,
-    bool *show_version)
+    bool *help,
+    bool *version)
 {
-    if (!options || !argv || !show_help || !show_version)
+    *help = false;
+    *version = false;
+    int option = 0;
+    while ((option = getopt_long(argc, argv, "d:hv", OPTIONS, NULL)) != -1)
     {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    *show_help = false;
-    *show_version = false;
-
-    static const struct option long_options[] = {
-        {"data-dir", required_argument, NULL, 'd'},
-        {"genesis-config", required_argument, NULL, OPT_GENESIS_CONFIG},
-        {"nodes-path", required_argument, NULL, OPT_NODES_PATH},
-        {"genesis-state", required_argument, NULL, OPT_GENESIS_STATE},
-        {"use-genesis-state", no_argument, NULL, OPT_USE_GENESIS_STATE},
-        {"validator_config", required_argument, NULL, OPT_VALIDATOR_CONFIG},
-        /* Deprecated: pre-migration lean-quickstart wrappers pass these three as
-         * file paths; we accept them and derive the parent directory. */
-        {"validator-registry-path", required_argument, NULL, OPT_LEGACY_VALIDATOR_REGISTRY_PATH},
-        {"validator-keys-path", required_argument, NULL, OPT_LEGACY_VALIDATOR_KEYS_PATH},
-        {"validator-config", required_argument, NULL, OPT_LEGACY_VALIDATOR_CONFIG_PATH},
-        {"node-id", required_argument, NULL, OPT_NODE_ID},
-        {"node-key", required_argument, NULL, OPT_NODE_KEY},
-        {"node-key-path", required_argument, NULL, OPT_NODE_KEY_PATH},
-        {"listen-address", required_argument, NULL, OPT_LISTEN_ADDRESS},
-        {"checkpoint-sync-url", required_argument, NULL, OPT_CHECKPOINT_SYNC_URL},
-        {"http-port", required_argument, NULL, OPT_HTTP_PORT},
-        {"metrics-port", required_argument, NULL, OPT_METRICS_PORT},
-        {"bootnode", required_argument, NULL, OPT_BOOTNODE},
-        {"bootnodes", required_argument, NULL, OPT_BOOTNODES},
-        {"bootnodes-file", required_argument, NULL, OPT_BOOTNODE_FILE},
-        {"devnet", required_argument, NULL, OPT_DEVNET},
-        {"log-level", required_argument, NULL, OPT_LOG_LEVEL},
-        {"xmss-key-dir", required_argument, NULL, OPT_XMSS_KEY_DIR},
-        {"hash-sig-key-dir", required_argument, NULL, OPT_HASH_SIG_KEY_DIR},
-        {"xmss-secret", required_argument, NULL, OPT_XMSS_SECRET_PATH},
-        {"xmss-secret-template", required_argument, NULL, OPT_XMSS_SECRET_TEMPLATE},
-        {"is-aggregator", no_argument, NULL, OPT_IS_AGGREGATOR},
-        {"attestation-committee-count", required_argument, NULL, OPT_ATTESTATION_COMMITTEE_COUNT},
-        {"aggregate-subnet-ids", required_argument, NULL, OPT_AGGREGATE_SUBNET_IDS},
-        {"shadow-xmss-aggregate-signatures-rate", required_argument, NULL, OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE},
-        {"shadow-xmss-verify-aggregated-signatures-rate", required_argument, NULL, OPT_SHADOW_XMSS_VERIFY_AGGREGATED_SIGNATURES_RATE},
-        {"shadow-xmss-merge-rate", required_argument, NULL, OPT_SHADOW_XMSS_MERGE_RATE},
-        {"help", no_argument, NULL, 'h'},
-        {"version", no_argument, NULL, 'v'},
-        {0, 0, 0, 0},
-    };
-
-    int opt = 0;
-    int option_index = 0;
-    while ((opt = getopt_long(argc, argv, "d:hv", long_options, &option_index)) != -1)
-    {
-        if (apply_option(options, opt, optarg, show_help, show_version) != LANTERN_CLIENT_OK)
+        if (apply_option(options, option, optarg, help, version) != LANTERN_CLIENT_OK)
         {
-            return LANTERN_CLIENT_ERR_INVALID_PARAM;
+            return -1;
         }
     }
-
-    if (options->node_key_hex && options->node_key_path)
+    if ((options->node_key_hex && options->node_key_path)
+        || (options->aggregate_subnet_id_count > 0u && !options->is_aggregator))
     {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){.validator = options->node_id},
-            "specify only one of --node-key or --node-key-path");
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
+        return -1;
     }
-    if (options->aggregate_subnet_id_count > 0 && !options->is_aggregator)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){.validator = options->node_id},
-            "--aggregate-subnet-ids requires --is-aggregator");
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return LANTERN_CLIENT_OK;
+    return 0;
 }
 
-
-/**
- * Validate required options are present.
- *
- * @param options  Populated options structure
- *
- * @return LANTERN_CLIENT_OK when required options are present
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM when validation fails
- *
- * @note Thread safety: Reentrant; read-only access to options.
- */
-static lantern_client_error validate_required_options(
-    const struct lantern_client_options *options)
+static int run_until_signal(struct lantern_client *client)
 {
-    if (!options)
+    struct timespec delay = {.tv_sec = 1, .tv_nsec = 0};
+    while (keep_running)
     {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    if (!options->node_id)
-    {
-        lantern_log_error(
-            "cli",
-            &(const struct lantern_log_metadata){0},
-            "--node-id is required");
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    return LANTERN_CLIENT_OK;
-}
-
-
-/**
- * Run the main sleep loop until shutdown is requested.
- *
- * @param client  Initialized client instance (used for logging)
- *
- * @return LANTERN_CLIENT_OK on clean exit
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM on failure
- *
- * @note Thread safety: Relies on the global shutdown flag; should be invoked
- *       from the main thread.
- */
-static lantern_client_error run_main_loop(struct lantern_client *client)
-{
-    if (!client)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    const struct timespec sleep_request = {
-        .tv_sec = 1,
-        .tv_nsec = 0,
-    };
-    struct timespec sleep_remaining = sleep_request;
-    while (g_keep_running)
-    {
-        if (nanosleep(&sleep_remaining, &sleep_remaining) != 0)
+        struct timespec remaining = delay;
+        while (nanosleep(&remaining, &remaining) != 0)
         {
-            if (errno == EINTR)
+            if (errno != EINTR)
             {
-                sleep_remaining = sleep_request;
-                continue;
+                lantern_log_error(
+                    "cli",
+                    &(const struct lantern_log_metadata){.validator = client->node_id},
+                    "sleep failed: %s",
+                    strerror(errno));
+                return -1;
             }
-
-            lantern_log_error(
-                "cli",
-                &(const struct lantern_log_metadata){.validator = client->node_id},
-                "sleep interrupted: %s",
-                strerror(errno));
-            return LANTERN_CLIENT_ERR_INVALID_PARAM;
         }
-        sleep_remaining = sleep_request;
     }
-
-    return LANTERN_CLIENT_OK;
+    return 0;
 }
 
+static void print_usage(const char *program)
+{
+    lantern_log_info(
+        "main",
+        NULL,
+        "Usage: %s [options]\n"
+        "  --data-dir PATH              Data directory (default %s)\n"
+        "  --genesis-config PATH        Path to genesis config YAML\n"
+        "  --nodes-path PATH            Path to nodes.yaml\n"
+        "  --genesis-state PATH         Deprecated; ignored\n"
+        "  --use-genesis-state          Deprecated; ignored\n"
+        "  --validator_config DIR       Directory with validator artifacts\n"
+        "  --node-id NAME               Node identifier\n"
+        "  --node-key HEX               Local 32-byte private key\n"
+        "  --node-key-path PATH         File containing the private key",
+        program,
+        LANTERN_DEFAULT_DATA_DIR);
+    lantern_log_info(
+        "main",
+        NULL,
+        "  --listen-address ADDR        QUIC listen multiaddr\n"
+        "  --checkpoint-sync-url URL    Remote finalized-state endpoint\n"
+        "  --http-port PORT             HTTP API port\n"
+        "  --metrics-port PORT          Metrics port\n"
+        "  --bootnode ENR               Add one bootnode\n"
+        "  --bootnodes VALUE            ENR or YAML/list file\n"
+        "  --bootnodes-file PATH        Newline-delimited ENRs\n"
+        "  --devnet NAME                Gossip topic devnet identifier\n"
+        "  --attestation-committee-count N  Override committee count\n"
+        "  --is-aggregator              Enable aggregation\n"
+        "  --aggregate-subnet-ids IDS   Comma-separated imported subnets");
+    lantern_log_info(
+        "main",
+        NULL,
+        "  --xmss-key-dir PATH          XMSS key directory\n"
+        "  --hash-sig-key-dir PATH      Alias for --xmss-key-dir\n"
+        "  --xmss-secret PATH           Single XMSS secret key\n"
+        "  --xmss-secret-template STR   Secret-key path template\n"
+        "  --shadow-xmss-aggregate-signatures-rate N\n"
+        "  --shadow-xmss-verify-aggregated-signatures-rate N\n"
+        "  --shadow-xmss-merge-rate N\n"
+        "  --log-level LEVEL            trace, debug, info, warn, or error\n"
+        "  --help                       Show this message\n"
+        "  --version                    Print version information");
+}
 
-/**
- * Program entry point.
- *
- * Parses command-line arguments, configures logging, initializes the client,
- * and blocks until a shutdown signal is received.
- *
- * @param argc  Argument count
- * @param argv  Argument vector
- *
- * @return 0 on clean shutdown
- * @return 1 on argument or initialization failure
- *
- * @note Thread safety: Must be invoked on the process main thread before any
- *       additional threads are started.
- */
 int main(int argc, char **argv)
 {
-    configure_allocator_from_env();
-
-    int exit_code = 0;
+    configure_allocator();
     struct lantern_client_options options;
     lantern_client_options_init(&options);
+    struct lantern_client client = {0};
+    bool help = false;
+    bool version = false;
+    int exit_code = 1;
 
-    struct lantern_client client;
-    memset(&client, 0, sizeof(client));
-
-    bool show_version = false;
-    bool show_help = false;
-
-    if (register_signal_handlers() != 0)
+    const char *environment_level = getenv("LANTERN_LOG_LEVEL");
+    if (register_signals() != 0
+        || (environment_level && lantern_log_set_level_from_string(environment_level, NULL) != 0)
+        || parse_arguments(&options, argc, argv, &help, &version) != 0)
     {
-        exit_code = 1;
         goto cleanup;
     }
-
-    if (configure_logging_from_env() != 0)
-    {
-        exit_code = 1;
-        goto cleanup;
-    }
-
-    if (parse_arguments(&options, argc, argv, &show_help, &show_version) != 0)
-    {
-        exit_code = 1;
-        goto cleanup;
-    }
-
-    if (show_version)
+    if (version)
     {
         lantern_log_info(
-            "main", NULL, "lantern %s (commit %s, branch %s)",
-            LANTERN_VERSION, LANTERN_GIT_COMMIT, LANTERN_GIT_BRANCH);
+            "main",
+            NULL,
+            "lantern %s (commit %s, branch %s)",
+            LANTERN_VERSION,
+            LANTERN_GIT_COMMIT,
+            LANTERN_GIT_BRANCH);
+        exit_code = 0;
         goto cleanup;
     }
-
-    if (show_help)
+    if (help)
     {
         print_usage(argv[0]);
+        exit_code = 0;
         goto cleanup;
     }
-
     lantern_log_info(
-        "cli", NULL, "lantern %s (commit %s, branch %s)",
-        LANTERN_VERSION, LANTERN_GIT_COMMIT, LANTERN_GIT_BRANCH);
-
-    if (validate_required_options(&options) != 0)
+        "cli",
+        NULL,
+        "lantern %s (commit %s, branch %s)",
+        LANTERN_VERSION,
+        LANTERN_GIT_COMMIT,
+        LANTERN_GIT_BRANCH);
+    if (!options.node_id)
     {
-        exit_code = 1;
         goto cleanup;
     }
-
-    if (lantern_init(&client, &options) != 0)
+    if (lantern_init(&client, &options) != LANTERN_CLIENT_OK)
     {
         lantern_log_error(
             "cli",
             &(const struct lantern_log_metadata){.validator = options.node_id},
             "initialization failed");
-        exit_code = 1;
         goto cleanup;
     }
-
     lantern_log_info(
         "cli",
         &(const struct lantern_log_metadata){.validator = client.node_id},
@@ -861,17 +503,7 @@ int main(int argc, char **argv)
         client.genesis.enrs.count,
         client.bootnodes.len,
         client.local_enr.encoded ? client.local_enr.encoded : "-");
-
-    if (run_main_loop(&client) != 0)
-    {
-        exit_code = 1;
-        goto cleanup;
-    }
-
-    lantern_log_info(
-        "cli",
-        &(const struct lantern_log_metadata){.validator = client.node_id},
-        "shutdown requested");
+    exit_code = run_until_signal(&client) == 0 ? 0 : 1;
 
 cleanup:
     lantern_shutdown(&client);
@@ -881,314 +513,4 @@ cleanup:
         print_usage(argv[0]);
     }
     return exit_code;
-}
-
-
-/**
- * @brief Print path-related CLI options.
- */
-static void print_usage_paths(void)
-{
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --data-dir PATH              Data directory (default %s)",
-        LANTERN_DEFAULT_DATA_DIR);
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --genesis-config PATH        Path to genesis config YAML");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --nodes-path PATH            Path to nodes.yaml");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --genesis-state PATH         Deprecated; ignored");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --use-genesis-state          Deprecated; ignored");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --validator_config DIR       Directory with annotated_validators.yaml and validator-config.yaml");
-}
-
-
-/**
- * @brief Print node identity CLI options.
- */
-static void print_usage_node_identity(void)
-{
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --node-id NAME               Node identifier (e.g., ream_0)");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --node-key HEX               Local node private key (32-byte hex)");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --node-key-path PATH         Path to file containing node private key hex");
-}
-
-
-/**
- * @brief Print network-related CLI options.
- */
-static void print_usage_network(void)
-{
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --listen-address ADDR        QUIC listen multiaddr");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --checkpoint-sync-url URL    Fetch finalized state from remote beacon API");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --http-port PORT             HTTP API port");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --metrics-port PORT          Metrics port");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --bootnode ENR               Add a bootnode enr");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --bootnodes VALUE            ENR or path to YAML/List file of ENRs");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --bootnodes-file PATH        File with newline-delimited ENRs");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --devnet NAME                Devnet identifier for gossip topics");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --attestation-committee-count N  Number of attestation committees (subnets); overrides config.yaml ATTESTATION_COMMITTEE_COUNT");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --is-aggregator              Mark this node as the subnet aggregator");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --aggregate-subnet-ids IDS   Comma-separated attestation subnets this aggregator imports");
-}
-
-
-/**
- * @brief Print hash signature key CLI options.
- */
-static void print_usage_xmss(void)
-{
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --xmss-key-dir PATH     Directory containing XMSS key files");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --hash-sig-key-dir PATH Alias for --xmss-key-dir");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --xmss-secret PATH      Path to a single XMSS secret key file");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --xmss-secret-template STR  printf-style template for secret key paths");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --shadow-xmss-aggregate-signatures-rate N  Shadow XMSS aggregate signatures per second");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --shadow-xmss-verify-aggregated-signatures-rate N  Shadow XMSS aggregate verification signatures per second");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --shadow-xmss-merge-rate N  Shadow XMSS Type-1 components merged per second");
-}
-
-
-/**
- * @brief Print miscellaneous CLI options.
- */
-static void print_usage_misc(void)
-{
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --log-level LEVEL           Minimum log level (trace, debug, info, warn, error)");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --help                       Show this message");
-    lantern_log_info(
-        "main",
-        NULL,
-        "  --version                    Print version information");
-}
-
-
-/**
- * Print command-line usage information.
- *
- * Outputs all available command-line options and their descriptions
- * to the log.
- *
- * @param prog  Program name (typically argv[0])
- *
- * @note Thread safety: Intended for single-threaded CLI execution before
- *       worker threads are started.
- */
-static void print_usage(const char *prog)
-{
-    lantern_log_info("main", NULL, "Usage: %s [options]", prog);
-    print_usage_paths();
-    print_usage_node_identity();
-    print_usage_network();
-    print_usage_xmss();
-    print_usage_misc();
-}
-
-static lantern_client_error parse_double_value(const char *text, double *out_value)
-{
-    if (!text || !out_value)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    if (isspace((unsigned char)text[0]))
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    char *end = NULL;
-    double parsed = strtod(text, &end);
-    if (end == text || (end && *end != '\0'))
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    *out_value = parsed;
-    return LANTERN_CLIENT_OK;
-}
-
-
-/**
- * Parse a string as an unsigned 16-bit integer.
- *
- * @param text       String to parse
- * @param out_value  Output parameter for the parsed value
- *
- * @return LANTERN_CLIENT_OK on success
- * @return LANTERN_CLIENT_ERR_INVALID_PARAM if text is NULL, out_value is NULL, or parsing fails
- *
- * @note Thread safety: Reentrant; no shared state.
- */
-static lantern_client_error parse_u16(const char *text, uint16_t *out_value)
-{
-    if (!text || !out_value)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    errno = 0;
-    char *end = NULL;
-    long parsed = strtol(text, &end, 10);
-    if (errno != 0 || end == text)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    while (end && *end != '\0' && isspace((unsigned char)*end))
-    {
-        ++end;
-    }
-    if (end && *end != '\0')
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    if (parsed < 0 || parsed > UINT16_MAX)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    *out_value = (uint16_t)parsed;
-    return LANTERN_CLIENT_OK;
-}
-
-static lantern_client_error parse_size_t_nonnegative(const char *text, size_t *out_value)
-{
-    if (!text || !out_value)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    while (*text && isspace((unsigned char)*text))
-    {
-        ++text;
-    }
-    if (*text == '-')
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    errno = 0;
-    char *end = NULL;
-    unsigned long long parsed = strtoull(text, &end, 10);
-    if (errno != 0 || end == text)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    while (end && *end != '\0' && isspace((unsigned char)*end))
-    {
-        ++end;
-    }
-    if ((end && *end != '\0') || parsed > (unsigned long long)SIZE_MAX)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    *out_value = (size_t)parsed;
-    return LANTERN_CLIENT_OK;
-}
-
-static lantern_client_error parse_size_t_positive(const char *text, size_t *out_value)
-{
-    if (!text || !out_value)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    errno = 0;
-    char *end = NULL;
-    unsigned long long parsed = strtoull(text, &end, 10);
-    if (errno != 0 || end == text)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-    while (end && *end != '\0' && isspace((unsigned char)*end))
-    {
-        ++end;
-    }
-    if ((end && *end != '\0') || parsed == 0 || parsed > (unsigned long long)SIZE_MAX)
-    {
-        return LANTERN_CLIENT_ERR_INVALID_PARAM;
-    }
-
-    *out_value = (size_t)parsed;
-    return LANTERN_CLIENT_OK;
 }

--- a/src/genesis/genesis_internal.h
+++ b/src/genesis/genesis_internal.h
@@ -32,8 +32,6 @@ enum
 void genesis_free_validator_config(struct lantern_validator_config *config);
 
 uint64_t genesis_parse_u64(const char *value, int *ok);
-char *genesis_dup_trimmed(const char *value);
-const char *genesis_yaml_object_value(const LanternYamlObject *object, const char *key);
 int genesis_decode_validator_pubkey_hex(
     const char *hex,
     uint8_t out[LANTERN_VALIDATOR_PUBKEY_SIZE]);

--- a/src/genesis/genesis_parse.c
+++ b/src/genesis/genesis_parse.c
@@ -1,288 +1,131 @@
-/**
- * @file genesis_parse.c
- * @brief Parsing and memory helpers for Lantern genesis artifacts.
- *
- * Implements internal helpers used by the public genesis API:
- * - YAML parsing for config/validators/validator-config/nodes files
- * - Memory ownership helpers for validator config structures
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- */
-
 #include "genesis_internal.h"
 
-#include <ctype.h>
-#include <inttypes.h>
 #include <limits.h>
-#include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "internal/yaml_parser.h"
 #include "lantern/support/strings.h"
 
-static const size_t GENESIS_LINE_BUFFER_LEN = 2048;
-static const size_t GENESIS_SMALL_LINE_BUFFER_LEN = 1024;
-
-static const char *const CHAIN_CONFIG_KEY_GENESIS_TIME = "GENESIS_TIME";
-static const char *const CHAIN_CONFIG_KEY_VALIDATOR_COUNT = "VALIDATOR_COUNT";
-static const char *const CHAIN_CONFIG_KEY_NUM_VALIDATORS = "NUM_VALIDATORS";
-static const char *const CHAIN_CONFIG_KEY_ATTESTATION_COMMITTEE_COUNT = "ATTESTATION_COMMITTEE_COUNT";
-static const char *const CHAIN_CONFIG_KEY_GENESIS_VALIDATORS = "GENESIS_VALIDATORS";
-static const char *const CHAIN_CONFIG_FIELD_ATTESTATION_PUBKEY = "attestation_pubkey";
-static const char *const CHAIN_CONFIG_FIELD_PROPOSAL_PUBKEY = "proposal_pubkey";
-
-static const char *const VALIDATOR_CONFIG_ARRAY_VALIDATORS = "validators";
-static const char *const VALIDATOR_CONFIG_FIELD_NAME = "name";
-static const char *const VALIDATOR_CONFIG_FIELD_COUNT = "count";
-static const char *const VALIDATOR_CONFIG_FIELD_IP = "ip";
-static const char *const VALIDATOR_CONFIG_FIELD_QUIC = "quic";
-static const char *const VALIDATOR_CONFIG_FIELD_SEQ = "seq";
-static const char *const VALIDATOR_CONFIG_FIELD_IS_AGGREGATOR = "is_aggregator";
-static const char *const VALIDATOR_CONFIG_FIELD_XMSS_DIR = "xmssDir";
-static const char *const VALIDATOR_CONFIG_FIELD_SUBNET = "subnet";
-
-static int parse_bool(const char *value, int *ok);
-
-static int parse_validator_config_entry(
-    const LanternYamlObject *object,
-    struct lantern_validator_config_entry *entry);
-static void free_validator_config_entry(struct lantern_validator_config_entry *entry);
-
-static int parse_bool(const char *value, int *ok)
+static const char *mapping_scalar(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *mapping,
+    const char *key)
 {
-    if (ok)
-    {
-        *ok = 0;
-    }
-    if (!value)
-    {
-        return 0;
-    }
-
-    char *trimmed = genesis_dup_trimmed(value);
-    if (!trimmed)
-    {
-        return 0;
-    }
-
-    for (char *p = trimmed; *p; ++p)
-    {
-        *p = (char)tolower((unsigned char)*p);
-    }
-
-    int parsed = 0;
-    if (strcmp(trimmed, "true") == 0 || strcmp(trimmed, "1") == 0)
-    {
-        parsed = 1;
-        if (ok)
-        {
-            *ok = 1;
-        }
-    }
-    else if (strcmp(trimmed, "false") == 0 || strcmp(trimmed, "0") == 0)
-    {
-        parsed = 0;
-        if (ok)
-        {
-            *ok = 1;
-        }
-    }
-    free(trimmed);
-    return parsed;
+    return lantern_yaml_scalar(lantern_yaml_mapping_get(document, mapping, key));
 }
 
+static int parse_u64_field(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *mapping,
+    const char *key,
+    uint64_t *out)
+{
+    int ok = 0;
+    const char *value = mapping_scalar(document, mapping, key);
+    if (value)
+    {
+        *out = genesis_parse_u64(value, &ok);
+    }
+    return value && ok ? 0 : -1;
+}
 
-/**
- * Free resources held by a validator config entry.
- *
- * @param entry Entry to reset.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to entry.
- */
+static int parse_bool(const char *value, bool *out)
+{
+    if (!value || !out)
+    {
+        return -1;
+    }
+    if (strcmp(value, "true") == 0 || strcmp(value, "1") == 0)
+    {
+        *out = true;
+        return 0;
+    }
+    if (strcmp(value, "false") == 0 || strcmp(value, "0") == 0)
+    {
+        *out = false;
+        return 0;
+    }
+    return -1;
+}
+
 static void free_validator_config_entry(struct lantern_validator_config_entry *entry)
 {
-    if (!entry)
+    if (entry)
     {
-        return;
+        free(entry->name);
+        free(entry->enr.ip);
+        free(entry->xmss_dir);
+        free(entry->indices);
+        *entry = (struct lantern_validator_config_entry){0};
     }
-
-    free(entry->name);
-    free(entry->enr.ip);
-    free(entry->xmss_dir);
-    free(entry->indices);
 }
 
-
-/**
- * Free resources held by a validator config.
- *
- * Frees owned entries, then resets `config` to an empty state. Safe to call
- * with NULL.
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- *
- * @param config Config to reset.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
 void genesis_free_validator_config(struct lantern_validator_config *config)
 {
     if (!config)
     {
         return;
     }
-
-    if (config->entries)
+    for (size_t i = 0; i < config->count; ++i)
     {
-        for (size_t i = 0; i < config->count; ++i)
-        {
-            free_validator_config_entry(&config->entries[i]);
-        }
-        free(config->entries);
+        free_validator_config_entry(&config->entries[i]);
     }
-
+    free(config->entries);
     *config = (struct lantern_validator_config){0};
 }
 
-
-/**
- * Parse chain configuration scalars from a chain config file.
- *
- * Parses the top-level `GENESIS_TIME` and validator-count scalar
- * (`VALIDATOR_COUNT` or `NUM_VALIDATORS`). Any prior validator registry in
- * `config` is freed and reset.
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- *
- * @param path   Path to the chain config YAML file.
- * @param config Config to populate (modified in place).
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_IO on file I/O errors.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on parse/validation failures.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
 int genesis_parse_chain_config(const char *path, struct lantern_chain_config *config)
 {
     if (!path || !config)
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
-    config->genesis_time = 0;
-    config->validator_count = 0;
-    config->attestation_committee_count = 0;
-
     free(config->validators);
-    config->validators = NULL;
+    *config = (struct lantern_chain_config){0};
 
-    FILE *fp = fopen(path, "r");
-    if (!fp)
+    struct lantern_yaml_document document;
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
         return LANTERN_GENESIS_ERR_IO;
     }
-
-    int result = LANTERN_GENESIS_OK;
-    char line[GENESIS_SMALL_LINE_BUFFER_LEN];
-
-    while (fgets(line, sizeof(line), fp))
+    const yaml_node_t *root = lantern_yaml_root(&document);
+    int result = LANTERN_GENESIS_ERR_INVALID_DATA;
+    if (root && root->type == YAML_MAPPING_NODE
+        && parse_u64_field(&document, root, "GENESIS_TIME", &config->genesis_time) == 0
+        && config->genesis_time != 0u)
     {
-        char *trimmed = lantern_trim_whitespace(line);
-        if (!trimmed || *trimmed == '\0' || *trimmed == '#')
+        const char *count_key = NULL;
+        if (mapping_scalar(&document, root, "VALIDATOR_COUNT"))
         {
-            continue;
+            count_key = "VALIDATOR_COUNT";
         }
-
-        char *sep = strchr(trimmed, ':');
-        if (!sep)
+        else if (mapping_scalar(&document, root, "NUM_VALIDATORS"))
         {
-            continue;
+            count_key = "NUM_VALIDATORS";
         }
-
-        *sep = '\0';
-        const char *key = trimmed;
-        char *value = lantern_trim_whitespace(sep + 1);
-
-        if (strcmp(key, CHAIN_CONFIG_KEY_GENESIS_TIME) == 0)
-        {
-            int ok = 0;
-            config->genesis_time = genesis_parse_u64(value, &ok);
-            if (!ok || config->genesis_time == 0)
-            {
-                result = LANTERN_GENESIS_ERR_INVALID_DATA;
-                break;
-            }
-        }
-        else if (strcmp(key, CHAIN_CONFIG_KEY_VALIDATOR_COUNT) == 0
-                 || strcmp(key, CHAIN_CONFIG_KEY_NUM_VALIDATORS) == 0)
-        {
-            int ok = 0;
-            config->validator_count = genesis_parse_u64(value, &ok);
-            if (!ok)
-            {
-                result = LANTERN_GENESIS_ERR_INVALID_DATA;
-                break;
-            }
-        }
-        else if (strcmp(key, CHAIN_CONFIG_KEY_ATTESTATION_COMMITTEE_COUNT) == 0)
-        {
-            int ok = 0;
-            config->attestation_committee_count = genesis_parse_u64(value, &ok);
-            if (!ok || config->attestation_committee_count == 0)
-            {
-                result = LANTERN_GENESIS_ERR_INVALID_DATA;
-                break;
-            }
-        }
+        const char *committees = mapping_scalar(&document, root, "ATTESTATION_COMMITTEE_COUNT");
+        result = (!count_key
+                  || parse_u64_field(
+                         &document,
+                         root,
+                         count_key,
+                         &config->validator_count)
+                      == 0)
+                && (!committees
+                || (parse_u64_field(
+                        &document,
+                        root,
+                        "ATTESTATION_COMMITTEE_COUNT",
+                        &config->attestation_committee_count)
+                        == 0
+                    && config->attestation_committee_count != 0u))
+            ? LANTERN_GENESIS_OK
+            : LANTERN_GENESIS_ERR_INVALID_DATA;
     }
-
-    fclose(fp);
-
-    if (result != LANTERN_GENESIS_OK)
-    {
-        return result;
-    }
-
-    if (config->genesis_time == 0)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-
-    return LANTERN_GENESIS_OK;
+    lantern_yaml_document_reset(&document);
+    return result;
 }
 
-
-/**
- * Parse genesis validators from a chain config file.
- *
- * Supports the dual-key object format:
- *
- *   GENESIS_VALIDATORS:
- *     - attestation_pubkey: 0x...
- *       proposal_pubkey: 0x...
- *
- * On success, the returned registry is caller-owned and must be freed with
- * `free()`.
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- *
- * @param path                     Path to the chain config YAML file.
- * @param out_validators           Output pointer for the validator registry.
- * @param out_count                Output pointer for the validator count.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_IO on file I/O errors.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_OVERFLOW on size/capacity overflow.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on parse/validation failures.
- *
- * @note Thread safety: Thread-safe if callers provide exclusive access to outputs.
- */
 int genesis_parse_genesis_validators(
     const char *path,
     LanternValidator **out_validators,
@@ -292,334 +135,185 @@ int genesis_parse_genesis_validators(
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
     *out_validators = NULL;
-    *out_count = 0;
+    *out_count = 0u;
 
-    size_t object_count = 0;
-    LanternYamlObject *objects = lantern_yaml_read_array(
-        path,
-        CHAIN_CONFIG_KEY_GENESIS_VALIDATORS,
-        &object_count);
-    if (!objects || object_count == 0)
+    struct lantern_yaml_document document;
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
-        lantern_yaml_free_objects(objects, object_count);
+        return LANTERN_GENESIS_ERR_IO;
+    }
+    const yaml_node_t *root = lantern_yaml_root(&document);
+    const yaml_node_t *sequence = lantern_yaml_mapping_get(
+        &document,
+        root,
+        "GENESIS_VALIDATORS");
+    size_t count = lantern_yaml_sequence_length(sequence);
+    if (count == 0u)
+    {
+        lantern_yaml_document_reset(&document);
         return LANTERN_GENESIS_OK;
     }
-
-    if (object_count > SIZE_MAX / sizeof(LanternValidator))
+    LanternValidator *validators = calloc(count, sizeof(*validators));
+    int result = validators ? LANTERN_GENESIS_OK : LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
+    for (size_t i = 0; result == LANTERN_GENESIS_OK && i < count; ++i)
     {
-        lantern_yaml_free_objects(objects, object_count);
-        return LANTERN_GENESIS_ERR_OVERFLOW;
-    }
-    LanternValidator *validators = calloc(object_count, sizeof(*validators));
-    if (!validators)
-    {
-        lantern_yaml_free_objects(objects, object_count);
-        return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
-    }
-    int result = LANTERN_GENESIS_OK;
-
-    for (size_t i = 0; i < object_count; ++i)
-    {
-        const char *attestation_value = genesis_yaml_object_value(
-            &objects[i],
-            CHAIN_CONFIG_FIELD_ATTESTATION_PUBKEY);
-        const char *proposal_value = genesis_yaml_object_value(
-            &objects[i],
-            CHAIN_CONFIG_FIELD_PROPOSAL_PUBKEY);
-        if (!attestation_value || !proposal_value)
+        const yaml_node_t *entry = lantern_yaml_sequence_get(&document, sequence, i);
+        const char *attestation = mapping_scalar(&document, entry, "attestation_pubkey");
+        const char *proposal = mapping_scalar(&document, entry, "proposal_pubkey");
+        if (!attestation || !proposal
+            || genesis_decode_validator_pubkey_hex(
+                   attestation,
+                   validators[i].attestation_pubkey)
+                != LANTERN_GENESIS_OK
+            || genesis_decode_validator_pubkey_hex(
+                   proposal,
+                   validators[i].proposal_pubkey)
+                != LANTERN_GENESIS_OK)
         {
             result = LANTERN_GENESIS_ERR_INVALID_DATA;
-            break;
         }
-
-        char *attestation_hex = genesis_dup_trimmed(attestation_value);
-        char *proposal_hex = genesis_dup_trimmed(proposal_value);
-        if (!attestation_hex || !proposal_hex)
-        {
-            free(attestation_hex);
-            free(proposal_hex);
-            result = LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
-            break;
-        }
-
-        result = genesis_decode_validator_pubkey_hex(
-            attestation_hex,
-            validators[i].attestation_pubkey);
-        if (result == LANTERN_GENESIS_OK)
-        {
-            result = genesis_decode_validator_pubkey_hex(
-                proposal_hex,
-                validators[i].proposal_pubkey);
-        }
-        validators[i].index = (uint64_t)i;
-
-        free(attestation_hex);
-        free(proposal_hex);
-
-        if (result != LANTERN_GENESIS_OK)
-        {
-            result = (result == LANTERN_GENESIS_ERR_OUT_OF_MEMORY)
-                ? result
-                : LANTERN_GENESIS_ERR_INVALID_DATA;
-            break;
-        }
+        validators[i].index = i;
     }
-
-    lantern_yaml_free_objects(objects, object_count);
-
+    lantern_yaml_document_reset(&document);
     if (result != LANTERN_GENESIS_OK)
     {
         free(validators);
         return result;
     }
-
     *out_validators = validators;
-    *out_count = object_count;
+    *out_count = count;
     return LANTERN_GENESIS_OK;
 }
 
-
-/**
- * Parse a validator-config.yaml entry into a config entry struct.
- *
- * Populates `entry` by duplicating required fields from `object`. On success,
- * `entry` owns any allocated strings and must be released with
- * `free_validator_config_entry()`.
- *
- * @param object YAML object to parse.
- * @param entry  Entry to populate (modified in place).
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on validation failures.
- * @return LANTERN_GENESIS_ERR_PARSE on decode/derivation failures.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to entry.
- */
 static int parse_validator_config_entry(
-    const LanternYamlObject *object,
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *mapping,
     struct lantern_validator_config_entry *entry)
 {
-    if (!object || !entry)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    const char *name_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_NAME);
-    const char *count_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_COUNT);
-    const char *ip_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_IP);
-    const char *quic_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_QUIC);
-    const char *seq_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_SEQ);
-    const char *is_aggregator_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_IS_AGGREGATOR);
-    const char *xmss_dir_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_XMSS_DIR);
-    const char *subnet_val = genesis_yaml_object_value(object, VALIDATOR_CONFIG_FIELD_SUBNET);
-
-    entry->name = genesis_dup_trimmed(name_val);
-    if (!entry->name)
-    {
-        return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
-    }
-
+    const yaml_node_t *enr = lantern_yaml_mapping_get(document, mapping, "enrFields");
+    const char *name = mapping_scalar(document, mapping, "name");
+    const char *ip = mapping_scalar(document, enr, "ip");
+    const char *quic = mapping_scalar(document, enr, "quic");
     int ok = 0;
-    entry->count = genesis_parse_u64(count_val, &ok);
-    if (!ok || entry->count == 0)
+    if (!name || !ip || !quic)
     {
         return LANTERN_GENESIS_ERR_INVALID_DATA;
     }
-
-    entry->enr.ip = genesis_dup_trimmed(ip_val);
-    if (ip_val && !entry->enr.ip)
+    entry->name = lantern_string_duplicate(name);
+    entry->enr.ip = lantern_string_duplicate(ip);
+    entry->count = genesis_parse_u64(mapping_scalar(document, mapping, "count"), &ok);
+    if (!entry->name || !entry->enr.ip)
     {
         return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
     }
-
-    uint64_t quic_port = genesis_parse_u64(quic_val, &ok);
-    if (!ok || quic_port > UINT16_MAX)
+    if (!ok || entry->count == 0u)
     {
         return LANTERN_GENESIS_ERR_INVALID_DATA;
     }
-    entry->enr.quic_port = (uint16_t)quic_port;
-
-    entry->enr.sequence = 1;
-    if (seq_val && *seq_val)
+    uint64_t port = genesis_parse_u64(quic, &ok);
+    if (!ok || port > UINT16_MAX)
     {
-        entry->enr.sequence = genesis_parse_u64(seq_val, &ok);
+        return LANTERN_GENESIS_ERR_INVALID_DATA;
+    }
+    entry->enr.quic_port = (uint16_t)port;
+    entry->enr.sequence = 1u;
+    const char *sequence = mapping_scalar(document, enr, "seq");
+    if (sequence)
+    {
+        entry->enr.sequence = genesis_parse_u64(sequence, &ok);
         if (!ok)
         {
             return LANTERN_GENESIS_ERR_INVALID_DATA;
         }
     }
-
-    entry->enr.is_aggregator = false;
-    if (is_aggregator_val && *is_aggregator_val)
+    const char *aggregator = mapping_scalar(document, enr, "is_aggregator");
+    if (!aggregator)
     {
-        int bool_ok = 0;
-        entry->enr.is_aggregator = parse_bool(is_aggregator_val, &bool_ok) ? true : false;
-        if (!bool_ok)
-        {
-            return LANTERN_GENESIS_ERR_INVALID_DATA;
-        }
+        aggregator = mapping_scalar(document, mapping, "isAggregator");
     }
-
-    entry->has_subnet = false;
-    entry->subnet = 0;
-    if (subnet_val && *subnet_val)
+    if (aggregator && parse_bool(aggregator, &entry->enr.is_aggregator) != 0)
     {
-        entry->subnet = genesis_parse_u64(subnet_val, &ok);
+        return LANTERN_GENESIS_ERR_INVALID_DATA;
+    }
+    const char *subnet = mapping_scalar(document, mapping, "subnet");
+    if (subnet)
+    {
+        entry->subnet = genesis_parse_u64(subnet, &ok);
+        entry->has_subnet = ok != 0;
         if (!ok)
         {
             return LANTERN_GENESIS_ERR_INVALID_DATA;
         }
-        entry->has_subnet = true;
     }
-
-    entry->xmss_dir = genesis_dup_trimmed(xmss_dir_val);
-    if (xmss_dir_val && !entry->xmss_dir)
+    const char *xmss_dir = mapping_scalar(document, mapping, "xmssDir");
+    if (xmss_dir && !(entry->xmss_dir = lantern_string_duplicate(xmss_dir)))
     {
         return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
     }
     return LANTERN_GENESIS_OK;
 }
 
-
-/**
- * Parse validator configuration entries from a validator-config.yaml file.
- *
- * On success, `config` owns the returned buffers and must be released with
- * `genesis_free_validator_config()`.
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- *
- * @param path   Path to validator-config.yaml.
- * @param config Config to populate.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_IO on file I/O errors.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_OVERFLOW on size/capacity overflow.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on validation failures.
- * @return LANTERN_GENESIS_ERR_PARSE on parse failures.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
 int genesis_parse_validator_config(const char *path, struct lantern_validator_config *config)
 {
     if (!path || !config)
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
     genesis_free_validator_config(config);
-
-    size_t object_count = 0;
-    LanternYamlObject *objects = lantern_yaml_read_array(
-        path,
-        VALIDATOR_CONFIG_ARRAY_VALIDATORS,
-        &object_count);
-    if (!objects || object_count == 0)
+    struct lantern_yaml_document document;
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
-        lantern_yaml_free_objects(objects, object_count);
-        return LANTERN_GENESIS_ERR_PARSE;
+        return LANTERN_GENESIS_ERR_IO;
     }
-
-    if (object_count > SIZE_MAX / sizeof(*config->entries))
+    const yaml_node_t *entries_node = lantern_yaml_mapping_get(
+        &document,
+        lantern_yaml_root(&document),
+        "validators");
+    size_t count = lantern_yaml_sequence_length(entries_node);
+    config->entries = calloc(count, sizeof(*config->entries));
+    int result = count > 0u && config->entries
+        ? LANTERN_GENESIS_OK
+        : LANTERN_GENESIS_ERR_PARSE;
+    config->count = count;
+    for (size_t i = 0; result == LANTERN_GENESIS_OK && i < count; ++i)
     {
-        lantern_yaml_free_objects(objects, object_count);
-        return LANTERN_GENESIS_ERR_OVERFLOW;
+        result = parse_validator_config_entry(
+            &document,
+            lantern_yaml_sequence_get(&document, entries_node, i),
+            &config->entries[i]);
     }
-
-    struct lantern_validator_config_entry *entries = calloc(object_count, sizeof(*entries));
-    if (!entries)
+    lantern_yaml_document_reset(&document);
+    if (result != LANTERN_GENESIS_OK)
     {
-        lantern_yaml_free_objects(objects, object_count);
-        return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
+        genesis_free_validator_config(config);
     }
-
-    for (size_t i = 0; i < object_count; ++i)
-    {
-        int result = parse_validator_config_entry(&objects[i], &entries[i]);
-        if (result != LANTERN_GENESIS_OK)
-        {
-            for (size_t j = 0; j <= i; ++j)
-            {
-                free_validator_config_entry(&entries[j]);
-            }
-            free(entries);
-            lantern_yaml_free_objects(objects, object_count);
-            return result;
-        }
-    }
-
-    lantern_yaml_free_objects(objects, object_count);
-
-    config->entries = entries;
-    config->count = object_count;
-    return LANTERN_GENESIS_OK;
+    return result;
 }
 
-
-/**
- * Parse `nodes.yaml` and append ENR entries to a list.
- *
- * @spec Lantern devnet genesis artifact files (lean quickstart).
- *
- * @param path Path to nodes.yaml.
- * @param list Record list to append to.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_IO on file I/O errors.
- * @return LANTERN_GENESIS_ERR_PARSE on parse failures.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to list.
- */
 int genesis_parse_nodes_file(const char *path, struct lantern_enr_record_list *list)
 {
     if (!path || !list)
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
-    FILE *fp = fopen(path, "r");
-    if (!fp)
+    struct lantern_yaml_document document;
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
         return LANTERN_GENESIS_ERR_IO;
     }
-
-    int result = LANTERN_GENESIS_OK;
-    char line[GENESIS_LINE_BUFFER_LEN];
-
-    while (fgets(line, sizeof(line), fp))
+    const yaml_node_t *root = lantern_yaml_root(&document);
+    int result = !root || root->type == YAML_SEQUENCE_NODE
+        ? LANTERN_GENESIS_OK
+        : LANTERN_GENESIS_ERR_PARSE;
+    for (size_t i = 0; result == LANTERN_GENESIS_OK && i < lantern_yaml_sequence_length(root); ++i)
     {
-        char *trimmed = lantern_trim_whitespace(line);
-        if (!trimmed || *trimmed == '\0' || *trimmed == '#')
-        {
-            continue;
-        }
-
-        char *enr = strstr(trimmed, "enr:");
-        if (!enr)
-        {
-            continue;
-        }
-
-        enr = lantern_trim_whitespace(enr);
-        if (!enr || *enr == '\0')
-        {
-            continue;
-        }
-
-        if (lantern_enr_record_list_append(list, enr) != 0)
+        const char *enr = lantern_yaml_scalar(lantern_yaml_sequence_get(&document, root, i));
+        if (!enr || lantern_enr_record_list_append(list, enr) != 0)
         {
             result = LANTERN_GENESIS_ERR_PARSE;
-            break;
         }
     }
-
-    fclose(fp);
+    lantern_yaml_document_reset(&document);
     return result;
 }

--- a/src/genesis/genesis_parse_helpers.c
+++ b/src/genesis/genesis_parse_helpers.c
@@ -47,53 +47,6 @@ uint64_t genesis_parse_u64(const char *value, int *ok)
     return (uint64_t)parsed;
 }
 
-char *genesis_dup_trimmed(const char *value)
-{
-    if (!value)
-    {
-        return NULL;
-    }
-
-    const char *start = value;
-    while (*start && isspace((unsigned char)*start))
-    {
-        ++start;
-    }
-
-    const char *end = start + strlen(start);
-    while (end > start && isspace((unsigned char)*(end - 1)))
-    {
-        --end;
-    }
-
-    if ((end - start) >= 2
-        && ((*start == '"' && *(end - 1) == '"') || (*start == '\'' && *(end - 1) == '\'')))
-    {
-        ++start;
-        --end;
-    }
-
-    return lantern_string_duplicate_len(start, (size_t)(end - start));
-}
-
-const char *genesis_yaml_object_value(const LanternYamlObject *object, const char *key)
-{
-    if (!object || !key)
-    {
-        return NULL;
-    }
-
-    for (size_t i = 0; i < object->num_pairs; ++i)
-    {
-        if (object->pairs[i].key && strcmp(object->pairs[i].key, key) == 0)
-        {
-            return object->pairs[i].value;
-        }
-    }
-
-    return NULL;
-}
-
 int genesis_decode_validator_pubkey_hex(const char *hex, uint8_t out[LANTERN_VALIDATOR_PUBKEY_SIZE])
 {
     if (!hex || !out)

--- a/src/genesis/genesis_validator_config.c
+++ b/src/genesis/genesis_validator_config.c
@@ -1,497 +1,55 @@
-/**
- * @file genesis_validator_config.c
- * @brief Validator configuration helpers for genesis bootstrapping.
- *
- * Implements:
- * - Lookup helpers for validator-config entries
- * - Default contiguous range assignment
- * - Explicit validator index assignment parsing from validators.yaml mappings
- *
- * @spec Lantern validator-config.yaml and validators.yaml mapping formats.
- */
-
 #include "lantern/genesis/genesis.h"
 
-#include <ctype.h>
 #include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "genesis_internal.h"
-#include "lantern/support/strings.h"
 
-static const size_t GENESIS_LINE_BUFFER_LEN = 2048;
-
-static int compare_u64(const void *lhs, const void *rhs);
-static bool entry_has_assignment_index(
-    const struct lantern_validator_config_entry *entry,
-    uint64_t index);
-static int append_assignment_index(struct lantern_validator_config_entry *entry, uint64_t index);
-static int parse_assignment_item_index(
-    const char *trimmed,
-    bool *out_has_index,
-    uint64_t *out_index);
-static int parse_assignment_mapping_key(
-    struct lantern_validator_config *config,
-    char *line,
-    bool *out_is_mapping_key,
-    struct lantern_validator_config_entry **out_entry);
-
-static int parse_assignment_file(
-    struct lantern_validator_config *config,
-    FILE *fp,
-    bool *assigned,
-    uint64_t validator_count,
-    bool *out_has_matching_entry,
-    size_t *out_assigned_total);
-
-static int finalize_assignment_entries(
-    struct lantern_validator_config *config);
-
-
-/**
- * Compare two `uint64_t` values for ascending sort order.
- *
- * @param lhs Pointer to a `uint64_t`.
- * @param rhs Pointer to a `uint64_t`.
- *
- * @return -1 if lhs < rhs.
- * @return  1 if lhs > rhs.
- * @return  0 if equal.
- *
- * @note Thread safety: Thread-safe.
- */
-static int compare_u64(const void *lhs, const void *rhs)
+static int compare_u64(const void *left, const void *right)
 {
-    const uint64_t *left_value = lhs;
-    const uint64_t *right_value = rhs;
-    if (*left_value < *right_value)
-    {
-        return -1;
-    }
-    if (*left_value > *right_value)
-    {
-        return 1;
-    }
-    return 0;
+    uint64_t lhs = *(const uint64_t *)left;
+    uint64_t rhs = *(const uint64_t *)right;
+    return lhs < rhs ? -1 : lhs > rhs;
 }
 
-static bool entry_has_assignment_index(
-    const struct lantern_validator_config_entry *entry,
-    uint64_t index)
-{
-    if (!entry)
-    {
-        return false;
-    }
-
-    for (size_t index_pos = 0; index_pos < entry->indices_len; ++index_pos)
-    {
-        if (entry->indices[index_pos] == index)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-
-/**
- * Append a validator index to an entry's explicit index list.
- *
- * Appends an index after the caller has checked it for duplication.
- *
- * @param entry Entry to update.
- * @param index Validator index to append.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM if entry is NULL.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA if index is already present.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_OVERFLOW on capacity overflow.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to entry.
- */
-static int append_assignment_index(struct lantern_validator_config_entry *entry, uint64_t index)
-{
-    if (!entry)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    if (entry->indices_len >= entry->count)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-    if (!entry->indices)
-    {
-        if (entry->count > SIZE_MAX / sizeof(*entry->indices))
-        {
-            return LANTERN_GENESIS_ERR_OVERFLOW;
-        }
-        entry->indices = malloc((size_t)entry->count * sizeof(*entry->indices));
-        if (!entry->indices)
-        {
-            return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
-        }
-    }
-
-    entry->indices[entry->indices_len] = index;
-    entry->indices_len++;
-    return LANTERN_GENESIS_OK;
-}
-
-static int parse_assignment_item_index(
-    const char *trimmed,
-    bool *out_has_index,
-    uint64_t *out_index)
-{
-    if (!trimmed || !out_has_index || !out_index)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    *out_has_index = false;
-    *out_index = 0;
-
-    if (*trimmed != '-')
-    {
-        return LANTERN_GENESIS_OK;
-    }
-
-    const char *value = lantern_trim_whitespace((char *)(trimmed + 1));
-    if (!value || *value == '\0')
-    {
-        return LANTERN_GENESIS_OK;
-    }
-
-    if (strncmp(value, "index", 5) == 0 && value[5] == ':')
-    {
-        value = lantern_trim_whitespace((char *)(value + 6));
-    }
-
-    int is_valid_index = 0;
-    uint64_t parsed = genesis_parse_u64(value, &is_valid_index);
-    if (!is_valid_index)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-
-    *out_has_index = true;
-    *out_index = parsed;
-    return LANTERN_GENESIS_OK;
-}
-
-
-/**
- * Parse a validators.yaml mapping key line.
- *
- * Accepts `<name>:` lines with optional trailing whitespace and/or a `#` comment,
- * and rejects inline values (e.g. `name: 1`). When a mapping is detected, `line`
- * is modified in place by replacing the colon with `\0`.
- *
- * @param config          Validator config to search.
- * @param line            Line buffer to parse (modified in place).
- * @param out_is_mapping_key Set to true if the line is a mapping key, false otherwise.
- * @param out_entry       Set to the matching entry, or NULL if not found.
- *
- * @return LANTERN_GENESIS_OK on success (including non-mapping lines).
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA if the mapping key is empty.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
-static int parse_assignment_mapping_key(
-    struct lantern_validator_config *config,
-    char *line,
-    bool *out_is_mapping_key,
-    struct lantern_validator_config_entry **out_entry)
-{
-    if (!config || !line || !out_is_mapping_key || !out_entry)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    *out_is_mapping_key = false;
-    *out_entry = NULL;
-
-    char *colon = strchr(line, ':');
-    if (!colon)
-    {
-        return LANTERN_GENESIS_OK;
-    }
-
-    char *value = colon + 1;
-    while (*value != '\0' && isspace((unsigned char)*value))
-    {
-        ++value;
-    }
-    if (*value != '\0' && *value != '#')
-    {
-        return LANTERN_GENESIS_OK;
-    }
-
-    *colon = '\0';
-    char *name = lantern_trim_whitespace(line);
-    if (!name || *name == '\0')
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-
-    size_t name_len = strlen(name);
-    if (name_len >= 2
-        && ((name[0] == '"' && name[name_len - 1] == '"')
-            || (name[0] == '\'' && name[name_len - 1] == '\'')))
-    {
-        name[name_len - 1] = '\0';
-        ++name;
-    }
-
-    if (*name == '\0')
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-
-    *out_entry = lantern_validator_config_find(config, name);
-    *out_is_mapping_key = true;
-    return LANTERN_GENESIS_OK;
-}
-
-
-/**
- * Parse a validators.yaml mapping file into explicit indices on config entries.
- *
- * Updates `entry->indices` for each mapping key that matches a config entry. List
- * items under unknown mapping keys are ignored. If `assigned` is provided, it is
- * used as a global uniqueness tracker across all entries.
- *
- * @param config             Validator config to update in place.
- * @param fp                 Open file handle to read from.
- * @param assigned           Optional bitset of length validator_count, or NULL.
- * @param validator_count    Maximum allowed validator index is validator_count - 1.
- * @param out_has_matching_entry Set true if at least one mapping key matched an entry.
- * @param out_assigned_total Total number of unique indices assigned across entries.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on malformed, duplicate, or out-of-range data.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_OVERFLOW on overflow.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
-static int parse_assignment_file(
-    struct lantern_validator_config *config,
-    FILE *fp,
-    bool *assigned,
-    uint64_t validator_count,
-    bool *out_has_matching_entry,
-    size_t *out_assigned_total)
-{
-    if (!fp || !config || !out_has_matching_entry || !out_assigned_total)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    *out_has_matching_entry = false;
-    *out_assigned_total = 0;
-
-    struct lantern_validator_config_entry *current = NULL;
-
-    char line[GENESIS_LINE_BUFFER_LEN];
-    while (fgets(line, sizeof(line), fp))
-    {
-        bool is_indented = isspace((unsigned char)line[0]) != 0;
-        char *trimmed = lantern_trim_whitespace(line);
-        if (!trimmed || *trimmed == '\0' || *trimmed == '#')
-        {
-            continue;
-        }
-
-        bool has_index = false;
-        uint64_t parsed = 0;
-        int item_rc = parse_assignment_item_index(trimmed, &has_index, &parsed);
-        if (item_rc != LANTERN_GENESIS_OK)
-        {
-            return item_rc;
-        }
-        if (has_index)
-        {
-            if (!current || !assigned || parsed >= validator_count)
-            {
-                continue;
-            }
-
-            if (entry_has_assignment_index(current, parsed))
-            {
-                continue;
-            }
-            if (assigned[(size_t)parsed])
-            {
-                return LANTERN_GENESIS_ERR_INVALID_DATA;
-            }
-
-            int result = append_assignment_index(current, parsed);
-            if (result != LANTERN_GENESIS_OK)
-            {
-                return result;
-            }
-
-            assigned[(size_t)parsed] = true;
-            (*out_assigned_total)++;
-            continue;
-        }
-
-        struct lantern_validator_config_entry *entry = NULL;
-        bool is_mapping_key = false;
-        int mapping_rc = parse_assignment_mapping_key(config, trimmed, &is_mapping_key, &entry);
-        if (mapping_rc != LANTERN_GENESIS_OK)
-        {
-            return mapping_rc;
-        }
-        if (!is_mapping_key)
-        {
-            if (is_indented && current)
-            {
-                continue;
-            }
-            current = NULL;
-            continue;
-        }
-
-        current = entry;
-        if (entry)
-        {
-            *out_has_matching_entry = true;
-            entry->indices_len = 0;
-        }
-    }
-
-    return LANTERN_GENESIS_OK;
-}
-
-
-/**
- * Validate and finalize config entries after explicit assignments are parsed.
- *
- * Ensures each entry has exactly `entry->count` explicit indices, then sorts
- * each list for binary-search lookup.
- *
- * @param config          Validator config to validate and update in place.
- * @param validator_count Total number of validators (must be non-zero).
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA if any entry is missing indices or has a mismatch.
- * @return LANTERN_GENESIS_ERR_OVERFLOW if computing the end index would overflow.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
-static int finalize_assignment_entries(struct lantern_validator_config *config)
-{
-    if (!config || !config->entries || config->count == 0)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_PARAM;
-    }
-
-    for (size_t entry_index = 0; entry_index < config->count; ++entry_index)
-    {
-        struct lantern_validator_config_entry *entry = &config->entries[entry_index];
-        if (entry->indices_len != entry->count || entry->indices_len == 0)
-        {
-            return LANTERN_GENESIS_ERR_INVALID_DATA;
-        }
-
-        qsort(entry->indices, entry->indices_len, sizeof(*entry->indices), compare_u64);
-    }
-
-    return LANTERN_GENESIS_OK;
-}
-
-
-/**
- * Find a validator config entry by name.
- *
- * @spec Lantern validator-config.yaml and validators.yaml mapping formats.
- *
- * @param config Validator config to search.
- * @param name   Entry name to match (exact string compare).
- *
- * @return Matching entry pointer, or NULL if not found.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
 struct lantern_validator_config_entry *lantern_validator_config_find(
     struct lantern_validator_config *config,
     const char *name)
 {
-    if (!config || !name || !config->entries)
+    if (!config || !name)
     {
         return NULL;
     }
-
-    for (size_t entry_index = 0; entry_index < config->count; ++entry_index)
+    for (size_t i = 0; i < config->count; ++i)
     {
-        if (config->entries[entry_index].name
-            && strcmp(config->entries[entry_index].name, name) == 0)
+        if (config->entries[i].name && strcmp(config->entries[i].name, name) == 0)
         {
-            return &config->entries[entry_index];
+            return &config->entries[i];
         }
     }
-
     return NULL;
 }
 
-
-/**
- * Assign contiguous validator index ranges for each config entry.
- *
- * Entries receive sequential index lists starting at zero, in config order.
- *
- * @spec Lantern validator-config.yaml and validators.yaml mapping formats.
- *
- * @param config          Validator config to update in place.
- * @param validator_count Total number of validators expected across all entries.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA if counts do not sum to validator_count.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
 int lantern_validator_config_assign_ranges(
     struct lantern_validator_config *config,
     uint64_t validator_count)
 {
-    if (!config || !config->entries || config->count == 0 || validator_count == 0)
+    if (!config || !config->entries || config->count == 0u || validator_count == 0u)
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
-    uint64_t next_index = 0;
+    uint64_t next = 0u;
     for (size_t entry_index = 0; entry_index < config->count; ++entry_index)
     {
         struct lantern_validator_config_entry *entry = &config->entries[entry_index];
-        if (entry->count == 0)
+        if (entry->count == 0u || next > validator_count
+            || entry->count > validator_count - next
+            || entry->count > SIZE_MAX / sizeof(*entry->indices))
         {
             return LANTERN_GENESIS_ERR_INVALID_DATA;
         }
-
-        if (entry->count > (validator_count - next_index))
-        {
-            return LANTERN_GENESIS_ERR_INVALID_DATA;
-        }
-
-        if (entry->count > SIZE_MAX / sizeof(*entry->indices))
-        {
-            return LANTERN_GENESIS_ERR_OVERFLOW;
-        }
-        uint64_t *indices = realloc(
-            entry->indices,
-            (size_t)entry->count * sizeof(*entry->indices));
+        uint64_t *indices = realloc(entry->indices, (size_t)entry->count * sizeof(*indices));
         if (!indices)
         {
             return LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
@@ -500,110 +58,135 @@ int lantern_validator_config_assign_ranges(
         entry->indices_len = (size_t)entry->count;
         for (size_t i = 0; i < entry->indices_len; ++i)
         {
-            entry->indices[i] = next_index + i;
+            entry->indices[i] = next++;
         }
-        next_index += entry->count;
     }
-
-    if (next_index != validator_count)
-    {
-        return LANTERN_GENESIS_ERR_INVALID_DATA;
-    }
-
-    return LANTERN_GENESIS_OK;
+    return next == validator_count ? LANTERN_GENESIS_OK : LANTERN_GENESIS_ERR_INVALID_DATA;
 }
 
+static bool entry_has_index(const struct lantern_validator_config_entry *entry, uint64_t index)
+{
+    for (size_t i = 0; entry && i < entry->indices_len; ++i)
+    {
+        if (entry->indices[i] == index)
+        {
+            return true;
+        }
+    }
+    return false;
+}
 
-/**
- * Apply explicit validator index assignments from a validators.yaml mapping file.
- *
- * The file is expected to contain YAML mappings of the form:
- *
- *   <entry-name>:
- *     - <validator-index>
- *     - ...
- *
- * Each config entry must list exactly `entry->count` unique indices, and the union
- * of all indices must cover `[0, validator_count)` with no duplicates.
- *
- * @spec Lantern validator-config.yaml and validators.yaml mapping formats.
- *
- * @param config          Validator config to update in place.
- * @param path            Filesystem path to validators.yaml.
- * @param validator_count Total number of validators expected.
- *
- * @return LANTERN_GENESIS_OK on success.
- * @return LANTERN_GENESIS_ERR_INVALID_PARAM on invalid parameters.
- * @return LANTERN_GENESIS_ERR_IO if the file cannot be opened.
- * @return LANTERN_GENESIS_ERR_OUT_OF_MEMORY on allocation failure.
- * @return LANTERN_GENESIS_ERR_INVALID_DATA on malformed or inconsistent assignments.
- * @return LANTERN_GENESIS_ERR_OVERFLOW on size/count overflow.
- *
- * @note Thread safety: Not thread-safe. Caller must ensure exclusive access to config.
- */
+static const char *assignment_index_text(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *item)
+{
+    if (!item)
+    {
+        return NULL;
+    }
+    if (item->type == YAML_SCALAR_NODE)
+    {
+        return lantern_yaml_scalar(item);
+    }
+    return lantern_yaml_scalar(lantern_yaml_mapping_get(document, item, "index"));
+}
+
 int lantern_validator_config_apply_assignments(
     struct lantern_validator_config *config,
     const char *path,
     uint64_t validator_count)
 {
-    if (!config || !config->entries || config->count == 0 || !path || validator_count == 0)
+    if (!config || !config->entries || config->count == 0u || !path
+        || validator_count == 0u || validator_count > SIZE_MAX)
     {
         return LANTERN_GENESIS_ERR_INVALID_PARAM;
     }
-
-    if (validator_count > SIZE_MAX)
-    {
-        return LANTERN_GENESIS_ERR_OVERFLOW;
-    }
-
-    int result = LANTERN_GENESIS_OK;
-    FILE *fp = fopen(path, "r");
-    if (!fp)
+    struct lantern_yaml_document document;
+    if (lantern_yaml_document_load(path, &document) != 0)
     {
         return LANTERN_GENESIS_ERR_IO;
     }
+    const yaml_node_t *root = lantern_yaml_root(&document);
+    bool *assigned = calloc((size_t)validator_count, sizeof(*assigned));
+    int result = assigned && root && root->type == YAML_MAPPING_NODE
+        ? LANTERN_GENESIS_OK
+        : LANTERN_GENESIS_ERR_INVALID_DATA;
+    size_t assigned_count = 0u;
+    bool matched = false;
 
-    size_t assigned_len = (size_t)validator_count;
-    bool *assigned = NULL;
-    if (assigned_len > 0)
+    for (size_t entry_index = 0; result == LANTERN_GENESIS_OK && entry_index < config->count;
+         ++entry_index)
     {
-        assigned = calloc(assigned_len, sizeof(*assigned));
-        if (!assigned)
+        struct lantern_validator_config_entry *entry = &config->entries[entry_index];
+        const yaml_node_t *sequence = lantern_yaml_mapping_get(&document, root, entry->name);
+        if (!sequence)
+        {
+            continue;
+        }
+        matched = true;
+        if (entry->count > SIZE_MAX / sizeof(*entry->indices))
+        {
+            result = LANTERN_GENESIS_ERR_INVALID_DATA;
+            break;
+        }
+        uint64_t *indices = realloc(entry->indices, (size_t)entry->count * sizeof(*indices));
+        if (!indices)
         {
             result = LANTERN_GENESIS_ERR_OUT_OF_MEMORY;
-            goto cleanup;
+            break;
+        }
+        entry->indices = indices;
+        entry->indices_len = 0u;
+        for (size_t i = 0; i < lantern_yaml_sequence_length(sequence); ++i)
+        {
+            int ok = 0;
+            uint64_t index = genesis_parse_u64(
+                assignment_index_text(
+                    &document,
+                    lantern_yaml_sequence_get(&document, sequence, i)),
+                &ok);
+            if (!ok || index >= validator_count)
+            {
+                result = LANTERN_GENESIS_ERR_INVALID_DATA;
+                break;
+            }
+            if (entry_has_index(entry, index))
+            {
+                continue;
+            }
+            if (assigned[(size_t)index] || entry->indices_len >= entry->count)
+            {
+                result = LANTERN_GENESIS_ERR_INVALID_DATA;
+                break;
+            }
+            entry->indices[entry->indices_len++] = index;
+            assigned[(size_t)index] = true;
+            ++assigned_count;
         }
     }
-
-    bool has_matching_entry = false;
-    size_t assigned_total = 0;
-    result = parse_assignment_file(
-        config,
-        fp,
-        assigned,
-        validator_count,
-        &has_matching_entry,
-        &assigned_total);
-    if (result != LANTERN_GENESIS_OK)
+    if (result == LANTERN_GENESIS_OK && matched)
     {
-        goto cleanup;
+        if (assigned_count != (size_t)validator_count)
+        {
+            result = LANTERN_GENESIS_ERR_INVALID_DATA;
+        }
+        for (size_t i = 0; result == LANTERN_GENESIS_OK && i < config->count; ++i)
+        {
+            if (config->entries[i].indices_len != config->entries[i].count)
+            {
+                result = LANTERN_GENESIS_ERR_INVALID_DATA;
+            }
+            else
+            {
+                qsort(
+                    config->entries[i].indices,
+                    config->entries[i].indices_len,
+                    sizeof(*config->entries[i].indices),
+                    compare_u64);
+            }
+        }
     }
-
-    if (!has_matching_entry)
-    {
-        goto cleanup;
-    }
-
-    if (assigned_total != assigned_len)
-    {
-        result = LANTERN_GENESIS_ERR_INVALID_DATA;
-        goto cleanup;
-    }
-
-    result = finalize_assignment_entries(config);
-
-cleanup:
-    fclose(fp);
     free(assigned);
+    lantern_yaml_document_reset(&document);
     return result;
 }

--- a/src/http/client.c
+++ b/src/http/client.c
@@ -1,595 +1,59 @@
-/**
- * @file client.c
- * @brief Small bounded HTTP/1.1 client for one-shot byte fetches.
- */
-
 #include "lantern/http/client.h"
 
-#include "lantern/http/core.h"
-#include "lantern/support/strings.h"
-
-#include <ctype.h>
-#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 
-#if defined(_WIN32)
-#include <windows.h>
-#else
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif
+#include <curl/curl.h>
 
-static int parse_port(const char *text, size_t text_len, uint16_t *out_port)
+struct response_writer {
+    struct lantern_http_fetch_result *result;
+    size_t limit;
+};
+
+static pthread_once_t curl_once = PTHREAD_ONCE_INIT;
+static int curl_initialized;
+
+static void initialize_curl(void)
 {
-    if (!text || text_len == 0 || !out_port)
-    {
-        return -1;
-    }
-
-    uint32_t port = 0;
-    for (size_t i = 0; i < text_len; ++i)
-    {
-        unsigned char ch = (unsigned char)text[i];
-        if (!isdigit(ch))
-        {
-            return -1;
-        }
-        port = (port * 10u) + (uint32_t)(ch - '0');
-        if (port > UINT16_MAX)
-        {
-            return -1;
-        }
-    }
-    if (port == 0)
-    {
-        return -1;
-    }
-    *out_port = (uint16_t)port;
-    return 0;
+    curl_initialized = curl_global_init(CURL_GLOBAL_DEFAULT) == CURLE_OK;
 }
 
-void lantern_http_url_reset(struct lantern_http_url *url)
+static size_t receive_body(char *data, size_t size, size_t count, void *context)
 {
-    if (!url)
+    struct response_writer *writer = context;
+    if (!writer || !writer->result || (size != 0u && count > SIZE_MAX / size))
     {
-        return;
+        return 0u;
     }
-    free(url->host);
-    free(url->path);
-    memset(url, 0, sizeof(*url));
+    size_t length = size * count;
+    if (length > writer->limit - writer->result->body_len)
+    {
+        return 0u;
+    }
+    size_t total = writer->result->body_len + length;
+    uint8_t *next = total > 0u ? realloc(writer->result->body, total) : NULL;
+    if (total > 0u && !next)
+    {
+        return 0u;
+    }
+    if (length > 0u)
+    {
+        memcpy(next + writer->result->body_len, data, length);
+    }
+    writer->result->body = next;
+    writer->result->body_len = total;
+    return length;
 }
 
-int lantern_http_url_parse(const char *url, struct lantern_http_url *out_url)
+static bool supported_url(const char *url)
 {
-    if (!url || !out_url)
-    {
-        return -1;
-    }
-
-    memset(out_url, 0, sizeof(*out_url));
-    const char *http_prefix = "http://";
-    const char *https_prefix = "https://";
-    size_t prefix_len = strlen(http_prefix);
-    if (strncasecmp(url, http_prefix, prefix_len) != 0)
-    {
-        if (strncasecmp(url, https_prefix, strlen(https_prefix)) != 0)
-        {
-            return -1;
-        }
-        prefix_len = strlen(https_prefix);
-    }
-
-    const char *cursor = url + prefix_len;
-    const char *authority_start = cursor;
-    while (*cursor && *cursor != '/' && *cursor != '?' && *cursor != '#')
-    {
-        ++cursor;
-    }
-    const char *authority_end = cursor;
-    if (authority_end <= authority_start)
-    {
-        return -1;
-    }
-
-    out_url->path = *cursor == '/'
-                        ? lantern_string_duplicate_len(cursor, strcspn(cursor, "?#"))
-                        : lantern_string_duplicate("");
-    if (!out_url->path)
-    {
-        return -1;
-    }
-
-    out_url->port = 80;
-    if (*authority_start == '[')
-    {
-        const char *host_start = authority_start + 1;
-        const char *host_end = host_start;
-        while (host_end < authority_end && *host_end != ']')
-        {
-            ++host_end;
-        }
-        if (host_end >= authority_end || host_end == host_start)
-        {
-            lantern_http_url_reset(out_url);
-            return -1;
-        }
-        out_url->host = lantern_string_duplicate_len(host_start, (size_t)(host_end - host_start));
-        const char *port_start = host_end + 1;
-        if (!out_url->host
-            || (port_start < authority_end
-                && (*port_start != ':'
-                    || parse_port(
-                           port_start + 1,
-                           (size_t)(authority_end - port_start - 1),
-                           &out_url->port)
-                        != 0)))
-        {
-            lantern_http_url_reset(out_url);
-            return -1;
-        }
-    }
-    else
-    {
-        const char *port_sep = NULL;
-        for (const char *p = authority_start; p < authority_end; ++p)
-        {
-            if (*p == ':')
-            {
-                port_sep = p;
-            }
-        }
-
-        const char *host_end = port_sep ? port_sep : authority_end;
-        if (host_end <= authority_start)
-        {
-            lantern_http_url_reset(out_url);
-            return -1;
-        }
-        out_url->host = lantern_string_duplicate_len(
-            authority_start,
-            (size_t)(host_end - authority_start));
-        if (!out_url->host
-            || (port_sep
-                && parse_port(
-                       port_sep + 1,
-                       (size_t)(authority_end - port_sep - 1),
-                       &out_url->port)
-                    != 0))
-        {
-            lantern_http_url_reset(out_url);
-            return -1;
-        }
-    }
-
-    if (!out_url->host[0])
-    {
-        lantern_http_url_reset(out_url);
-        return -1;
-    }
-    return 0;
-}
-
-static bool header_value_has_token(
-    const char *value,
-    const char *value_end,
-    const char *token)
-{
-    size_t token_len = strlen(token);
-    while (value < value_end)
-    {
-        while (value < value_end && (*value == ',' || isspace((unsigned char)*value)))
-        {
-            ++value;
-        }
-        const char *entry_start = value;
-        while (value < value_end && *value != ',')
-        {
-            ++value;
-        }
-        const char *entry_end = value;
-        while (entry_end > entry_start && isspace((unsigned char)*(entry_end - 1)))
-        {
-            --entry_end;
-        }
-        if ((size_t)(entry_end - entry_start) == token_len
-            && strncasecmp(entry_start, token, token_len) == 0)
-        {
-            return true;
-        }
-        if (value < value_end && *value == ',')
-        {
-            ++value;
-        }
-    }
-    return false;
-}
-
-static const char *find_crlf(const char *start, const char *end)
-{
-    for (const char *p = start; p + 1 < end; ++p)
-    {
-        if (p[0] == '\r' && p[1] == '\n')
-        {
-            return p;
-        }
-    }
-    return NULL;
-}
-
-static int parse_status_code(const char *headers, size_t headers_len, int *out_status_code)
-{
-    if (!headers || !out_status_code)
-    {
-        return -1;
-    }
-
-    const char *headers_end = headers + headers_len;
-    const char *line_end = find_crlf(headers, headers_end);
-    const char *cursor = headers;
-    if (!line_end || line_end - cursor < 10 || memcmp(cursor, "HTTP/", 5u) != 0)
-    {
-        return -1;
-    }
-    cursor += 5u;
-    if (cursor >= line_end || !isdigit((unsigned char)*cursor))
-    {
-        return -1;
-    }
-    while (cursor < line_end && isdigit((unsigned char)*cursor))
-    {
-        ++cursor;
-    }
-    if (cursor >= line_end || *cursor++ != '.')
-    {
-        return -1;
-    }
-    if (cursor >= line_end || !isdigit((unsigned char)*cursor))
-    {
-        return -1;
-    }
-    while (cursor < line_end && isdigit((unsigned char)*cursor))
-    {
-        ++cursor;
-    }
-    if (cursor >= line_end || !isspace((unsigned char)*cursor))
-    {
-        return -1;
-    }
-    while (cursor < line_end && isspace((unsigned char)*cursor))
-    {
-        ++cursor;
-    }
-    if (cursor >= line_end || !isdigit((unsigned char)*cursor))
-    {
-        return -1;
-    }
-
-    int status = 0;
-    while (cursor < line_end && isdigit((unsigned char)*cursor))
-    {
-        status = (status * 10) + (*cursor - '0');
-        ++cursor;
-    }
-    *out_status_code = status;
-    return 0;
-}
-
-static bool response_is_chunked(const char *headers, size_t headers_len)
-{
-    static const char HEADER[] = "Transfer-Encoding:";
-    const size_t header_len = sizeof(HEADER) - 1u;
-    const char *headers_end = headers + headers_len;
-    const char *line = find_crlf(headers, headers_end);
-    line = line ? line + 2 : headers_end;
-
-    while (line < headers_end)
-    {
-        const char *line_end = find_crlf(line, headers_end);
-        if (!line_end || line_end == line)
-        {
-            break;
-        }
-        if ((size_t)(line_end - line) >= header_len
-            && strncasecmp(line, HEADER, header_len) == 0)
-        {
-            const char *value = line + header_len;
-            while (value < line_end && isspace((unsigned char)*value))
-            {
-                ++value;
-            }
-            if (header_value_has_token(value, line_end, "chunked"))
-            {
-                return true;
-            }
-        }
-        line = line_end + 2;
-    }
-    return false;
-}
-
-static int copy_body(
-    const char *body,
-    size_t body_len,
-    uint8_t **out_body,
-    size_t *out_body_len)
-{
-    uint8_t *copy = NULL;
-    if (body_len > 0)
-    {
-        copy = malloc(body_len);
-        if (!copy)
-        {
-            return -1;
-        }
-        memcpy(copy, body, body_len);
-    }
-    *out_body = copy;
-    *out_body_len = body_len;
-    return 0;
-}
-
-static int decode_chunked_body(
-    const char *chunked,
-    size_t chunked_len,
-    size_t max_body_bytes,
-    uint8_t **out_body,
-    size_t *out_body_len)
-{
-    struct lantern_http_buffer decoded = {0};
-    size_t cursor = 0;
-
-    while (cursor < chunked_len)
-    {
-        size_t line_start = cursor;
-        while (cursor + 1 < chunked_len && !(chunked[cursor] == '\r' && chunked[cursor + 1] == '\n'))
-        {
-            ++cursor;
-        }
-        if (cursor + 1 >= chunked_len || cursor == line_start || cursor - line_start >= 64u)
-        {
-            goto fail;
-        }
-
-        char line[64];
-        memcpy(line, chunked + line_start, cursor - line_start);
-        line[cursor - line_start] = '\0';
-        char *extensions = strchr(line, ';');
-        if (extensions)
-        {
-            *extensions = '\0';
-        }
-
-        char *trimmed = line;
-        while (*trimmed && isspace((unsigned char)*trimmed))
-        {
-            ++trimmed;
-        }
-        errno = 0;
-        char *endptr = NULL;
-        unsigned long long chunk_size_u64 = strtoull(trimmed, &endptr, 16);
-        if (errno != 0 || endptr == trimmed)
-        {
-            goto fail;
-        }
-        while (*endptr && isspace((unsigned char)*endptr))
-        {
-            ++endptr;
-        }
-        if (*endptr != '\0')
-        {
-            goto fail;
-        }
-        cursor += 2u;
-
-        if (chunk_size_u64 == 0)
-        {
-            if (cursor + 1 < chunked_len && chunked[cursor] == '\r' && chunked[cursor + 1] == '\n')
-            {
-                break;
-            }
-            for (size_t i = cursor; i + 3 < chunked_len; ++i)
-            {
-                if (memcmp(chunked + i, "\r\n\r\n", 4u) == 0)
-                {
-                    *out_body = (uint8_t *)decoded.data;
-                    *out_body_len = decoded.len;
-                    memset(&decoded, 0, sizeof(decoded));
-                    return 0;
-                }
-            }
-            goto fail;
-        }
-
-        if (chunk_size_u64 > (unsigned long long)(chunked_len - cursor)
-            || chunk_size_u64 > (unsigned long long)(max_body_bytes - decoded.len))
-        {
-            goto fail;
-        }
-        size_t chunk_size = (size_t)chunk_size_u64;
-        if (lantern_http_buffer_reserve(&decoded, chunk_size) != 0)
-        {
-            goto fail;
-        }
-        memcpy(decoded.data + decoded.len, chunked + cursor, chunk_size);
-        decoded.len += chunk_size;
-        decoded.data[decoded.len] = '\0';
-        cursor += chunk_size;
-        if (cursor + 1 >= chunked_len || chunked[cursor] != '\r' || chunked[cursor + 1] != '\n')
-        {
-            goto fail;
-        }
-        cursor += 2u;
-    }
-
-    *out_body = (uint8_t *)decoded.data;
-    *out_body_len = decoded.len;
-    memset(&decoded, 0, sizeof(decoded));
-    return 0;
-
-fail:
-    lantern_http_buffer_free(&decoded);
-    return -1;
-}
-
-static int extract_response_body(
-    const char *response,
-    size_t response_len,
-    size_t max_body_bytes,
-    struct lantern_http_fetch_result *out_result)
-{
-    const char *body = NULL;
-    size_t body_available = 0;
-    if (!lantern_http_locate_body(response, response_len, &body, &body_available))
-    {
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-
-    size_t headers_len = (size_t)(body - response);
-    if (parse_status_code(response, headers_len, &out_result->status_code) != 0)
-    {
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-    if (out_result->status_code != 200)
-    {
-        return LANTERN_HTTP_CLIENT_STATUS_ERROR;
-    }
-
-    if (response_is_chunked(response, headers_len))
-    {
-        return decode_chunked_body(
-                   body,
-                   body_available,
-                   max_body_bytes,
-                   &out_result->body,
-                   &out_result->body_len)
-                   == 0
-               ? LANTERN_HTTP_CLIENT_OK
-               : LANTERN_HTTP_CLIENT_ERR;
-    }
-
-    size_t content_length = 0;
-    size_t body_len = body_available;
-    if (lantern_http_parse_content_length(response, response_len, &content_length) == 0)
-    {
-        if (body_available < content_length)
-        {
-            return LANTERN_HTTP_CLIENT_ERR;
-        }
-        body_len = content_length;
-    }
-    if (body_len > max_body_bytes)
-    {
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-    return copy_body(body, body_len, &out_result->body, &out_result->body_len) == 0
-               ? LANTERN_HTTP_CLIENT_OK
-               : LANTERN_HTTP_CLIENT_ERR;
-}
-
-#if defined(_WIN32)
-static int connect_tcp(const char *host, uint16_t port)
-{
-    (void)host;
-    (void)port;
-    return -1;
-}
-#else
-static int connect_tcp(const char *host, uint16_t port)
-{
-    char port_text[6];
-    int port_written = snprintf(port_text, sizeof(port_text), "%u", (unsigned int)port);
-    if (!host || !host[0] || port_written <= 0 || (size_t)port_written >= sizeof(port_text))
-    {
-        return -1;
-    }
-
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-
-    struct addrinfo *results = NULL;
-    if (getaddrinfo(host, port_text, &hints, &results) != 0)
-    {
-        return -1;
-    }
-
-    int fd = -1;
-    for (const struct addrinfo *candidate = results; candidate; candidate = candidate->ai_next)
-    {
-        fd = socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol);
-        if (fd < 0)
-        {
-            continue;
-        }
-        if (connect(fd, candidate->ai_addr, candidate->ai_addrlen) == 0)
-        {
-            break;
-        }
-        close(fd);
-        fd = -1;
-    }
-    freeaddrinfo(results);
-    return fd;
-}
-#endif
-
-static int read_response(
-    int fd,
-    size_t max_response_bytes,
-    struct lantern_http_fetch_result *out_result)
-{
-    struct lantern_http_buffer response;
-    if (lantern_http_buffer_init(&response, 8192u) != 0)
-    {
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-
-    for (;;)
-    {
-        char chunk[4096];
-#if defined(_WIN32)
-        int received = recv(fd, chunk, (int)sizeof(chunk), 0);
-#else
-        ssize_t received = recv(fd, chunk, sizeof(chunk), 0);
-#endif
-        if (received < 0)
-        {
-#if !defined(_WIN32)
-            if (errno == EINTR)
-            {
-                continue;
-            }
-#endif
-            lantern_http_buffer_free(&response);
-            return LANTERN_HTTP_CLIENT_ERR;
-        }
-        if (received == 0)
-        {
-            break;
-        }
-        if ((size_t)received > max_response_bytes - response.len
-            || lantern_http_buffer_reserve(&response, (size_t)received) != 0)
-        {
-            lantern_http_buffer_free(&response);
-            return LANTERN_HTTP_CLIENT_ERR;
-        }
-        memcpy(response.data + response.len, chunk, (size_t)received);
-        response.len += (size_t)received;
-        response.data[response.len] = '\0';
-    }
-
-    int rc = response.len == 0
-                 ? LANTERN_HTTP_CLIENT_ERR
-                 : extract_response_body(response.data, response.len, max_response_bytes, out_result);
-    lantern_http_buffer_free(&response);
-    return rc;
+    return strncasecmp(url, "http://", 7u) == 0
+        || strncasecmp(url, "https://", 8u) == 0;
 }
 
 int lantern_http_get_bytes(
@@ -598,78 +62,69 @@ int lantern_http_get_bytes(
     size_t max_response_bytes,
     struct lantern_http_fetch_result *out_result)
 {
-    if (!url || !out_result || max_response_bytes == 0)
+    if (!url || !out_result || max_response_bytes == 0u || !supported_url(url))
     {
         return LANTERN_HTTP_CLIENT_ERR;
     }
     memset(out_result, 0, sizeof(*out_result));
-
-    struct lantern_http_url parsed;
-    if (lantern_http_url_parse(url, &parsed) != 0)
-    {
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-    if (!parsed.path || !parsed.path[0])
-    {
-        lantern_http_url_reset(&parsed);
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-
-    struct lantern_http_buffer request;
-    if (lantern_http_buffer_init(&request, 256u) != 0)
-    {
-        lantern_http_url_reset(&parsed);
-        return LANTERN_HTTP_CLIENT_ERR;
-    }
-
+    pthread_once(&curl_once, initialize_curl);
+    CURL *curl = curl_initialized ? curl_easy_init() : NULL;
     const char *accept_value = accept ? accept : "*/*";
-    bool is_ipv6 = strchr(parsed.host, ':') != NULL;
-    int format_rc =
-        lantern_http_buffer_appendf(&request, "GET %s HTTP/1.1\r\nHost: ", parsed.path)
-        || lantern_http_buffer_appendf(
-               &request,
-               is_ipv6 ? "[%s]:%u\r\n" : "%s:%u\r\n",
-               parsed.host,
-               (unsigned int)parsed.port)
-        || lantern_http_buffer_appendf(
-               &request,
-               "Accept: %s\r\nConnection: close\r\n\r\n",
-               accept_value);
-    if (format_rc != 0)
+    size_t accept_length = strlen(accept_value) + sizeof("Accept: ");
+    char *accept_header = malloc(accept_length);
+    if (!curl || !accept_header)
     {
-        lantern_http_buffer_free(&request);
-        lantern_http_url_reset(&parsed);
+        if (curl)
+        {
+            curl_easy_cleanup(curl);
+        }
+        free(accept_header);
         return LANTERN_HTTP_CLIENT_ERR;
     }
-
-    int fd = connect_tcp(parsed.host, parsed.port);
-    if (fd < 0)
+    snprintf(accept_header, accept_length, "Accept: %s", accept_value);
+    struct curl_slist *headers = curl_slist_append(NULL, accept_header);
+    free(accept_header);
+    struct response_writer writer = {
+        .result = out_result,
+        .limit = max_response_bytes,
+    };
+    CURLcode result = headers
+            && curl_easy_setopt(curl, CURLOPT_URL, url) == CURLE_OK
+            && curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers) == CURLE_OK
+            && curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, receive_body) == CURLE_OK
+            && curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writer) == CURLE_OK
+            && curl_easy_setopt(curl, CURLOPT_NOPROXY, "*") == CURLE_OK
+            && curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L) == CURLE_OK
+        ? curl_easy_perform(curl)
+        : CURLE_FAILED_INIT;
+    long status = 0;
+    if (result == CURLE_OK)
     {
-        lantern_http_buffer_free(&request);
-        lantern_http_url_reset(&parsed);
+        result = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    }
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    if (result != CURLE_OK || status > INT_MAX)
+    {
+        lantern_http_fetch_result_reset(out_result);
         return LANTERN_HTTP_CLIENT_ERR;
     }
-
-    int rc = LANTERN_HTTP_CLIENT_ERR;
-    if (lantern_http_send_all(fd, request.data, request.len) == 0)
+    out_result->status_code = (int)status;
+    if (status != 200)
     {
-        rc = read_response(fd, max_response_bytes, out_result);
+        free(out_result->body);
+        out_result->body = NULL;
+        out_result->body_len = 0u;
+        return LANTERN_HTTP_CLIENT_STATUS_ERROR;
     }
-
-#if !defined(_WIN32)
-    close(fd);
-#endif
-    lantern_http_buffer_free(&request);
-    lantern_http_url_reset(&parsed);
-    return rc;
+    return LANTERN_HTTP_CLIENT_OK;
 }
 
 void lantern_http_fetch_result_reset(struct lantern_http_fetch_result *result)
 {
-    if (!result)
+    if (result)
     {
-        return;
+        free(result->body);
+        memset(result, 0, sizeof(*result));
     }
-    free(result->body);
-    memset(result, 0, sizeof(*result));
 }

--- a/src/http/core.c
+++ b/src/http/core.c
@@ -1,511 +1,35 @@
-/**
- * @file core.c
- * @brief Shared HTTP transport core.
- *
- * Owns Lantern's small blocking HTTP/1.1 server loop, request-line parsing,
- * response writing, request-body reads, and growable formatting buffers.
- *
- * @spec RFC 9110/9112 and POSIX sockets/pthreads.
- */
-
 #include "lantern/http/core.h"
 
 #include <arpa/inet.h>
-#include <errno.h>
 #include <inttypes.h>
 #include <netinet/in.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
+
+#include <event2/buffer.h>
+#include <event2/event.h>
+#include <event2/http.h>
+#include <event2/thread.h>
 
 #include "lantern/support/log.h"
-#include "lantern/support/strings.h"
 
-static const size_t HTTP_RESPONSE_HEADER_BUFFER_LEN = 256;
-static const size_t HTTP_BUFFER_DEFAULT_CAP = 1024;
+static const ev_ssize_t HTTP_MAX_HEADERS_SIZE = 64u * 1024u;
+static const ev_ssize_t HTTP_MAX_BODY_SIZE = 64u * 1024u * 1024u;
 static const int HTTP_STATUS_CODE_MIN = 100;
 static const int HTTP_STATUS_CODE_MAX = 999;
-
-enum
-{
-    LANTERN_HTTP_SEND_OK = 0,
-    LANTERN_HTTP_SEND_ERR_INVALID_PARAM = -1,
-    LANTERN_HTTP_SEND_ERR_SEND_FAILED = -2,
-    LANTERN_HTTP_SEND_ERR_HEADER_TOO_LARGE = -3,
-};
-
-static const char DEFAULT_MALFORMED_JSON[] = "{\"error\":\"malformed request\"}";
 static const char DEFAULT_UNKNOWN_JSON[] = "{\"error\":\"unknown endpoint\"}";
+
+static pthread_once_t event_threads_once = PTHREAD_ONCE_INIT;
+static int event_threads_ready;
+
+static void initialize_event_threads(void)
+{
+    event_threads_ready = evthread_use_pthreads() == 0;
+}
 
 static const char *core_log_module(const struct lantern_http_core_server *server)
 {
     return server && server->config.log_module ? server->config.log_module : "http";
-}
-
-static void peer_to_text(const struct sockaddr_in *peer_addr, char *out, size_t out_len)
-{
-    if (!out || out_len == 0)
-    {
-        return;
-    }
-    if (!peer_addr || !inet_ntop(AF_INET, &peer_addr->sin_addr, out, out_len))
-    {
-        (void)lantern_string_copy(out, out_len, "unknown");
-    }
-}
-
-static int parse_request_line(
-    const char *request,
-    char *method,
-    size_t method_len,
-    char *path,
-    size_t path_len)
-{
-    if (!request || !method || method_len == 0 || !path || path_len == 0)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-
-    const char *space = strchr(request, ' ');
-    if (!space)
-    {
-        return LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST;
-    }
-
-    size_t method_written = (size_t)(space - request);
-    if (method_written == 0 || method_written >= method_len)
-    {
-        return LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST;
-    }
-    memcpy(method, request, method_written);
-    method[method_written] = '\0';
-
-    const char *cursor = space;
-    while (*cursor == ' ')
-    {
-        ++cursor;
-    }
-    if (*cursor == '\0')
-    {
-        return LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST;
-    }
-
-    const char *path_start = cursor;
-    while (*cursor != '\0'
-        && *cursor != ' '
-        && *cursor != '\r'
-        && *cursor != '\n'
-        && *cursor != '\t')
-    {
-        ++cursor;
-    }
-
-    size_t path_written = (size_t)(cursor - path_start);
-    if (path_written == 0 || path_written >= path_len)
-    {
-        return LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST;
-    }
-    memcpy(path, path_start, path_written);
-    path[path_written] = '\0';
-    return LANTERN_HTTP_CORE_OK;
-}
-
-bool lantern_http_locate_body(
-    const char *buffer,
-    size_t buffer_len,
-    const char **out_body,
-    size_t *out_body_len)
-{
-    if (!buffer || buffer_len == 0 || !out_body || !out_body_len)
-    {
-        return false;
-    }
-    static const char SEPARATOR[] = "\r\n\r\n";
-    const size_t sep_len = sizeof(SEPARATOR) - 1u;
-    if (buffer_len < sep_len)
-    {
-        return false;
-    }
-    for (size_t i = 0; i + sep_len <= buffer_len; ++i)
-    {
-        if (memcmp(buffer + i, SEPARATOR, sep_len) == 0)
-        {
-            *out_body = buffer + i + sep_len;
-            *out_body_len = buffer_len - i - sep_len;
-            return true;
-        }
-    }
-    return false;
-}
-
-int lantern_http_parse_content_length(
-    const char *buffer,
-    size_t buffer_len,
-    size_t *out_content_length)
-{
-    if (!buffer || !out_content_length)
-    {
-        return -1;
-    }
-    *out_content_length = 0;
-
-    const char *headers_end = NULL;
-    static const char SEPARATOR[] = "\r\n\r\n";
-    const size_t sep_len = sizeof(SEPARATOR) - 1u;
-    for (size_t i = 0; i + sep_len <= buffer_len; ++i)
-    {
-        if (memcmp(buffer + i, SEPARATOR, sep_len) == 0)
-        {
-            headers_end = buffer + i;
-            break;
-        }
-    }
-    if (!headers_end)
-    {
-        return -1;
-    }
-
-    const char *cursor = buffer;
-    static const char HEADER[] = "content-length:";
-    const size_t header_len = sizeof(HEADER) - 1u;
-    while (cursor < headers_end)
-    {
-        const char *line_end = memchr(cursor, '\n', (size_t)(headers_end - cursor));
-        if (!line_end)
-        {
-            line_end = headers_end;
-        }
-        const char *line = cursor;
-        if (line_end > line && *(line_end - 1) == '\r')
-        {
-            line_end -= 1;
-        }
-        size_t line_len = (size_t)(line_end - line);
-        if (line_len >= header_len && strncasecmp(line, HEADER, header_len) == 0)
-        {
-            const char *value = line + header_len;
-            while (value < line_end && (*value == ' ' || *value == '\t'))
-            {
-                ++value;
-            }
-            if (value == line_end)
-            {
-                return -1;
-            }
-
-            size_t content_length = 0;
-            bool have_digit = false;
-            while (value < line_end)
-            {
-                if (*value == ' ' || *value == '\t')
-                {
-                    break;
-                }
-                if (*value < '0' || *value > '9')
-                {
-                    return -1;
-                }
-                have_digit = true;
-                size_t digit = (size_t)(*value - '0');
-                if (content_length > (SIZE_MAX - digit) / 10u)
-                {
-                    return -1;
-                }
-                content_length = (content_length * 10u) + digit;
-                ++value;
-            }
-            while (value < line_end && (*value == ' ' || *value == '\t'))
-            {
-                ++value;
-            }
-            if (!have_digit || value != line_end)
-            {
-                return -1;
-            }
-            *out_content_length = content_length;
-            return 0;
-        }
-
-        cursor = line_end;
-        if (cursor < headers_end && *cursor == '\r')
-        {
-            ++cursor;
-        }
-        if (cursor < headers_end && *cursor == '\n')
-        {
-            ++cursor;
-        }
-    }
-    return -1;
-}
-
-int lantern_http_send_all(int fd, const char *data, size_t length)
-{
-    if (fd < 0 || (!data && length != 0))
-    {
-        return LANTERN_HTTP_SEND_ERR_INVALID_PARAM;
-    }
-
-    int flags = 0;
-#ifdef MSG_NOSIGNAL
-    flags |= MSG_NOSIGNAL;
-#endif
-
-    while (length > 0)
-    {
-        ssize_t written = send(fd, data, length, flags);
-        if (written == 0)
-        {
-            return LANTERN_HTTP_SEND_ERR_SEND_FAILED;
-        }
-        if (written < 0)
-        {
-            if (errno == EINTR)
-            {
-                continue;
-            }
-            return LANTERN_HTTP_SEND_ERR_SEND_FAILED;
-        }
-        data += (size_t)written;
-        length -= (size_t)written;
-    }
-    return LANTERN_HTTP_SEND_OK;
-}
-
-int lantern_http_send_response(
-    int fd,
-    int status_code,
-    const char *status_text,
-    const char *content_type,
-    const char *body,
-    size_t body_len)
-{
-    if (fd < 0
-        || status_code < HTTP_STATUS_CODE_MIN
-        || status_code > HTTP_STATUS_CODE_MAX
-        || (!body && body_len != 0))
-    {
-        return LANTERN_HTTP_SEND_ERR_INVALID_PARAM;
-    }
-
-    const char *text = status_text ? status_text : "OK";
-    const char *type = content_type ? content_type : "application/json";
-    size_t content_length = body ? body_len : 0u;
-
-    char header[HTTP_RESPONSE_HEADER_BUFFER_LEN];
-    int header_len = snprintf(
-        header,
-        sizeof(header),
-        "HTTP/1.1 %d %s\r\n"
-        "Content-Type: %s\r\n"
-        "Content-Length: %zu\r\n"
-        "Connection: close\r\n"
-        "\r\n",
-        status_code,
-        text,
-        type,
-        content_length);
-    if (header_len <= 0 || (size_t)header_len >= sizeof(header))
-    {
-        return LANTERN_HTTP_SEND_ERR_HEADER_TOO_LARGE;
-    }
-
-    int result = lantern_http_send_all(fd, header, (size_t)header_len);
-    if (result != 0 || content_length == 0)
-    {
-        return result;
-    }
-    return lantern_http_send_all(fd, body, content_length);
-}
-
-int lantern_http_send_json_error(
-    int fd,
-    int status_code,
-    const char *status_text,
-    const char *json_body)
-{
-    return lantern_http_send_response(
-        fd,
-        status_code,
-        status_text,
-        "application/json",
-        json_body,
-        json_body ? strlen(json_body) : 0u);
-}
-
-int lantern_http_buffer_init(struct lantern_http_buffer *buf, size_t initial_cap)
-{
-    if (!buf)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-
-    size_t capacity = initial_cap != 0 ? initial_cap : HTTP_BUFFER_DEFAULT_CAP;
-    buf->data = malloc(capacity);
-    if (!buf->data)
-    {
-        return LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY;
-    }
-    buf->len = 0;
-    buf->cap = capacity;
-    buf->data[0] = '\0';
-    return LANTERN_HTTP_CORE_OK;
-}
-
-void lantern_http_buffer_free(struct lantern_http_buffer *buf)
-{
-    if (!buf)
-    {
-        return;
-    }
-    free(buf->data);
-    buf->data = NULL;
-    buf->len = 0;
-    buf->cap = 0;
-}
-
-int lantern_http_buffer_reserve(struct lantern_http_buffer *buf, size_t extra)
-{
-    if (!buf)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-    if (extra == 0)
-    {
-        return LANTERN_HTTP_CORE_OK;
-    }
-    if (buf->len >= SIZE_MAX - 1 || extra > (SIZE_MAX - buf->len - 1))
-    {
-        return LANTERN_HTTP_CORE_ERR_OVERFLOW;
-    }
-
-    size_t required = buf->len + extra + 1;
-    if (required <= buf->cap)
-    {
-        return LANTERN_HTTP_CORE_OK;
-    }
-
-    size_t new_cap = buf->cap != 0 ? buf->cap : HTTP_BUFFER_DEFAULT_CAP;
-    while (new_cap < required)
-    {
-        if (new_cap > SIZE_MAX / 2)
-        {
-            return LANTERN_HTTP_CORE_ERR_OVERFLOW;
-        }
-        new_cap *= 2;
-    }
-
-    char *new_data = realloc(buf->data, new_cap);
-    if (!new_data)
-    {
-        return LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY;
-    }
-    buf->data = new_data;
-    buf->cap = new_cap;
-    return LANTERN_HTTP_CORE_OK;
-}
-
-int lantern_http_buffer_appendf(struct lantern_http_buffer *buf, const char *fmt, ...)
-{
-    if (!buf || !fmt)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-
-    va_list args;
-    va_start(args, fmt);
-
-    va_list measure;
-    va_copy(measure, args);
-    int needed = vsnprintf(NULL, 0, fmt, measure);
-    va_end(measure);
-    if (needed < 0)
-    {
-        va_end(args);
-        return LANTERN_HTTP_CORE_ERR_FORMATTING;
-    }
-
-    int reserve_rc = lantern_http_buffer_reserve(buf, (size_t)needed);
-    if (reserve_rc != 0)
-    {
-        va_end(args);
-        return reserve_rc;
-    }
-
-    int written = vsnprintf(buf->data + buf->len, buf->cap - buf->len, fmt, args);
-    va_end(args);
-    if (written < 0 || written != needed)
-    {
-        return LANTERN_HTTP_CORE_ERR_FORMATTING;
-    }
-    buf->len += (size_t)written;
-    return LANTERN_HTTP_CORE_OK;
-}
-
-int lantern_http_request_read_body(
-    const struct lantern_http_request *request,
-    size_t max_body_size,
-    char **out_body,
-    size_t *out_body_len)
-{
-    if (!request || request->client_fd < 0 || !request->raw || !out_body || !out_body_len)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-    *out_body = NULL;
-    *out_body_len = 0;
-
-    const char *body_ptr = NULL;
-    size_t available_len = 0;
-    if (!lantern_http_locate_body(request->raw, request->raw_len, &body_ptr, &available_len))
-    {
-        return LANTERN_HTTP_CORE_ERR_MALFORMED_REQUEST;
-    }
-
-    size_t content_length = 0;
-    if (lantern_http_parse_content_length(request->raw, request->raw_len, &content_length) != 0)
-    {
-        content_length = available_len;
-    }
-    if (content_length > max_body_size || content_length == SIZE_MAX)
-    {
-        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
-    }
-
-    char *body = malloc(content_length + 1u);
-    if (!body)
-    {
-        return LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY;
-    }
-
-    size_t copied = available_len < content_length ? available_len : content_length;
-    if (copied > 0)
-    {
-        memcpy(body, body_ptr, copied);
-    }
-    while (copied < content_length)
-    {
-        ssize_t received = recv(request->client_fd, body + copied, content_length - copied, 0);
-        if (received < 0 && errno == EINTR)
-        {
-            continue;
-        }
-        if (received <= 0)
-        {
-            free(body);
-            return LANTERN_HTTP_CORE_ERR_IO;
-        }
-        copied += (size_t)received;
-    }
-    body[content_length] = '\0';
-    *out_body = body;
-    *out_body_len = content_length;
-    return LANTERN_HTTP_CORE_OK;
 }
 
 static void fill_config_defaults(struct lantern_http_core_config *config)
@@ -518,13 +42,36 @@ static void fill_config_defaults(struct lantern_http_core_config *config)
     {
         config->listen_label = "http server";
     }
-    if (!config->malformed_json)
-    {
-        config->malformed_json = DEFAULT_MALFORMED_JSON;
-    }
     if (!config->unknown_json)
     {
         config->unknown_json = DEFAULT_UNKNOWN_JSON;
+    }
+}
+
+static const char *http_method(enum evhttp_cmd_type command)
+{
+    switch (command)
+    {
+    case EVHTTP_REQ_GET:
+        return "GET";
+    case EVHTTP_REQ_POST:
+        return "POST";
+    case EVHTTP_REQ_HEAD:
+        return "HEAD";
+    case EVHTTP_REQ_PUT:
+        return "PUT";
+    case EVHTTP_REQ_DELETE:
+        return "DELETE";
+    case EVHTTP_REQ_OPTIONS:
+        return "OPTIONS";
+    case EVHTTP_REQ_TRACE:
+        return "TRACE";
+    case EVHTTP_REQ_CONNECT:
+        return "CONNECT";
+    case EVHTTP_REQ_PATCH:
+        return "PATCH";
+    default:
+        return "UNKNOWN";
     }
 }
 
@@ -533,86 +80,99 @@ static int route_matches(
     const char *method,
     const char *path)
 {
-    return route
-        && route->path
-        && route->handler
+    return route && route->path && route->handler
         && strcmp(route->path, path) == 0
         && (!route->method || strcmp(route->method, method) == 0);
 }
 
-static void handle_client_connection(
-    struct lantern_http_core_server *server,
-    int client_fd,
-    const struct sockaddr_in *peer_addr)
+int lantern_http_send_response(
+    const struct lantern_http_request *request,
+    int status_code,
+    const char *status_text,
+    const char *content_type,
+    const char *body,
+    size_t body_len)
 {
-    if (!server || client_fd < 0)
+    if (!request || !request->transport
+        || status_code < HTTP_STATUS_CODE_MIN
+        || status_code > HTTP_STATUS_CODE_MAX
+        || (!body && body_len != 0u))
     {
-        return;
+        return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
     }
-
-    char peer_text[INET_ADDRSTRLEN];
-    peer_to_text(peer_addr, peer_text, sizeof(peer_text));
-
-    char buffer[LANTERN_HTTP_CORE_READ_BUFFER_SIZE];
-    ssize_t received = -1;
-    do
+    struct evbuffer *buffer = evbuffer_new();
+    struct evkeyvalq *headers = evhttp_request_get_output_headers(request->transport);
+    if (!buffer || !headers
+        || evhttp_add_header(
+               headers,
+               "Content-Type",
+               content_type ? content_type : "application/json")
+            != 0
+        || evhttp_add_header(headers, "Connection", "close") != 0
+        || (body_len > 0u && evbuffer_add(buffer, body, body_len) != 0))
     {
-        received = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
-    } while (received < 0 && errno == EINTR);
-    if (received <= 0)
-    {
-        return;
-    }
-    buffer[(size_t)received] = '\0';
-
-    char method[LANTERN_HTTP_CORE_METHOD_CAP];
-    char path[LANTERN_HTTP_CORE_PATH_CAP];
-    int rc = parse_request_line(
-        buffer,
-        method,
-        sizeof(method),
-        path,
-        sizeof(path));
-    if (rc != 0)
-    {
-        int send_rc = lantern_http_send_json_error(
-            client_fd,
-            400,
-            "Bad Request",
-            server->config.malformed_json);
-        if (send_rc == 0)
+        if (buffer)
         {
-            lantern_log_info(
-                core_log_module(server),
-                &(const struct lantern_log_metadata){.peer = peer_text},
-                "malformed request -> 400");
+            evbuffer_free(buffer);
         }
-        else
-        {
-            lantern_log_error(
-                core_log_module(server),
-                &(const struct lantern_log_metadata){.peer = peer_text},
-                "failed to send 400 response rc=%d",
-                send_rc);
-        }
-        return;
+        return LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY;
     }
+    evhttp_send_reply(
+        request->transport,
+        status_code,
+        status_text ? status_text : "OK",
+        buffer);
+    evbuffer_free(buffer);
+    return LANTERN_HTTP_CORE_OK;
+}
 
-    const char *body = NULL;
-    size_t body_len = 0;
-    bool has_body = lantern_http_locate_body(buffer, (size_t)received, &body, &body_len);
+int lantern_http_send_json_error(
+    const struct lantern_http_request *request,
+    int status_code,
+    const char *status_text,
+    const char *json_body)
+{
+    return lantern_http_send_response(
+        request,
+        status_code,
+        status_text,
+        "application/json",
+        json_body,
+        json_body ? strlen(json_body) : 0u);
+}
+
+static void handle_http_request(struct evhttp_request *transport, void *context)
+{
+    struct lantern_http_core_server *server = context;
+    const struct evhttp_uri *uri = evhttp_request_get_evhttp_uri(transport);
+    const char *path = uri ? evhttp_uri_get_path(uri) : NULL;
+    const char *method = http_method(evhttp_request_get_command(transport));
+    struct evbuffer *input = evhttp_request_get_input_buffer(transport);
+    size_t body_len = input ? evbuffer_get_length(input) : 0u;
+    const char *body = body_len > 0u
+        ? (const char *)evbuffer_pullup(input, -1)
+        : NULL;
+    char *peer = NULL;
+    ev_uint16_t peer_port = 0u;
+    struct evhttp_connection *connection = evhttp_request_get_connection(transport);
+    if (connection)
+    {
+        evhttp_connection_get_peer(connection, &peer, &peer_port);
+    }
+    (void)peer_port;
     struct lantern_http_request request = {
-        .client_fd = client_fd,
+        .transport = transport,
         .method = method,
-        .path = path,
-        .raw = buffer,
-        .raw_len = (size_t)received,
+        .path = path ? path : "",
         .body = body,
         .body_len = body_len,
-        .has_body = has_body,
-        .peer = peer_text,
+        .peer = peer ? peer : "unknown",
     };
-
+    if (!server || !path || (body_len > 0u && !body))
+    {
+        evhttp_send_error(transport, 400, "Bad Request");
+        return;
+    }
     for (size_t i = 0; i < server->config.route_count; ++i)
     {
         if (route_matches(&server->config.routes[i], method, path))
@@ -621,149 +181,111 @@ static void handle_client_connection(
             return;
         }
     }
-
-    int send_rc = lantern_http_send_json_error(
-        client_fd,
+    int result = lantern_http_send_json_error(
+        &request,
         404,
         "Not Found",
         server->config.unknown_json);
-    if (send_rc == 0)
-    {
-        lantern_log_info(
-            core_log_module(server),
-            &(const struct lantern_log_metadata){.peer = peer_text},
-            "%s %s -> 404",
-            method,
-            path);
-    }
-    else
-    {
-        lantern_log_error(
-            core_log_module(server),
-            &(const struct lantern_log_metadata){.peer = peer_text},
-            "failed to send 404 response rc=%d",
-            send_rc);
-    }
+    lantern_log_info(
+        core_log_module(server),
+        &(const struct lantern_log_metadata){.peer = request.peer},
+        "%s %s -> 404 (rc=%d)",
+        method,
+        path,
+        result);
 }
 
-static void *lantern_http_core_thread(void *arg)
+static void *http_server_thread(void *context)
 {
-    struct lantern_http_core_server *server = arg;
-    if (!server)
+    struct lantern_http_core_server *server = context;
+    int result = event_base_dispatch(server->event_base);
+    if (result < 0)
     {
-        return NULL;
-    }
-
-    int listen_fd = server->listen_fd;
-    for (;;)
-    {
-        struct sockaddr_in peer;
-        socklen_t peer_len = sizeof(peer);
-        int client_fd = accept(listen_fd, (struct sockaddr *)&peer, &peer_len);
-        if (client_fd < 0)
-        {
-            if (errno == EINTR)
-            {
-                continue;
-            }
-            if (!server->running || errno == EBADF || errno == EINVAL)
-            {
-                break;
-            }
-            if (errno == ECONNABORTED)
-            {
-                continue;
-            }
-            lantern_log_error(core_log_module(server), NULL, "accept failed errno=%d", errno);
-            continue;
-        }
-
-        handle_client_connection(server, client_fd, &peer);
-        close(client_fd);
+        lantern_log_error(core_log_module(server), NULL, "HTTP event loop failed");
     }
     return NULL;
 }
 
+static void release_transport(struct lantern_http_core_server *server)
+{
+    if (server->http)
+    {
+        evhttp_free(server->http);
+        server->http = NULL;
+    }
+    if (server->event_base)
+    {
+        event_base_free(server->event_base);
+        server->event_base = NULL;
+    }
+    server->listen_fd = -1;
+}
+
 void lantern_http_core_init(struct lantern_http_core_server *server)
 {
-    if (!server)
+    if (server)
     {
-        return;
+        memset(server, 0, sizeof(*server));
+        server->listen_fd = -1;
     }
-    memset(server, 0, sizeof(*server));
-    server->listen_fd = -1;
 }
 
 int lantern_http_core_start(
     struct lantern_http_core_server *server,
     const struct lantern_http_core_config *config)
 {
-    if (!server || !config || (!config->routes && config->route_count != 0))
+    if (!server || !config || server->http || server->thread_started
+        || (!config->routes && config->route_count != 0u))
     {
         return LANTERN_HTTP_CORE_ERR_INVALID_PARAM;
     }
-
     struct lantern_http_core_config normalized = *config;
     fill_config_defaults(&normalized);
-
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0)
+    pthread_once(&event_threads_once, initialize_event_threads);
+    if (!event_threads_ready)
     {
-        lantern_log_error(normalized.log_module, NULL, "socket creation failed errno=%d", errno);
         return LANTERN_HTTP_CORE_ERR_IO;
     }
-
-    int opt = 1;
-    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) != 0)
+    server->event_base = event_base_new();
+    server->http = server->event_base ? evhttp_new(server->event_base) : NULL;
+    if (!server->http)
     {
-        lantern_log_warn(normalized.log_module, NULL, "setsockopt(SO_REUSEADDR) failed errno=%d", errno);
+        release_transport(server);
+        return LANTERN_HTTP_CORE_ERR_OUT_OF_MEMORY;
     }
-
-    struct sockaddr_in addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
-    addr.sin_port = htons(normalized.port);
-
-    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+    evhttp_set_max_headers_size(server->http, HTTP_MAX_HEADERS_SIZE);
+    evhttp_set_max_body_size(server->http, HTTP_MAX_BODY_SIZE);
+    evhttp_set_default_content_type(server->http, NULL);
+    evhttp_set_allowed_methods(server->http, UINT16_MAX);
+    evhttp_set_gencb(server->http, handle_http_request, server);
+    struct evhttp_bound_socket *socket = evhttp_bind_socket_with_handle(
+        server->http,
+        "0.0.0.0",
+        normalized.port);
+    if (!socket)
     {
-        lantern_log_error(normalized.log_module, NULL, "bind failed errno=%d", errno);
-        close(fd);
+        lantern_log_error(normalized.log_module, NULL, "HTTP bind failed port=%" PRIu16, normalized.port);
+        release_transport(server);
         return LANTERN_HTTP_CORE_ERR_IO;
     }
-    if (listen(fd, LANTERN_HTTP_CORE_LISTEN_BACKLOG) != 0)
-    {
-        lantern_log_error(normalized.log_module, NULL, "listen failed errno=%d", errno);
-        close(fd);
-        return LANTERN_HTTP_CORE_ERR_IO;
-    }
-
-    server->listen_fd = fd;
+    server->listen_fd = (int)evhttp_bound_socket_get_fd(socket);
     server->config = normalized;
-    server->running = 1;
-    server->thread_started = 0;
-
     uint16_t bound_port = normalized.port;
-    if (bound_port == 0)
+    if (bound_port == 0u)
     {
-        struct sockaddr_in bound_addr;
-        socklen_t bound_len = sizeof(bound_addr);
-        if (getsockname(fd, (struct sockaddr *)&bound_addr, &bound_len) == 0)
+        struct sockaddr_in address;
+        socklen_t length = sizeof(address);
+        if (getsockname(server->listen_fd, (struct sockaddr *)&address, &length) == 0)
         {
-            bound_port = ntohs(bound_addr.sin_port);
+            bound_port = ntohs(address.sin_port);
         }
     }
-
-    int create_rc = pthread_create(&server->thread, NULL, lantern_http_core_thread, server);
-    if (create_rc != 0)
+    int result = pthread_create(&server->thread, NULL, http_server_thread, server);
+    if (result != 0)
     {
-        lantern_log_error(normalized.log_module, NULL, "pthread_create failed rc=%d", create_rc);
-        close(fd);
-        server->listen_fd = -1;
-        server->running = 0;
+        release_transport(server);
         return LANTERN_HTTP_CORE_ERR_IO;
     }
-
     server->thread_started = 1;
     lantern_log_info(
         normalized.log_module,
@@ -780,18 +302,12 @@ void lantern_http_core_stop(struct lantern_http_core_server *server)
     {
         return;
     }
-
-    server->running = 0;
-    int listen_fd = server->listen_fd;
-    server->listen_fd = -1;
-    if (listen_fd >= 0)
-    {
-        (void)shutdown(listen_fd, SHUT_RDWR);
-        close(listen_fd);
-    }
     if (server->thread_started)
     {
+        (void)event_base_loopbreak(server->event_base);
         pthread_join(server->thread, NULL);
         server->thread_started = 0;
     }
+    release_transport(server);
+    server->config = (struct lantern_http_core_config){0};
 }

--- a/src/http/server.c
+++ b/src/http/server.c
@@ -15,6 +15,12 @@
 
 #include "lantern/http/server.h"
 
+#define JSMN_STATIC
+#define JSMN_STRICT
+#include "jsmn.h"
+#undef JSMN_STATIC
+#undef JSMN_STRICT
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -42,7 +48,6 @@ static const char LANTERN_HTTP_PATH_TEST_STATE_RUN[] =
 static const char LANTERN_HTTP_PATH_TEST_VERIFY_RUN[] =
     "/lean/v0/test_driver/verify_signatures/run";
 static const char LANTERN_HTTP_JSON_HEALTH[] = "{\"status\":\"healthy\",\"service\":\"lean-rpc-api\"}";
-static const char LANTERN_HTTP_JSON_MALFORMED[] = "{\"error\":\"malformed request\"}";
 static const char LANTERN_HTTP_JSON_UNKNOWN_ENDPOINT[] = "{\"error\":\"unknown endpoint\"}";
 static const char LANTERN_HTTP_JSON_UNAVAILABLE[] = "{\"error\":\"service unavailable\"}";
 static const char LANTERN_HTTP_JSON_STATE_MISSING[] = "{\"error\":\"finalized state not available\"}";
@@ -60,10 +65,10 @@ enum
     LANTERN_HTTP_SERVER_ERR_IO = -2,
 };
 
-static int send_unavailable(int fd) { return lantern_http_send_json_error(fd, 503, "Service Unavailable", LANTERN_HTTP_JSON_UNAVAILABLE); }
-static int send_internal(int fd) { return lantern_http_send_json_error(fd, 500, "Internal Server Error", LANTERN_HTTP_JSON_INTERNAL); }
-static int send_bad_request(int fd) { return lantern_http_send_json_error(fd, 400, "Bad Request", LANTERN_HTTP_JSON_BAD_REQUEST); }
-static int send_method_not_allowed(int fd) { return lantern_http_send_json_error(fd, 405, "Method Not Allowed", LANTERN_HTTP_JSON_METHOD_NOT_ALLOWED); }
+static int send_unavailable(const struct lantern_http_request *request) { return lantern_http_send_json_error(request, 503, "Service Unavailable", LANTERN_HTTP_JSON_UNAVAILABLE); }
+static int send_internal(const struct lantern_http_request *request) { return lantern_http_send_json_error(request, 500, "Internal Server Error", LANTERN_HTTP_JSON_INTERNAL); }
+static int send_bad_request(const struct lantern_http_request *request) { return lantern_http_send_json_error(request, 400, "Bad Request", LANTERN_HTTP_JSON_BAD_REQUEST); }
+static int send_method_not_allowed(const struct lantern_http_request *request) { return lantern_http_send_json_error(request, 405, "Method Not Allowed", LANTERN_HTTP_JSON_METHOD_NOT_ALLOWED); }
 
 
 static int format_fork_choice_response(
@@ -115,14 +120,16 @@ static int format_fork_choice_response(
         return -1;
     }
 
-    struct lantern_http_buffer buf;
-    memset(&buf, 0, sizeof(buf));
-    if (lantern_http_buffer_appendf(&buf, "{\"nodes\":[") != 0)
+    FILE *stream = open_memstream(out_body, out_len);
+    if (!stream)
     {
-        lantern_http_buffer_free(&buf);
         return -1;
     }
-
+    int result = -1;
+    if (fprintf(stream, "{\"nodes\":[") < 0)
+    {
+        goto cleanup;
+    }
     for (size_t i = 0; i < snapshot->node_count; ++i)
     {
         const struct lantern_fork_choice_tree_node *node = &snapshot->nodes[i];
@@ -143,12 +150,11 @@ static int format_fork_choice_response(
                    1)
                    != 0)
         {
-            lantern_http_buffer_free(&buf);
-            return -1;
+            goto cleanup;
         }
 
-        if (lantern_http_buffer_appendf(
-                &buf,
+        if (fprintf(
+                stream,
                 "%s{\"root\":\"%s\",\"slot\":%" PRIu64
                 ",\"parent_root\":\"%s\",\"proposer_index\":%" PRIu64
                 ",\"weight\":%" PRIu64 "}",
@@ -158,15 +164,14 @@ static int format_fork_choice_response(
                 parent_hex,
                 node->proposer_index,
                 node->weight)
-            != 0)
+            < 0)
         {
-            lantern_http_buffer_free(&buf);
-            return -1;
+            goto cleanup;
         }
     }
 
-    if (lantern_http_buffer_appendf(
-            &buf,
+    if (fprintf(
+            stream,
             "],\"head\":\"%s\",\"justified\":{\"slot\":%" PRIu64 ",\"root\":\"%s\"},"
             "\"finalized\":{\"slot\":%" PRIu64 ",\"root\":\"%s\"},"
             "\"safe_target\":\"%s\",\"validator_count\":%" PRIu64 "}",
@@ -177,15 +182,24 @@ static int format_fork_choice_response(
             finalized_hex,
             safe_target_hex,
             snapshot->validator_count)
-        != 0)
+        < 0)
     {
-        lantern_http_buffer_free(&buf);
-        return -1;
+        goto cleanup;
     }
+    result = 0;
 
-    *out_body = buf.data;
-    *out_len = buf.len;
-    return 0;
+cleanup:
+    if (fclose(stream) != 0)
+    {
+        result = -1;
+    }
+    if (result != 0)
+    {
+        free(*out_body);
+        *out_body = NULL;
+        *out_len = 0u;
+    }
+    return result;
 }
 
 
@@ -204,78 +218,31 @@ static int parse_enabled_bool_body(const char *body, size_t body_len, bool *out_
     {
         return -1;
     }
-    size_t i = 0;
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
-    {
-        ++i;
-    }
-    if (i >= body_len || body[i] != '{')
-    {
-        return -1;
-    }
-    ++i;
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
-    {
-        ++i;
-    }
-    static const char KEY[] = "\"enabled\"";
-    const size_t key_len = sizeof(KEY) - 1u;
-    if (i + key_len > body_len || memcmp(body + i, KEY, key_len) != 0)
+    jsmn_parser parser;
+    jsmntok_t tokens[3];
+    jsmn_init(&parser);
+    if (jsmn_parse(&parser, body, body_len, tokens, 3u) != 3
+        || tokens[0].type != JSMN_OBJECT || tokens[0].size != 1
+        || tokens[1].type != JSMN_STRING
+        || tokens[1].end - tokens[1].start != 7
+        || memcmp(body + tokens[1].start, "enabled", 7u) != 0
+        || tokens[2].type != JSMN_PRIMITIVE)
     {
         return -1;
     }
-    i += key_len;
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
+    size_t value_len = (size_t)(tokens[2].end - tokens[2].start);
+    const char *value = body + tokens[2].start;
+    if (value_len == 4u && memcmp(value, "true", 4u) == 0)
     {
-        ++i;
+        *out_enabled = true;
+        return 0;
     }
-    if (i >= body_len || body[i] != ':')
+    if (value_len == 5u && memcmp(value, "false", 5u) == 0)
     {
-        return -1;
+        *out_enabled = false;
+        return 0;
     }
-    ++i;
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
-    {
-        ++i;
-    }
-    bool value = false;
-    static const char TRUE_LIT[] = "true";
-    static const char FALSE_LIT[] = "false";
-    if (i + (sizeof(TRUE_LIT) - 1u) <= body_len
-        && memcmp(body + i, TRUE_LIT, sizeof(TRUE_LIT) - 1u) == 0)
-    {
-        value = true;
-        i += sizeof(TRUE_LIT) - 1u;
-    }
-    else if (i + (sizeof(FALSE_LIT) - 1u) <= body_len
-        && memcmp(body + i, FALSE_LIT, sizeof(FALSE_LIT) - 1u) == 0)
-    {
-        value = false;
-        i += sizeof(FALSE_LIT) - 1u;
-    }
-    else
-    {
-        return -1;
-    }
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
-    {
-        ++i;
-    }
-    if (i >= body_len || body[i] != '}')
-    {
-        return -1;
-    }
-    ++i;
-    while (i < body_len && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n'))
-    {
-        ++i;
-    }
-    if (i != body_len)
-    {
-        return -1;
-    }
-    *out_enabled = value;
-    return 0;
+    return -1;
 }
 
 
@@ -293,14 +260,13 @@ static int handle_admin_aggregator(
     {
         return LANTERN_HTTP_SERVER_ERR_INVALID_PARAM;
     }
-    int client_fd = request->client_fd;
     const char *method = request->method;
     const char *peer_text = request->peer;
     const bool is_get = (strcmp(method, "GET") == 0);
     const bool is_post = (strcmp(method, "POST") == 0);
     if (!is_get && !is_post)
     {
-        int rc = send_method_not_allowed(client_fd);
+        int rc = send_method_not_allowed(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -315,7 +281,7 @@ static int handle_admin_aggregator(
     {
         if (!server->callbacks.get_is_aggregator)
         {
-            int rc = send_unavailable(client_fd);
+            int rc = send_unavailable(request);
             lantern_log_info(
                 "http",
                 &(const struct lantern_log_metadata){.peer = peer_text},
@@ -328,7 +294,7 @@ static int handle_admin_aggregator(
         int cb_rc = server->callbacks.get_is_aggregator(server->callbacks.context, &enabled);
         if (cb_rc != LANTERN_HTTP_CB_OK)
         {
-            int rc = send_unavailable(client_fd);
+            int rc = send_unavailable(request);
             lantern_log_info(
                 "http",
                 &(const struct lantern_log_metadata){.peer = peer_text},
@@ -346,10 +312,10 @@ static int handle_admin_aggregator(
             enabled ? "true" : "false");
         if (body_len <= 0 || (size_t)body_len >= sizeof(body))
         {
-            send_internal(client_fd);
+            send_internal(request);
             return 0;
         }
-        int rc = lantern_http_send_response(client_fd, 200, "OK", "application/json", body, (size_t)body_len);
+        int rc = lantern_http_send_response(request, 200, "OK", "application/json", body, (size_t)body_len);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -362,7 +328,7 @@ static int handle_admin_aggregator(
     /* POST */
     if (!server->callbacks.set_is_aggregator)
     {
-        int rc = send_unavailable(client_fd);
+        int rc = send_unavailable(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -371,9 +337,9 @@ static int handle_admin_aggregator(
             rc);
         return 0;
     }
-    if (!request->has_body || request->body_len == 0)
+    if (request->body_len == 0u)
     {
-        int rc = send_bad_request(client_fd);
+        int rc = send_bad_request(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -385,7 +351,7 @@ static int handle_admin_aggregator(
     bool enabled = false;
     if (parse_enabled_bool_body(request->body, request->body_len, &enabled) != 0)
     {
-        int rc = send_bad_request(client_fd);
+        int rc = send_bad_request(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -398,7 +364,7 @@ static int handle_admin_aggregator(
     int cb_rc = server->callbacks.set_is_aggregator(server->callbacks.context, enabled, &previous);
     if (cb_rc != LANTERN_HTTP_CB_OK)
     {
-        int rc = send_unavailable(client_fd);
+        int rc = send_unavailable(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -417,10 +383,10 @@ static int handle_admin_aggregator(
         previous ? "true" : "false");
     if (resp_len <= 0 || (size_t)resp_len >= sizeof(resp))
     {
-        send_internal(client_fd);
+        send_internal(request);
         return 0;
     }
-    int rc = lantern_http_send_response(client_fd, 200, "OK", "application/json", resp, (size_t)resp_len);
+    int rc = lantern_http_send_response(request, 200, "OK", "application/json", resp, (size_t)resp_len);
     lantern_log_info(
         "http",
         &(const struct lantern_log_metadata){.peer = peer_text},
@@ -441,13 +407,12 @@ static int handle_test_driver(
     {
         return LANTERN_HTTP_SERVER_ERR_INVALID_PARAM;
     }
-    int client_fd = request->client_fd;
     const char *method = request->method;
     const char *path = request->path;
     const char *peer_text = request->peer;
     if (strcmp(method, "POST") != 0)
     {
-        int rc = send_method_not_allowed(client_fd);
+        int rc = send_method_not_allowed(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -458,16 +423,11 @@ static int handle_test_driver(
         return 0;
     }
 
-    char *request_body = NULL;
-    size_t request_body_len = 0;
-    if (lantern_http_request_read_body(
-            request,
-            LANTERN_HTTP_MAX_TEST_DRIVER_BODY_SIZE,
-            &request_body,
-            &request_body_len)
-        != 0)
+    const char *request_body = request->body;
+    size_t request_body_len = request->body_len;
+    if (request_body_len > LANTERN_HTTP_MAX_TEST_DRIVER_BODY_SIZE)
     {
-        int rc = send_bad_request(client_fd);
+        int rc = send_bad_request(request);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -482,10 +442,9 @@ static int handle_test_driver(
         char *error = NULL;
         int driver_rc =
             lantern_test_driver_fork_choice_init(request_body, request_body_len, &error);
-        free(request_body);
         if (driver_rc != 0)
         {
-            int rc = send_bad_request(client_fd);
+            int rc = send_bad_request(request);
             lantern_log_info(
                 "http",
                 &(const struct lantern_log_metadata){.peer = peer_text},
@@ -497,7 +456,7 @@ static int handle_test_driver(
             free(error);
             return 0;
         }
-        int rc = lantern_http_send_response(client_fd, 204, "No Content", "application/json", NULL, 0);
+        int rc = lantern_http_send_response(request, 204, "No Content", "application/json", NULL, 0);
         lantern_log_info(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -534,12 +493,10 @@ static int handle_test_driver(
             &response_body,
             &response_body_len);
     }
-    free(request_body);
-
     if (driver_rc != 0 || !response_body)
     {
         free(response_body);
-        int rc = send_internal(client_fd);
+        int rc = send_internal(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = peer_text},
@@ -551,7 +508,7 @@ static int handle_test_driver(
     }
 
     int rc = lantern_http_send_response(
-        client_fd,
+        request,
         200,
         "OK",
         "application/json",
@@ -574,7 +531,7 @@ static int handle_health(
 {
     (void)context;
     int rc = lantern_http_send_response(
-        request->client_fd,
+        request,
         200,
         "OK",
         "application/json",
@@ -631,7 +588,7 @@ static int send_finalized_error(
         status_text = "Service Unavailable";
     }
 
-    int rc = lantern_http_send_json_error(request->client_fd, status_code, status_text, body);
+    int rc = lantern_http_send_json_error(request, status_code, status_text, body);
     if (callback_rc == LANTERN_HTTP_CB_ERR_NOT_FOUND)
     {
         lantern_log_info(
@@ -674,7 +631,7 @@ static int send_finalized_bytes(
     if (!bytes || len == 0)
     {
         free(bytes);
-        int rc = send_internal(request->client_fd);
+        int rc = send_internal(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -685,7 +642,7 @@ static int send_finalized_bytes(
     }
 
     int rc = lantern_http_send_response(
-        request->client_fd,
+        request,
         200,
         "OK",
         "application/octet-stream",
@@ -720,7 +677,7 @@ static int handle_finalized_ssz(
 {
     if (!callback)
     {
-        int rc = send_unavailable(request->client_fd);
+        int rc = send_unavailable(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -793,7 +750,7 @@ static int send_snapshot_error(
         status_text = "Service Unavailable";
     }
 
-    int rc = lantern_http_send_json_error(request->client_fd, status_code, status_text, body);
+    int rc = lantern_http_send_json_error(request, status_code, status_text, body);
     if (status_code == 503)
     {
         lantern_log_warn(
@@ -824,7 +781,7 @@ static int handle_justified(
     struct lantern_http_server *server = context;
     if (!server->callbacks.snapshot_justified)
     {
-        int rc = send_unavailable(request->client_fd);
+        int rc = send_unavailable(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -856,7 +813,7 @@ static int handle_justified(
             1)
         != 0)
     {
-        int rc = send_internal(request->client_fd);
+        int rc = send_internal(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -874,7 +831,7 @@ static int handle_justified(
         root_hex);
     if (body_written < 0 || (size_t)body_written >= sizeof(body))
     {
-        int rc = send_internal(request->client_fd);
+        int rc = send_internal(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -884,7 +841,7 @@ static int handle_justified(
     }
 
     int rc = lantern_http_send_response(
-        request->client_fd,
+        request,
         200,
         "OK",
         "application/json",
@@ -915,7 +872,7 @@ static int handle_fork_choice(
     struct lantern_http_server *server = context;
     if (!server->callbacks.snapshot_fork_choice)
     {
-        int rc = send_unavailable(request->client_fd);
+        int rc = send_unavailable(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -942,7 +899,7 @@ static int handle_fork_choice(
     lantern_fork_choice_tree_snapshot_reset(&snapshot);
     if (result != 0)
     {
-        int rc = send_internal(request->client_fd);
+        int rc = send_internal(request);
         lantern_log_error(
             "http",
             &(const struct lantern_log_metadata){.peer = request->peer},
@@ -952,7 +909,7 @@ static int handle_fork_choice(
     }
 
     result = lantern_http_send_response(
-        request->client_fd,
+        request,
         200,
         "OK",
         "application/json",
@@ -1049,7 +1006,6 @@ int lantern_http_server_start(
     core_config.port = config->port;
     core_config.log_module = "http";
     core_config.listen_label = "http server";
-    core_config.malformed_json = LANTERN_HTTP_JSON_MALFORMED;
     core_config.unknown_json = LANTERN_HTTP_JSON_UNKNOWN_ENDPOINT;
     core_config.context = server;
     core_config.routes = kHttpRoutes;

--- a/src/internal/yaml_parser.c
+++ b/src/internal/yaml_parser.c
@@ -1,204 +1,97 @@
 #include "internal/yaml_parser.h"
 
-#include <ctype.h>
-#include <stdbool.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-static char *trim_left(char *text) {
-    while (isspace((unsigned char)*text)) {
-        ++text;
-    }
-    return text;
-}
-
-static void trim_right(char *text) {
-    size_t length = strlen(text);
-    while (length > 0u && isspace((unsigned char)text[length - 1u])) {
-        text[--length] = '\0';
-    }
-}
-
-static size_t indentation(const char *line) {
-    size_t count = 0u;
-    while (line[count] == ' ' || line[count] == '\t') {
-        ++count;
-    }
-    return count;
-}
-
-static void yaml_object_reset(LanternYamlObject *object) {
-    if (!object) {
-        return;
-    }
-    for (size_t i = 0u; i < object->num_pairs; ++i) {
-        free(object->pairs[i].key);
-        free(object->pairs[i].value);
-    }
-    free(object->pairs);
-    *object = (LanternYamlObject){0};
-}
-
-static int yaml_object_add_pair(LanternYamlObject *object, const char *key, const char *value) {
-    if (!object || !key || !value) {
+int lantern_yaml_document_load(const char *path, struct lantern_yaml_document *document)
+{
+    if (!path || !document)
+    {
         return -1;
     }
-    if (object->num_pairs == object->capacity) {
-        size_t capacity = object->capacity ? object->capacity * 2u : 4u;
-        if (capacity < object->capacity || capacity > SIZE_MAX / sizeof(*object->pairs)) {
-            return -1;
-        }
-        LanternYamlKeyValPair *pairs = realloc(object->pairs, capacity * sizeof(*pairs));
-        if (!pairs) {
-            return -1;
-        }
-        object->pairs = pairs;
-        object->capacity = capacity;
-    }
-    char *key_copy = strdup(key);
-    char *value_copy = strdup(value);
-    if (!key_copy || !value_copy) {
-        free(key_copy);
-        free(value_copy);
+    *document = (struct lantern_yaml_document){0};
+    FILE *file = fopen(path, "rb");
+    if (!file)
+    {
         return -1;
     }
-    object->pairs[object->num_pairs++] = (LanternYamlKeyValPair){
-        .key = key_copy,
-        .value = value_copy,
-    };
-    return 0;
-}
-
-static int append_object(
-    LanternYamlObject *current,
-    LanternYamlObject **objects,
-    size_t *count,
-    size_t *capacity) {
-    if (current->num_pairs == 0u) {
-        return 0;
+    yaml_parser_t parser;
+    int ok = yaml_parser_initialize(&parser);
+    if (ok)
+    {
+        yaml_parser_set_input_file(&parser, file);
+        ok = yaml_parser_load(&parser, &document->value);
+        yaml_parser_delete(&parser);
     }
-    if (*count == *capacity) {
-        size_t next_capacity = *capacity ? *capacity * 2u : 4u;
-        if (next_capacity < *capacity
-            || next_capacity > SIZE_MAX / sizeof(**objects)) {
-            return -1;
-        }
-        LanternYamlObject *next = realloc(*objects, next_capacity * sizeof(*next));
-        if (!next) {
-            return -1;
-        }
-        *objects = next;
-        *capacity = next_capacity;
-    }
-    (*objects)[(*count)++] = *current;
-    *current = (LanternYamlObject){0};
-    return 0;
-}
-
-LanternYamlObject *lantern_yaml_read_array(
-    const char *file_path,
-    const char *array_name,
-    size_t *out_count) {
-    if (!file_path || !array_name || !out_count) {
-        return NULL;
-    }
-    *out_count = 0u;
-    FILE *file = fopen(file_path, "r");
-    if (!file) {
-        return NULL;
-    }
-
-    LanternYamlObject current = {0};
-    LanternYamlObject *objects = NULL;
-    size_t capacity = 0u;
-    size_t target_indent = 0u;
-    size_t item_indent = 0u;
-    bool in_target = false;
-    bool have_item = false;
-    bool failed = false;
-    char line[2048];
-
-    while (fgets(line, sizeof(line), file)) {
-        trim_right(line);
-        char *content = trim_left(line);
-        if (*content == '\0' || *content == '#') {
-            continue;
-        }
-        size_t indent = indentation(line);
-
-        if (!in_target) {
-            char *separator = strchr(content, ':');
-            if (!separator) {
-                continue;
-            }
-            *separator = '\0';
-            trim_right(content);
-            char *value = trim_left(separator + 1);
-            if (strcmp(content, array_name) == 0
-                && (*value == '\0' || *value == '#')) {
-                in_target = true;
-                target_indent = indent;
-            }
-            continue;
-        }
-
-        if (indent < target_indent || (indent == target_indent && *content != '-')) {
-            break;
-        }
-        if (*content == '-' && (!have_item || indent <= item_indent)) {
-            if (append_object(&current, &objects, out_count, &capacity) != 0) {
-                failed = true;
-                break;
-            }
-            have_item = true;
-            item_indent = indent;
-            content = trim_left(content + 1);
-            if (*content == '\0') {
-                continue;
-            }
-        }
-        if (!have_item) {
-            continue;
-        }
-
-        char *separator = strchr(content, ':');
-        if (!separator) {
-            continue;
-        }
-        *separator = '\0';
-        trim_right(content);
-        char *value = trim_left(separator + 1);
-        if (*content == '\0' || yaml_object_add_pair(&current, content, value) != 0) {
-            failed = true;
-            break;
-        }
-    }
-
     fclose(file);
-    if (!failed && in_target
-        && append_object(&current, &objects, out_count, &capacity) != 0) {
-        failed = true;
-    }
-    yaml_object_reset(&current);
-    if (failed) {
-        lantern_yaml_free_objects(objects, *out_count);
-        *out_count = 0u;
-        return NULL;
-    }
-    if (*out_count == 0u) {
-        free(objects);
-        return NULL;
-    }
-    return objects;
+    document->loaded = ok;
+    return ok ? 0 : -1;
 }
 
-void lantern_yaml_free_objects(LanternYamlObject *objects, size_t count) {
-    if (!objects) {
-        return;
+void lantern_yaml_document_reset(struct lantern_yaml_document *document)
+{
+    if (document && document->loaded)
+    {
+        yaml_document_delete(&document->value);
+        *document = (struct lantern_yaml_document){0};
     }
-    for (size_t i = 0u; i < count; ++i) {
-        yaml_object_reset(&objects[i]);
+}
+
+const yaml_node_t *lantern_yaml_root(const struct lantern_yaml_document *document)
+{
+    return document && document->loaded
+        ? yaml_document_get_root_node((yaml_document_t *)&document->value)
+        : NULL;
+}
+
+const char *lantern_yaml_scalar(const yaml_node_t *node)
+{
+    return node && node->type == YAML_SCALAR_NODE ? (const char *)node->data.scalar.value : NULL;
+}
+
+const yaml_node_t *lantern_yaml_mapping_get(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *mapping,
+    const char *key)
+{
+    if (!document || !document->loaded || !mapping || mapping->type != YAML_MAPPING_NODE || !key)
+    {
+        return NULL;
     }
-    free(objects);
+    for (yaml_node_pair_t *pair = mapping->data.mapping.pairs.start;
+         pair < mapping->data.mapping.pairs.top;
+         ++pair)
+    {
+        const yaml_node_t *key_node = yaml_document_get_node(
+            (yaml_document_t *)&document->value,
+            pair->key);
+        const char *name = lantern_yaml_scalar(key_node);
+        if (name && strcmp(name, key) == 0)
+        {
+            return yaml_document_get_node((yaml_document_t *)&document->value, pair->value);
+        }
+    }
+    return NULL;
+}
+
+size_t lantern_yaml_sequence_length(const yaml_node_t *sequence)
+{
+    return sequence && sequence->type == YAML_SEQUENCE_NODE
+        ? (size_t)(sequence->data.sequence.items.top - sequence->data.sequence.items.start)
+        : 0u;
+}
+
+const yaml_node_t *lantern_yaml_sequence_get(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *sequence,
+    size_t index)
+{
+    size_t length = lantern_yaml_sequence_length(sequence);
+    if (!document || !document->loaded || index >= length)
+    {
+        return NULL;
+    }
+    return yaml_document_get_node(
+        (yaml_document_t *)&document->value,
+        sequence->data.sequence.items.start[index]);
 }

--- a/src/internal/yaml_parser.h
+++ b/src/internal/yaml_parser.h
@@ -2,20 +2,26 @@
 #define LANTERN_INTERNAL_YAML_PARSER_H
 
 #include <stddef.h>
-#include <stdint.h>
 
-typedef struct {
-    char *key;
-    char *value;
-} LanternYamlKeyValPair;
+#include <yaml.h>
 
-typedef struct {
-    LanternYamlKeyValPair *pairs;
-    size_t num_pairs;
-    size_t capacity;
-} LanternYamlObject;
+struct lantern_yaml_document {
+    yaml_document_t value;
+    int loaded;
+};
 
-LanternYamlObject *lantern_yaml_read_array(const char *file_path, const char *array_name, size_t *out_count);
-void lantern_yaml_free_objects(LanternYamlObject *objects, size_t count);
+int lantern_yaml_document_load(const char *path, struct lantern_yaml_document *document);
+void lantern_yaml_document_reset(struct lantern_yaml_document *document);
+const yaml_node_t *lantern_yaml_root(const struct lantern_yaml_document *document);
+const yaml_node_t *lantern_yaml_mapping_get(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *mapping,
+    const char *key);
+const char *lantern_yaml_scalar(const yaml_node_t *node);
+size_t lantern_yaml_sequence_length(const yaml_node_t *sequence);
+const yaml_node_t *lantern_yaml_sequence_get(
+    const struct lantern_yaml_document *document,
+    const yaml_node_t *sequence,
+    size_t index);
 
 #endif /* LANTERN_INTERNAL_YAML_PARSER_H */

--- a/src/metrics/server.c
+++ b/src/metrics/server.c
@@ -15,6 +15,8 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -24,7 +26,6 @@
 
 #define ARRAY_LEN(x) (sizeof(x) / sizeof((x)[0]))
 
-static const size_t LANTERN_METRICS_BODY_INITIAL_CAP = 2048;
 static const char LANTERN_METRICS_ENDPOINT_PATH[] = "/metrics";
 static const char *const kLeanDirectionLabels[LEAN_METRICS_DIR_COUNT] = {"inbound", "outbound"};
 static const char *const kLeanConnectionResultLabels[LEAN_METRICS_CONN_RESULT_COUNT] = {"success", "timeout", "error"};
@@ -42,14 +43,19 @@ enum
     LANTERN_METRICS_SERVER_OK = 0,
     LANTERN_METRICS_SERVER_ERR_INVALID_PARAM = -1,
     LANTERN_METRICS_SERVER_ERR_OUT_OF_MEMORY = -2,
-    LANTERN_METRICS_SERVER_ERR_OVERFLOW = -3,
     LANTERN_METRICS_SERVER_ERR_IO = -4,
     LANTERN_METRICS_SERVER_ERR_FORMATTING = -5,
-    LANTERN_METRICS_SERVER_ERR_MALFORMED_REQUEST = -6,
-    LANTERN_METRICS_SERVER_ERR_UNAVAILABLE = -7,
 };
 
-static const char METRICS_JSON_MALFORMED_REQUEST[] = "{\"error\":\"malformed request\"}";
+static int lantern_http_buffer_appendf(FILE *buffer, const char *format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = vfprintf(buffer, format, arguments);
+    va_end(arguments);
+    return result < 0 ? LANTERN_METRICS_SERVER_ERR_FORMATTING : LANTERN_METRICS_SERVER_OK;
+}
+
 static const char METRICS_JSON_UNKNOWN_ENDPOINT[] = "{\"error\":\"unknown endpoint\"}";
 static const char METRICS_JSON_UNAVAILABLE[] = "{\"error\":\"metrics unavailable\"}";
 static const char METRICS_JSON_FORMATTING_FAILED[] = "{\"error\":\"metrics formatting failed\"}";
@@ -67,7 +73,7 @@ static const char *metrics_client_label(const struct lantern_metrics_snapshot *s
  * @brief Append a single Prometheus metric with a uint64 value.
  */
 static int append_metric_uint64(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const char *name,
     const char *help,
     const char *type,
@@ -91,7 +97,7 @@ static int append_metric_uint64(
  * @brief Append a single Prometheus metric with a size_t value.
  */
 static int append_metric_size_t(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const char *name,
     const char *help,
     const char *type,
@@ -115,7 +121,7 @@ static int append_metric_size_t(
  * @brief Append a Prometheus histogram from a lean metrics snapshot.
  */
 static int append_histogram_metrics(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const char *name,
     const char *help,
     const struct lean_metrics_histogram_snapshot *hist)
@@ -247,7 +253,7 @@ static const struct lean_metrics_histogram_snapshot *metric_histogram_at(
 }
 
 static int append_metric_scalar(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot,
     const struct metric_scalar_desc *desc)
 {
@@ -280,7 +286,7 @@ static int append_metric_scalar(
 }
 
 static int append_metric_scalars(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot,
     const struct metric_scalar_desc *descs,
     size_t count)
@@ -297,7 +303,7 @@ static int append_metric_scalars(
 }
 
 static int append_client_size_t_metrics(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot,
     const struct metric_client_size_t_desc *descs,
     size_t count)
@@ -326,7 +332,7 @@ static int append_client_size_t_metrics(
 }
 
 static int append_histogram_descs(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lean_metrics_snapshot *lean,
     const struct metric_histogram_desc *descs,
     size_t count)
@@ -347,7 +353,7 @@ static int append_histogram_descs(
 }
 
 static int append_peer_vote_metric(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot,
     const struct peer_vote_metric_desc *desc,
     size_t count)
@@ -477,7 +483,7 @@ static const struct metric_histogram_desc kLeanHistograms[] = {
  * @brief Append chain and lean subsystem metrics.
  */
 static int append_lean_chain_metrics(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot)
 {
     if (!buf || !snapshot)
@@ -619,7 +625,7 @@ static int append_lean_chain_metrics(
  * @brief Append per-peer vote gossip metrics.
  */
 static int append_peer_vote_metrics(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lantern_metrics_snapshot *snapshot)
 {
     if (!buf || !snapshot)
@@ -653,7 +659,7 @@ static int append_peer_vote_metrics(
  * @brief Append peer connection metrics derived from the lean metrics snapshot.
  */
 static int append_lean_peer_connection_metrics(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lean_metrics_snapshot *lean)
 {
     if (!buf || !lean)
@@ -721,7 +727,7 @@ static int append_lean_peer_connection_metrics(
  * @brief Append histogram metrics derived from the lean metrics snapshot.
  */
 static int append_lean_histograms(
-    struct lantern_http_buffer *buf,
+    FILE *buf,
     const struct lean_metrics_snapshot *lean)
 {
     if (!buf || !lean)
@@ -762,47 +768,51 @@ static int format_metrics_body(
         return LANTERN_METRICS_SERVER_ERR_INVALID_PARAM;
     }
 
-    int result = 0;
-    struct lantern_http_buffer buf;
-    memset(&buf, 0, sizeof(buf));
-
-    result = lantern_http_buffer_init(&buf, LANTERN_METRICS_BODY_INITIAL_CAP);
-    if (result != 0)
+    *out_body = NULL;
+    *out_len = 0u;
+    FILE *buf = open_memstream(out_body, out_len);
+    if (!buf)
     {
-        return result;
+        return LANTERN_METRICS_SERVER_ERR_OUT_OF_MEMORY;
     }
 
-    result = append_lean_chain_metrics(&buf, snapshot);
-    if (result != 0)
-    {
-        goto cleanup;
-    }
-
-    result = append_peer_vote_metrics(&buf, snapshot);
+    int result = append_lean_chain_metrics(buf, snapshot);
     if (result != 0)
     {
         goto cleanup;
     }
 
-    result = append_lean_peer_connection_metrics(&buf, &snapshot->lean_metrics);
+    result = append_peer_vote_metrics(buf, snapshot);
     if (result != 0)
     {
         goto cleanup;
     }
 
-    result = append_lean_histograms(&buf, &snapshot->lean_metrics);
+    result = append_lean_peer_connection_metrics(buf, &snapshot->lean_metrics);
     if (result != 0)
     {
         goto cleanup;
     }
 
-    *out_body = buf.data;
-    *out_len = buf.len;
-    buf.data = NULL;
+    result = append_lean_histograms(buf, &snapshot->lean_metrics);
+    if (result != 0)
+    {
+        goto cleanup;
+    }
+
     result = 0;
 
 cleanup:
-    lantern_http_buffer_free(&buf);
+    if (fclose(buf) != 0 && result == 0)
+    {
+        result = LANTERN_METRICS_SERVER_ERR_FORMATTING;
+    }
+    if (result != 0)
+    {
+        free(*out_body);
+        *out_body = NULL;
+        *out_len = 0u;
+    }
     return result;
 }
 
@@ -843,7 +853,7 @@ int lantern_metrics_handle_http(
     if (!handler->callbacks.snapshot)
     {
         int rc = lantern_http_send_json_error(
-            request->client_fd,
+            request,
             503,
             "Service Unavailable",
             unavailable_json);
@@ -860,7 +870,7 @@ int lantern_metrics_handle_http(
     if (handler->callbacks.snapshot(handler->callbacks.context, &snapshot) != 0)
     {
         int rc = lantern_http_send_json_error(
-            request->client_fd,
+            request,
             503,
             "Service Unavailable",
             unavailable_json);
@@ -878,7 +888,7 @@ int lantern_metrics_handle_http(
     if (result != 0)
     {
         int rc = lantern_http_send_json_error(
-            request->client_fd,
+            request,
             500,
             "Internal Server Error",
             formatting_json);
@@ -892,7 +902,7 @@ int lantern_metrics_handle_http(
     }
 
     result = lantern_http_send_response(
-        request->client_fd,
+        request,
         200,
         "OK",
         LANTERN_METRICS_CONTENT_TYPE,
@@ -965,7 +975,6 @@ int lantern_metrics_server_start(
     config.port = port;
     config.log_module = "metrics";
     config.listen_label = "metrics server";
-    config.malformed_json = METRICS_JSON_MALFORMED_REQUEST;
     config.unknown_json = METRICS_JSON_UNKNOWN_ENDPOINT;
     config.context = server;
     config.routes = kMetricsRoutes;

--- a/src/networking/gossip_payloads.c
+++ b/src/networking/gossip_payloads.c
@@ -52,66 +52,6 @@ static size_t signed_block_max_ssz_size(void) {
     return total + proof_max;
 }
 
-static int basic_attestation_data_sanity(const LanternAttestationData *data) {
-    if (!data) {
-        return -1;
-    }
-    if (data->target.slot < data->source.slot) {
-        return -1;
-    }
-    if (data->slot < data->target.slot) {
-        return -1;
-    }
-    return 0;
-}
-
-static int basic_vote_sanity(const LanternVote *vote) {
-    if (!vote) {
-        return -1;
-    }
-    if (basic_attestation_data_sanity(&vote->data) != 0) {
-        return -1;
-    }
-    return 0;
-}
-
-static int basic_block_sanity(const LanternSignedBlock *block) {
-    if (!block) {
-        return -1;
-    }
-    const LanternBlock *message = &block->block;
-    for (size_t i = 0; i < message->body.attestations.length; ++i) {
-        const LanternAggregatedAttestation *att = &message->body.attestations.data[i];
-        if (basic_attestation_data_sanity(&att->data) != 0) {
-            return -1;
-        }
-    }
-    size_t att_count = message->body.attestations.length;
-    (void)att_count;
-    size_t proof_size = 0;
-    if (lantern_ssz_encode_multi_message_aggregate(&block->proof, NULL, 0, &proof_size) != SSZ_SUCCESS) {
-        return -1;
-    }
-    return 0;
-}
-
-static int basic_signed_aggregated_attestation_sanity(
-    const LanternSignedAggregatedAttestation *attestation) {
-    if (!attestation) {
-        return -1;
-    }
-    if (basic_attestation_data_sanity(&attestation->data) != 0) {
-        return -1;
-    }
-    if (attestation->proof.participants.bit_length == 0 || !attestation->proof.participants.bytes) {
-        return -1;
-    }
-    if (attestation->proof.proof_data.length == 0 || !attestation->proof.proof_data.data) {
-        return -1;
-    }
-    return 0;
-}
-
 static size_t signed_aggregated_attestation_max_ssz_size(void) {
     size_t bits_max = bitlist_encoded_size_bits(LANTERN_VALIDATOR_REGISTRY_LIMIT);
     size_t proof_max = (SSZ_BYTES_PER_LENGTH_OFFSET * 2u) + bits_max + LANTERN_AGG_PROOF_MAX_BYTES;
@@ -199,8 +139,7 @@ int lantern_gossip_decode_signed_block_snappy(
     size_t raw_len = 0;
     size_t max_ssz = signed_block_max_ssz_size();
     if (decode_snappy_payload(data, data_len, 1u, max_ssz, &raw, &raw_len) != 0
-        || lantern_ssz_decode_signed_block(block, raw, raw_len) != SSZ_SUCCESS
-        || basic_block_sanity(block) != 0) {
+        || lantern_ssz_decode_signed_block(block, raw, raw_len) != SSZ_SUCCESS) {
         free(raw);
         return -1;
     }
@@ -217,9 +156,6 @@ int lantern_gossip_encode_signed_vote_snappy(
     size_t out_len,
     size_t *written) {
     if (!vote || !out || !written) {
-        return -1;
-    }
-    if (basic_vote_sanity(&vote->data) != 0) {
         return -1;
     }
     uint8_t raw[LANTERN_SIGNED_VOTE_SSZ_SIZE];
@@ -253,7 +189,7 @@ int lantern_gossip_decode_signed_vote_snappy(
     }
     ssz_error_t decode_rc = lantern_ssz_decode_signed_vote(vote, raw, raw_len);
     free(raw);
-    return decode_rc == SSZ_SUCCESS && basic_vote_sanity(&vote->data) == 0 ? 0 : -1;
+    return decode_rc == SSZ_SUCCESS ? 0 : -1;
 }
 
 int lantern_gossip_encode_signed_aggregated_attestation_snappy(
@@ -262,9 +198,6 @@ int lantern_gossip_encode_signed_aggregated_attestation_snappy(
     size_t out_len,
     size_t *written) {
     if (!attestation || !out || !written) {
-        return -1;
-    }
-    if (basic_signed_aggregated_attestation_sanity(attestation) != 0) {
         return -1;
     }
     size_t raw_capacity = 0;
@@ -302,8 +235,5 @@ int lantern_gossip_decode_signed_aggregated_attestation_snappy(
     }
     ssz_error_t decode_rc = lantern_ssz_decode_signed_aggregated_attestation(attestation, raw, raw_len);
     free(raw);
-    return decode_rc == SSZ_SUCCESS
-            && basic_signed_aggregated_attestation_sanity(attestation) == 0
-        ? 0
-        : -1;
+    return decode_rc == SSZ_SUCCESS ? 0 : -1;
 }

--- a/src/networking/reqresp_service.c
+++ b/src/networking/reqresp_service.c
@@ -43,6 +43,12 @@ struct lantern_reqresp_exchange {
     struct lantern_reqresp_exchange *next;
 };
 
+static const char *const kReqrespProtocolIds[LANTERN_REQRESP_PROTOCOL_KIND_COUNT] = {
+    [LANTERN_REQRESP_PROTOCOL_STATUS] = LANTERN_REQRESP_STATUS_PROTOCOL,
+    [LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_ROOT] = LANTERN_REQRESP_BLOCKS_BY_ROOT_PROTOCOL,
+    [LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE] = LANTERN_REQRESP_BLOCKS_BY_RANGE_PROTOCOL,
+};
+
 static uint8_t normalize_response_code(uint8_t code) {
     if (code <= LANTERN_REQRESP_RESPONSE_RESOURCE_UNAVAILABLE) {
         return code;
@@ -1170,52 +1176,26 @@ int lantern_reqresp_service_start(
         service->lock_initialized = 1;
     }
 
-    service->status_protocol.id = (const uint8_t *)LANTERN_REQRESP_STATUS_PROTOCOL;
-    service->status_protocol.id_len = strlen(LANTERN_REQRESP_STATUS_PROTOCOL);
-    service->status_protocol.on_open = reqresp_on_open;
-    service->status_protocol.on_event = reqresp_on_event;
-    service->status_context.service = service;
-    service->status_context.kind = LANTERN_REQRESP_PROTOCOL_STATUS;
-    service->status_protocol.user_data = &service->status_context;
-
-    service->blocks_protocol.id = (const uint8_t *)LANTERN_REQRESP_BLOCKS_BY_ROOT_PROTOCOL;
-    service->blocks_protocol.id_len = strlen(LANTERN_REQRESP_BLOCKS_BY_ROOT_PROTOCOL);
-    service->blocks_protocol.on_open = reqresp_on_open;
-    service->blocks_protocol.on_event = reqresp_on_event;
-    service->blocks_context.service = service;
-    service->blocks_context.kind = LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_ROOT;
-    service->blocks_protocol.user_data = &service->blocks_context;
-
-    service->blocks_by_range_protocol.id = (const uint8_t *)LANTERN_REQRESP_BLOCKS_BY_RANGE_PROTOCOL;
-    service->blocks_by_range_protocol.id_len = strlen(LANTERN_REQRESP_BLOCKS_BY_RANGE_PROTOCOL);
-    service->blocks_by_range_protocol.on_open = reqresp_on_open;
-    service->blocks_by_range_protocol.on_event = reqresp_on_event;
-    service->blocks_by_range_context.service = service;
-    service->blocks_by_range_context.kind = LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE;
-    service->blocks_by_range_protocol.user_data = &service->blocks_by_range_context;
-
-    if (lantern_libp2p_host_register_protocol(service->network, &service->status_protocol) != 0 ||
-        lantern_libp2p_host_register_protocol(service->network, &service->blocks_protocol) != 0 ||
-        lantern_libp2p_host_register_protocol(service->network, &service->blocks_by_range_protocol) != 0) {
-        return -1;
+    for (size_t i = 0; i < LANTERN_REQRESP_PROTOCOL_KIND_COUNT; ++i) {
+        libp2p_host_protocol_t *protocol = &service->protocols[i];
+        struct lantern_reqresp_protocol_context *context = &service->protocol_contexts[i];
+        protocol->id = (const uint8_t *)kReqrespProtocolIds[i];
+        protocol->id_len = strlen(kReqrespProtocolIds[i]);
+        protocol->on_open = reqresp_on_open;
+        protocol->on_event = reqresp_on_event;
+        protocol->user_data = context;
+        context->service = service;
+        context->kind = (enum lantern_reqresp_protocol_kind)i;
+    }
+    for (size_t i = 0; i < LANTERN_REQRESP_PROTOCOL_KIND_COUNT; ++i) {
+        if (lantern_libp2p_host_register_protocol(service->network, &service->protocols[i]) != 0) {
+            return -1;
+        }
     }
     if (lantern_libp2p_host_register_event_handler(service->network, reqresp_host_event, service) != 0) {
         return -1;
     }
     return 0;
-}
-
-static const char *reqresp_protocol_id_for_kind(enum lantern_reqresp_protocol_kind kind) {
-    switch (kind) {
-    case LANTERN_REQRESP_PROTOCOL_STATUS:
-        return LANTERN_REQRESP_STATUS_PROTOCOL;
-    case LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_ROOT:
-        return LANTERN_REQRESP_BLOCKS_BY_ROOT_PROTOCOL;
-    case LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE:
-        return LANTERN_REQRESP_BLOCKS_BY_RANGE_PROTOCOL;
-    default:
-        return NULL;
-    }
 }
 
 static int service_open_exchange(
@@ -1228,7 +1208,8 @@ static int service_open_exchange(
     const LanternRoot *roots,
     size_t root_count,
     uint64_t request_id) {
-    if (!service || !service->network || !service->network->host || !peer_id || !frame || frame_len == 0u) {
+    if (!service || !service->network || !service->network->host || !peer_id || !frame || frame_len == 0u
+        || (unsigned)kind >= LANTERN_REQRESP_PROTOCOL_KIND_COUNT) {
         free(frame);
         return -1;
     }
@@ -1275,12 +1256,7 @@ static int service_open_exchange(
         exchange->root_count = root_count;
     }
     service_add_exchange(service, exchange);
-    const char *protocol = reqresp_protocol_id_for_kind(kind);
-    if (!protocol) {
-        service_remove_exchange(service, exchange);
-        exchange_free(exchange);
-        return -1;
-    }
+    const char *protocol = kReqrespProtocolIds[kind];
     libp2p_host_stream_open_t *open = NULL;
     libp2p_host_err_t err = libp2p_host_open_stream(
         service->network->host,

--- a/src/storage/storage.c
+++ b/src/storage/storage.c
@@ -1,19 +1,18 @@
 #include "lantern/storage/storage.h"
 
+#include <dirent.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-#include <dirent.h>
 
 #if defined(_WIN32)
 #include <direct.h>
@@ -22,985 +21,677 @@
 
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/ssz.h"
-#include "lantern/networking/messages.h"
 #include "lantern/support/log.h"
 #include "lantern/support/strings.h"
 #include "ssz.h"
 
-#define LANTERN_STORAGE_BLOCKS_DIR "blocks"
-#define LANTERN_STORAGE_STATES_DIR "states"
-#define LANTERN_STORAGE_STATE_FILE "state.ssz"
+#define STORAGE_BLOCKS_DIR "blocks"
+#define STORAGE_STATES_DIR "states"
+#define STORAGE_STATE_FILE "state.ssz"
 
-#if defined(_WIN32)
-#define LANTERN_STORAGE_PATH_SEP '\\'
-#else
-#define LANTERN_STORAGE_PATH_SEP '/'
-#endif
-
-/*
- * Internal helpers for filesystem/path handling, SSZ size estimation, and
- * atomic file reads/writes.
- *
- * Public API: see include/lantern/storage/storage.h
- */
-
-static int ensure_directory(const char *path) {
-    if (!path) {
-        return -1;
-    }
-    struct stat st;
-    if (stat(path, &st) == 0) {
-        return S_ISDIR(st.st_mode) ? 0 : -1;
-    }
-#if defined(_WIN32)
-    if (_mkdir(path) != 0 && errno != EEXIST) {
-        return -1;
-    }
-#else
-    if (mkdir(path, 0700) != 0 && errno != EEXIST) {
-        return -1;
-    }
-#endif
-    return 0;
-}
-
-static int join_path(const char *base, const char *leaf, char **out_path) {
-    if (!base || !leaf || !out_path) {
-        return -1;
-    }
-    const size_t base_len = strlen(base);
-    const size_t leaf_len = strlen(leaf);
-    bool needs_sep = false;
-    if (base_len > 0) {
-        const char tail = base[base_len - 1];
-        needs_sep = (tail != '/' && tail != '\\');
-    }
-    const size_t total = base_len + (needs_sep ? 1u : 0u) + leaf_len + 1u;
-    char *buffer = malloc(total);
-    if (!buffer) {
-        return -1;
-    }
-    memcpy(buffer, base, base_len);
-    size_t offset = base_len;
-    if (needs_sep) {
-        buffer[offset++] = LANTERN_STORAGE_PATH_SEP;
-    }
-    memcpy(buffer + offset, leaf, leaf_len);
-    buffer[offset + leaf_len] = '\0';
-    *out_path = buffer;
-    return 0;
-}
-
-static int write_atomic_file(const char *path, const uint8_t *data, size_t data_len) {
-    if (!path || !data || data_len == 0) {
-        return -1;
-    }
-    int rc = -1;
-    FILE *fp = NULL;
-    char *tmp_path = NULL;
-
-    const size_t path_len = strlen(path);
-    tmp_path = malloc(path_len + sizeof(".tmp"));
-    if (!tmp_path) {
-        goto cleanup;
-    }
-    memcpy(tmp_path, path, path_len);
-    memcpy(tmp_path + path_len, ".tmp", sizeof(".tmp"));
-
-    fp = fopen(tmp_path, "wb");
-    if (!fp) {
-        goto cleanup;
-    }
-    const size_t written = fwrite(data, 1u, data_len, fp);
-    if (written != data_len) {
-        goto cleanup;
-    }
-    if (fflush(fp) != 0) {
-        goto cleanup;
-    }
-#if defined(_WIN32)
-    if (_commit(_fileno(fp)) != 0) {
-        goto cleanup;
-    }
-#else
-    if (fsync(fileno(fp)) != 0) {
-        goto cleanup;
-    }
-#endif
-    const int close_rc = fclose(fp);
-    fp = NULL;
-    if (close_rc != 0) {
-        goto cleanup;
-    }
-#if defined(_WIN32)
-    if (remove(path) != 0 && errno != ENOENT) {
-        goto cleanup;
-    }
-#endif
-    if (rename(tmp_path, path) != 0) {
-        goto cleanup;
-    }
-    rc = 0;
-
-cleanup:
-    if (fp) {
-        fclose(fp);
-    }
-    free(tmp_path);
-    return rc;
-}
-
-static int read_file_buffer(const char *path, uint8_t **out_data, size_t *out_len) {
-    if (!path || !out_data || !out_len) {
-        return -1;
-    }
-    FILE *fp = fopen(path, "rb");
-    if (!fp) {
-        return (errno == ENOENT) ? 1 : -1;
-    }
-    int rc = -1;
-    uint8_t *buffer = NULL;
-
-    if (fseek(fp, 0, SEEK_END) != 0) {
-        goto cleanup;
-    }
-    const long file_size = ftell(fp);
-    if (file_size < 0) {
-        goto cleanup;
-    }
-    if (fseek(fp, 0, SEEK_SET) != 0) {
-        goto cleanup;
-    }
-    if (file_size == 0) {
-        rc = 1;
-        goto cleanup;
-    }
-    buffer = malloc((size_t)file_size);
-    if (!buffer) {
-        goto cleanup;
-    }
-    const size_t read = fread(buffer, 1u, (size_t)file_size, fp);
-    if (read != (size_t)file_size) {
-        goto cleanup;
-    }
-
-    *out_data = buffer;
-    *out_len = (size_t)file_size;
-    buffer = NULL;
-    rc = 0;
-
-cleanup:
-    fclose(fp);
-    free(buffer);
-    return rc;
-}
-
-enum storage_dir_kind {
-    STORAGE_DIR_BLOCKS,
-    STORAGE_DIR_STATES,
-    STORAGE_DIR_COUNT,
+struct storage_context {
+    char *blocks_dir;
+    char *states_dir;
+    char *state_file;
+    pthread_rwlock_t lock;
 };
 
-static const char *const STORAGE_DIR_LEAVES[STORAGE_DIR_COUNT] = {
-    [STORAGE_DIR_BLOCKS] = LANTERN_STORAGE_BLOCKS_DIR,
-    [STORAGE_DIR_STATES] = LANTERN_STORAGE_STATES_DIR,
-};
-
-static int storage_dir_path(
-    const char *data_dir,
-    enum storage_dir_kind kind,
-    char **out_path) {
-    if (!data_dir || !out_path) {
-        return -1;
-    }
-    *out_path = NULL;
-
-    const unsigned index = (unsigned)kind;
-    if (index >= (unsigned)STORAGE_DIR_COUNT || !STORAGE_DIR_LEAVES[index]) {
-        return -1;
-    }
-    return join_path(data_dir, STORAGE_DIR_LEAVES[index], out_path);
+static struct storage_context *get_context(const struct lantern_storage *storage)
+{
+    return storage ? storage->backend : NULL;
 }
 
-static int ensure_storage_dir(
-    const char *data_dir,
-    enum storage_dir_kind kind,
-    char **out_path) {
-    if (out_path) {
-        *out_path = NULL;
-    }
-    char *path = NULL;
-    if (storage_dir_path(data_dir, kind, &path) != 0 || ensure_directory(path) != 0) {
-        free(path);
+static int ensure_directory(const char *path)
+{
+    struct stat status;
+    if (!path)
+    {
         return -1;
     }
-    if (out_path) {
-        *out_path = path;
-    } else {
-        free(path);
+    if (stat(path, &status) == 0)
+    {
+        return S_ISDIR(status.st_mode) ? 0 : -1;
     }
-    return 0;
+#if defined(_WIN32)
+    return _mkdir(path) == 0 || errno == EEXIST ? 0 : -1;
+#else
+    return mkdir(path, 0700) == 0 || errno == EEXIST ? 0 : -1;
+#endif
 }
 
-static int storage_dir_file_path(
-    const char *data_dir,
-    enum storage_dir_kind kind,
-    const char *filename,
-    bool ensure_parent,
-    char **out_path) {
-    if (!data_dir || !filename || !out_path) {
-        return -1;
+static char *join_path(const char *directory, const char *leaf)
+{
+    if (!directory || !leaf)
+    {
+        return NULL;
     }
-    *out_path = NULL;
-
-    char *dir = NULL;
-    int rc = ensure_parent
-        ? ensure_storage_dir(data_dir, kind, &dir)
-        : storage_dir_path(data_dir, kind, &dir);
-    if (rc == 0) {
-        rc = join_path(dir, filename, out_path);
+    size_t directory_length = strlen(directory);
+    size_t leaf_length = strlen(leaf);
+    bool separator = directory_length > 0u
+        && directory[directory_length - 1u] != '/'
+        && directory[directory_length - 1u] != '\\';
+    if (directory_length > SIZE_MAX - leaf_length - 2u)
+    {
+        return NULL;
     }
-    free(dir);
-    return rc;
+    size_t length = directory_length + leaf_length + (separator ? 2u : 1u);
+    char *path = malloc(length);
+    if (path)
+    {
+        snprintf(path, length, "%s%s%s", directory, separator ? "/" : "", leaf);
+    }
+    return path;
 }
 
-static int storage_root_file_path(
-    const char *data_dir,
-    enum storage_dir_kind kind,
-    const LanternRoot *root,
-    bool ensure_parent,
-    char **out_path,
-    char *out_root_hex,
-    size_t out_root_hex_len) {
-    if (!data_dir || !root || !out_path) {
-        return -1;
-    }
-    *out_path = NULL;
-
-    char local_hex[2u * LANTERN_ROOT_SIZE + 1u];
-    char *root_hex = out_root_hex ? out_root_hex : local_hex;
-    size_t root_hex_len = out_root_hex ? out_root_hex_len : sizeof(local_hex);
-    if (lantern_bytes_to_hex(root->bytes, LANTERN_ROOT_SIZE, root_hex, root_hex_len, 0) != 0) {
-        return -1;
-    }
-
-    char filename[2u * LANTERN_ROOT_SIZE + 5u];
-    const int wrote = snprintf(filename, sizeof(filename), "%s.ssz", root_hex);
-    if (wrote < 0 || (size_t)wrote >= sizeof(filename)) {
-        return -1;
-    }
-    return storage_dir_file_path(data_dir, kind, filename, ensure_parent, out_path);
+static int sync_file(FILE *file)
+{
+#if defined(_WIN32)
+    return _commit(_fileno(file));
+#else
+    return fsync(fileno(file));
+#endif
 }
 
-static int storage_write_state_path(const char *path, const LanternState *state) {
-    if (!path || !state || state->validator_count == 0) {
+static int write_atomic_file(const char *path, const uint8_t *data, size_t length)
+{
+    if (!path || !data || length == 0u)
+    {
         return -1;
     }
-
-    int rc = -1;
-    uint8_t *buffer = NULL;
-    size_t encoded_size = 0;
-    if (lantern_ssz_encode_state(state, NULL, 0, &encoded_size) != SSZ_SUCCESS
-        || encoded_size == 0) {
-        goto cleanup;
+    size_t path_length = strlen(path);
+    char *temporary = malloc(path_length + sizeof(".tmp"));
+    if (!temporary)
+    {
+        return -1;
     }
-    buffer = malloc(encoded_size);
-    if (!buffer) {
-        goto cleanup;
+    memcpy(temporary, path, path_length);
+    memcpy(temporary + path_length, ".tmp", sizeof(".tmp"));
+    FILE *file = fopen(temporary, "wb");
+    int result = -1;
+    if (file
+        && fwrite(data, 1u, length, file) == length
+        && fflush(file) == 0
+        && sync_file(file) == 0)
+    {
+        int close_result = fclose(file);
+        file = NULL;
+        if (close_result != 0)
+        {
+            goto cleanup;
+        }
+#if defined(_WIN32)
+        if (remove(path) != 0 && errno != ENOENT)
+        {
+            goto cleanup;
+        }
+#endif
+        result = rename(temporary, path) == 0 ? 0 : -1;
     }
-    size_t written = 0;
-    if (lantern_ssz_encode_state(state, buffer, encoded_size, &written) != SSZ_SUCCESS
-        || written != encoded_size) {
-        goto cleanup;
-    }
-    rc = write_atomic_file(path, buffer, written);
-
 cleanup:
-    free(buffer);
-    return rc;
+    if (file)
+    {
+        fclose(file);
+    }
+    if (result != 0)
+    {
+        (void)remove(temporary);
+    }
+    free(temporary);
+    return result;
 }
 
-static int storage_load_root_bytes(
-    const char *data_dir,
-    enum storage_dir_kind kind,
-    const LanternRoot *root,
-    uint8_t **out_data,
-    size_t *out_len) {
-    if (!data_dir || !root || !out_data || !out_len) {
+static int read_file(const char *path, uint8_t **out_data, size_t *out_length)
+{
+    if (!path || !out_data || !out_length)
+    {
         return -1;
     }
     *out_data = NULL;
-    *out_len = 0;
-
-    char *path = NULL;
+    *out_length = 0u;
+    FILE *file = fopen(path, "rb");
+    if (!file)
+    {
+        return errno == ENOENT ? 1 : -1;
+    }
     uint8_t *data = NULL;
-    size_t len = 0;
-    int rc = storage_root_file_path(data_dir, kind, root, false, &path, NULL, 0);
-    if (rc != 0) {
+    int result = -1;
+    if (fseek(file, 0, SEEK_END) != 0)
+    {
         goto cleanup;
     }
-    rc = read_file_buffer(path, &data, &len);
-    if (rc != 0) {
-        rc = (rc > 0) ? 1 : -1;
+    long size = ftell(file);
+    if (size <= 0 || (uintmax_t)size > SIZE_MAX || fseek(file, 0, SEEK_SET) != 0)
+    {
         goto cleanup;
     }
-
+    data = malloc((size_t)size);
+    if (!data || fread(data, 1u, (size_t)size, file) != (size_t)size)
+    {
+        goto cleanup;
+    }
     *out_data = data;
-    *out_len = len;
+    *out_length = (size_t)size;
     data = NULL;
-
+    result = 0;
 cleanup:
-    free(path);
+    if (fclose(file) != 0 && result == 0)
+    {
+        free(*out_data);
+        *out_data = NULL;
+        *out_length = 0u;
+        result = -1;
+    }
     free(data);
-    return rc;
+    return result;
 }
 
-static bool storage_root_is_kept(
-    const LanternRoot *root,
-    const LanternRoot *keep_roots,
-    size_t keep_root_count) {
-    if (!root || !keep_roots || keep_root_count == 0) {
+static char *root_path(const char *directory, const LanternRoot *root)
+{
+    if (!directory || !root)
+    {
+        return NULL;
+    }
+    char filename[(2u * LANTERN_ROOT_SIZE) + sizeof(".ssz")];
+    if (lantern_bytes_to_hex(
+            root->bytes, LANTERN_ROOT_SIZE, filename, sizeof(filename) - 4u, 0) != 0)
+    {
+        return NULL;
+    }
+    memcpy(filename + (2u * LANTERN_ROOT_SIZE), ".ssz", sizeof(".ssz"));
+    return join_path(directory, filename);
+}
+
+static bool filename_root(const char *filename, LanternRoot *root)
+{
+    if (!filename || !root || strlen(filename) != (2u * LANTERN_ROOT_SIZE) + 4u
+        || strcmp(filename + (2u * LANTERN_ROOT_SIZE), ".ssz") != 0)
+    {
         return false;
     }
-    for (size_t i = 0; i < keep_root_count; ++i) {
-        if (memcmp(root->bytes, keep_roots[i].bytes, LANTERN_ROOT_SIZE) == 0) {
+    char hex[(2u * LANTERN_ROOT_SIZE) + 1u];
+    memcpy(hex, filename, sizeof(hex) - 1u);
+    hex[sizeof(hex) - 1u] = '\0';
+    return lantern_hex_decode(hex, root->bytes, LANTERN_ROOT_SIZE) == 0;
+}
+
+int lantern_storage_open(struct lantern_storage *storage, const char *data_dir)
+{
+    if (!storage || storage->backend || ensure_directory(data_dir) != 0)
+    {
+        return -1;
+    }
+    struct storage_context *context = calloc(1u, sizeof(*context));
+    if (!context)
+    {
+        return -1;
+    }
+    context->blocks_dir = join_path(data_dir, STORAGE_BLOCKS_DIR);
+    context->states_dir = join_path(data_dir, STORAGE_STATES_DIR);
+    context->state_file = join_path(data_dir, STORAGE_STATE_FILE);
+    if (!context->blocks_dir || !context->states_dir || !context->state_file
+        || ensure_directory(context->blocks_dir) != 0
+        || ensure_directory(context->states_dir) != 0
+        || pthread_rwlock_init(&context->lock, NULL) != 0)
+    {
+        free(context->blocks_dir);
+        free(context->states_dir);
+        free(context->state_file);
+        free(context);
+        return -1;
+    }
+    storage->backend = context;
+    return 0;
+}
+
+void lantern_storage_close(struct lantern_storage *storage)
+{
+    struct storage_context *context = get_context(storage);
+    if (!context)
+    {
+        return;
+    }
+    storage->backend = NULL;
+    pthread_rwlock_destroy(&context->lock);
+    free(context->blocks_dir);
+    free(context->states_dir);
+    free(context->state_file);
+    free(context);
+}
+
+static int encode_state(const LanternState *state, uint8_t **out_data, size_t *out_length)
+{
+    size_t length = 0u;
+    if (!state || state->validator_count == 0u || !out_data || !out_length
+        || lantern_ssz_encode_state(state, NULL, 0u, &length) != SSZ_SUCCESS || length == 0u)
+    {
+        return -1;
+    }
+    uint8_t *data = malloc(length);
+    size_t written = 0u;
+    if (!data || lantern_ssz_encode_state(state, data, length, &written) != SSZ_SUCCESS
+        || written != length)
+    {
+        free(data);
+        return -1;
+    }
+    *out_data = data;
+    *out_length = length;
+    return 0;
+}
+
+static int encode_block(const LanternSignedBlock *block, uint8_t **out_data, size_t *out_length)
+{
+    size_t length = 0u;
+    if (!block || !out_data || !out_length
+        || lantern_ssz_encode_signed_block(block, NULL, 0u, &length) != SSZ_SUCCESS || length == 0u)
+    {
+        return -1;
+    }
+    uint8_t *data = malloc(length);
+    size_t written = 0u;
+    if (!data || lantern_ssz_encode_signed_block(block, data, length, &written) != SSZ_SUCCESS
+        || written != length)
+    {
+        free(data);
+        return -1;
+    }
+    *out_data = data;
+    *out_length = length;
+    return 0;
+}
+
+static int write_storage_file(
+    const struct lantern_storage *storage,
+    const char *path,
+    const uint8_t *data,
+    size_t length,
+    bool immutable)
+{
+    struct storage_context *context = get_context(storage);
+    if (!context || !path || pthread_rwlock_wrlock(&context->lock) != 0)
+    {
+        return -1;
+    }
+    int result = -1;
+    struct stat status;
+    if (immutable && stat(path, &status) == 0)
+    {
+        result = S_ISREG(status.st_mode) ? 0 : -1;
+    }
+    else if (!immutable || errno == ENOENT)
+    {
+        result = write_atomic_file(path, data, length);
+    }
+    pthread_rwlock_unlock(&context->lock);
+    return result;
+}
+
+static int read_storage_file(
+    const struct lantern_storage *storage,
+    const char *path,
+    uint8_t **out_data,
+    size_t *out_length)
+{
+    struct storage_context *context = get_context(storage);
+    if (!context || !path || pthread_rwlock_rdlock(&context->lock) != 0)
+    {
+        return -1;
+    }
+    int result = read_file(path, out_data, out_length);
+    pthread_rwlock_unlock(&context->lock);
+    return result;
+}
+
+int lantern_storage_save_state(const struct lantern_storage *storage, const LanternState *state)
+{
+    struct storage_context *context = get_context(storage);
+    uint8_t *data = NULL;
+    size_t length = 0u;
+    if (!context || encode_state(state, &data, &length) != 0)
+    {
+        return -1;
+    }
+    int result = write_storage_file(storage, context->state_file, data, length, false);
+    free(data);
+    return result;
+}
+
+int lantern_storage_load_state(const struct lantern_storage *storage, LanternState *state)
+{
+    struct storage_context *context = get_context(storage);
+    if (!context || !state)
+    {
+        return -1;
+    }
+    uint8_t *data = NULL;
+    size_t length = 0u;
+    int result = read_storage_file(storage, context->state_file, &data, &length);
+    if (result != 0)
+    {
+        return result;
+    }
+    LanternState decoded;
+    lantern_state_init(&decoded);
+    if (lantern_ssz_decode_state(&decoded, data, length) != SSZ_SUCCESS
+        || decoded.validator_count == 0u)
+    {
+        result = -1;
+    }
+    else
+    {
+        lantern_state_reset(state);
+        *state = decoded;
+        decoded = (LanternState){0};
+    }
+    lantern_state_reset(&decoded);
+    free(data);
+    return result;
+}
+
+static bool block_is_synthetic_anchor_alias(const LanternSignedBlock *block)
+{
+    const LanternBlockBody *body = block ? &block->block.body : NULL;
+    return body && body->attestations.length == 0u && !body->attestations.data
+        && block->proof.length == 0u && !block->proof.data;
+}
+
+static int verify_block_root(const LanternSignedBlock *block, const LanternRoot *root)
+{
+    LanternRoot computed;
+    if (!block || !root || lantern_hash_tree_root_block(&block->block, &computed) != SSZ_SUCCESS)
+    {
+        return -1;
+    }
+    if (memcmp(computed.bytes, root->bytes, LANTERN_ROOT_SIZE) == 0)
+    {
+        return 0;
+    }
+    if (!block_is_synthetic_anchor_alias(block))
+    {
+        return -1;
+    }
+    lantern_log_warn(
+        "storage",
+        &(const struct lantern_log_metadata){0},
+        "accepted synthetic anchor root alias at slot=%" PRIu64,
+        block->block.slot);
+    return 0;
+}
+
+static int store_block(
+    const struct lantern_storage *storage,
+    const LanternRoot *root,
+    const LanternSignedBlock *block)
+{
+    struct storage_context *context = get_context(storage);
+    char *path = context ? root_path(context->blocks_dir, root) : NULL;
+    uint8_t *data = NULL;
+    size_t length = 0u;
+    if (!path || encode_block(block, &data, &length) != 0)
+    {
+        free(path);
+        return -1;
+    }
+    int result = write_storage_file(storage, path, data, length, true);
+    free(data);
+    free(path);
+    return result;
+}
+
+int lantern_storage_store_block(const struct lantern_storage *storage, const LanternSignedBlock *block)
+{
+    LanternRoot root;
+    return block && lantern_hash_tree_root_block(&block->block, &root) == SSZ_SUCCESS
+        ? store_block(storage, &root, block)
+        : -1;
+}
+
+int lantern_storage_store_block_for_root(
+    const struct lantern_storage *storage,
+    const LanternRoot *root,
+    const LanternSignedBlock *block)
+{
+    return root && block ? store_block(storage, root, block) : -1;
+}
+
+int lantern_storage_store_state_for_root(
+    const struct lantern_storage *storage,
+    const LanternRoot *root,
+    const LanternState *state)
+{
+    struct storage_context *context = get_context(storage);
+    char *path = context ? root_path(context->states_dir, root) : NULL;
+    uint8_t *data = NULL;
+    size_t length = 0u;
+    if (!path || encode_state(state, &data, &length) != 0)
+    {
+        free(path);
+        return -1;
+    }
+    int result = write_storage_file(storage, path, data, length, false);
+    free(data);
+    free(path);
+    return result;
+}
+
+static int load_root_bytes(
+    const struct lantern_storage *storage,
+    const char *directory,
+    const LanternRoot *root,
+    uint8_t **out_data,
+    size_t *out_length)
+{
+    char *path = root_path(directory, root);
+    if (!path)
+    {
+        return -1;
+    }
+    int result = read_storage_file(storage, path, out_data, out_length);
+    free(path);
+    return result;
+}
+
+int lantern_storage_load_state_bytes_for_root(
+    const struct lantern_storage *storage,
+    const LanternRoot *root,
+    uint8_t **out_data,
+    size_t *out_len)
+{
+    struct storage_context *context = get_context(storage);
+    return context && root
+        ? load_root_bytes(storage, context->states_dir, root, out_data, out_len)
+        : -1;
+}
+
+int lantern_storage_load_block_bytes_for_root(
+    const struct lantern_storage *storage,
+    const LanternRoot *root,
+    uint8_t **out_data,
+    size_t *out_len)
+{
+    struct storage_context *context = get_context(storage);
+    return context && root
+        ? load_root_bytes(storage, context->blocks_dir, root, out_data, out_len)
+        : -1;
+}
+
+int lantern_storage_collect_blocks(
+    const struct lantern_storage *storage,
+    const LanternRoot *roots,
+    size_t root_count,
+    LanternSignedBlockList *out_blocks)
+{
+    if (!get_context(storage) || (!roots && root_count > 0u) || !out_blocks
+        || lantern_signed_block_list_resize(out_blocks, 0u) != 0)
+    {
+        return -1;
+    }
+    for (size_t i = 0; i < root_count; ++i)
+    {
+        uint8_t *data = NULL;
+        size_t length = 0u;
+        int result = lantern_storage_load_block_bytes_for_root(storage, &roots[i], &data, &length);
+        if (result > 0)
+        {
+            continue;
+        }
+        size_t index = out_blocks->length;
+        if (result < 0 || lantern_signed_block_list_resize(out_blocks, index + 1u) != 0
+            || lantern_ssz_decode_signed_block(&out_blocks->blocks[index], data, length) != SSZ_SUCCESS
+            || verify_block_root(&out_blocks->blocks[index], &roots[i]) != 0)
+        {
+            free(data);
+            return -1;
+        }
+        free(data);
+    }
+    return 0;
+}
+
+static int scan_blocks(
+    struct storage_context *storage,
+    lantern_storage_block_visitor_fn visitor,
+    void *context)
+{
+    DIR *directory = opendir(storage->blocks_dir);
+    if (!directory)
+    {
+        return errno == ENOENT ? 0 : -1;
+    }
+    int result = 0;
+    struct dirent *entry;
+    while ((entry = readdir(directory)) != NULL)
+    {
+        LanternRoot root;
+        if (!filename_root(entry->d_name, &root))
+        {
+            continue;
+        }
+        char *path = join_path(storage->blocks_dir, entry->d_name);
+        uint8_t *data = NULL;
+        size_t length = 0u;
+        int read_result = path ? read_file(path, &data, &length) : -1;
+        free(path);
+        if (read_result > 0)
+        {
+            continue;
+        }
+        LanternSignedBlock block;
+        lantern_signed_block_init(&block);
+        if (read_result < 0
+            || lantern_ssz_decode_signed_block(&block, data, length) != SSZ_SUCCESS
+            || verify_block_root(&block, &root) != 0)
+        {
+            result = -1;
+        }
+        else
+        {
+            result = visitor(&block, &root, context);
+        }
+        lantern_signed_block_reset(&block);
+        free(data);
+        if (result != 0)
+        {
+            break;
+        }
+    }
+    closedir(directory);
+    return result;
+}
+
+int lantern_storage_iterate_blocks(
+    const struct lantern_storage *storage,
+    lantern_storage_block_visitor_fn visitor,
+    void *context)
+{
+    struct storage_context *backend = get_context(storage);
+    if (!backend || !visitor || pthread_rwlock_rdlock(&backend->lock) != 0)
+    {
+        return -1;
+    }
+    int result = scan_blocks(backend, visitor, context);
+    pthread_rwlock_unlock(&backend->lock);
+    return result;
+}
+
+static bool root_is_kept(
+    const LanternRoot *root,
+    const LanternRoot *keep_roots,
+    size_t keep_root_count)
+{
+    for (size_t i = 0; i < keep_root_count; ++i)
+    {
+        if (memcmp(root->bytes, keep_roots[i].bytes, LANTERN_ROOT_SIZE) == 0)
+        {
             return true;
         }
     }
     return false;
 }
 
-static int remove_storage_path(const char *path, int *pruned) {
-    if (!path || !pruned) {
+static int remove_root_file(const char *directory, const LanternRoot *root, int *count)
+{
+    char *path = root_path(directory, root);
+    if (!path)
+    {
         return -1;
     }
-    if (remove(path) != 0) {
-        return (errno == ENOENT) ? 0 : -1;
-    }
-    if (*pruned < INT_MAX) {
-        *pruned += 1;
-    }
-    return 0;
-}
-
-/**
- * Ensure all storage directories exist under `data_dir`.
- *
- * @param data_dir Base directory path.
- * @return 0 on success.
- * @return -1 on invalid parameters or filesystem errors.
- */
-int lantern_storage_prepare(const char *data_dir) {
-    if (!data_dir) {
-        return -1;
-    }
-
-    if (ensure_directory(data_dir) != 0) {
-        return -1;
-    }
-    const enum storage_dir_kind dirs[] = {
-        STORAGE_DIR_BLOCKS,
-        STORAGE_DIR_STATES,
-    };
-    for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); ++i) {
-        if (ensure_storage_dir(data_dir, dirs[i], NULL) != 0) {
+    int result = remove(path);
+    int remove_error = errno;
+    free(path);
+    if (result == 0)
+    {
+        if (*count == INT_MAX)
+        {
             return -1;
         }
+        ++*count;
+        return 0;
     }
-    return 0;
-}
-
-/**
- * Persist `state` under `data_dir` using SSZ (`state.ssz`).
- *
- * @param data_dir Base directory path.
- * @param state State to persist.
- * @return 0 on success.
- * @return -1 on invalid parameters, encoding failure, or filesystem errors.
- */
-int lantern_storage_save_state(const char *data_dir, const LanternState *state) {
-    if (!data_dir) {
-        return -1;
-    }
-    char *path = NULL;
-    int rc = join_path(data_dir, LANTERN_STORAGE_STATE_FILE, &path);
-    if (rc == 0) {
-        rc = storage_write_state_path(path, state);
-    }
-    free(path);
-    return rc;
-}
-
-/**
- * Load a persisted state from `data_dir/state.ssz`.
- *
- * On success, the contents of `state` are replaced.
- *
- * @param data_dir Base directory path.
- * @param state Output state (replaced on success).
- * @return 0 on success.
- * @return 1 if the state file is missing or empty.
- * @return -1 on invalid parameters or decode/validation errors.
- */
-int lantern_storage_load_state(const char *data_dir, LanternState *state) {
-    if (!data_dir || !state) {
-        return -1;
-    }
-
-    int rc = -1;
-    char *path = NULL;
-    uint8_t *data = NULL;
-    size_t data_len = 0;
-    LanternState decoded;
-    lantern_state_init(&decoded);
-
-    if (join_path(data_dir, LANTERN_STORAGE_STATE_FILE, &path) != 0) {
-        goto cleanup;
-    }
-    rc = read_file_buffer(path, &data, &data_len);
-    if (rc != 0) {
-        goto cleanup;
-    }
-    if (lantern_ssz_decode_state(&decoded, data, data_len) != SSZ_SUCCESS
-        || decoded.validator_count == 0) {
-        rc = -1;
-        goto cleanup;
-    }
-    lantern_state_reset(state);
-    *state = decoded;
-    decoded = (LanternState){0};
-    rc = 0;
-
-cleanup:
-    free(path);
-    free(data);
-    lantern_state_reset(&decoded);
-    return rc;
-}
-
-static bool block_is_synthetic_anchor_alias(const LanternSignedBlock *block) {
-    if (!block) {
-        return false;
-    }
-
-    /*
-     * Fork-choice bootstrap can persist the materialized synthetic anchor
-     * block under the hinted checkpoint root when no source block bytes are
-     * available. That root can differ from the block's computed hash_tree_root
-     * because the header's historical body_root is not reconstructible from the
-     * empty synthetic body.
-     *
-     * The persisted alias is only expected for the anchor-shaped block we
-     * synthesize locally: no attestations and no block-level proof.
-     */
-    const LanternBlockBody *body = &block->block.body;
-    if (body->attestations.length != 0 || block->proof.length != 0u) {
-        return false;
-    }
-    if (body->attestations.data != NULL || block->proof.data != NULL) {
-        return false;
-    }
-
-    return true;
-}
-
-static int storage_store_block_internal(
-    const char *data_dir,
-    const LanternSignedBlock *block,
-    const LanternRoot *root_override) {
-    if (!data_dir || !block) {
-        return -1;
-    }
-
-    int rc = -1;
-    char *block_path = NULL;
-    uint8_t *buffer = NULL;
-
-    LanternRoot root = {0};
-    if (root_override) {
-        root = *root_override;
-    } else if (lantern_hash_tree_root_block(&block->block, &root) != SSZ_SUCCESS) {
-        goto cleanup;
-    }
-    if (storage_root_file_path(
-            data_dir,
-            STORAGE_DIR_BLOCKS,
-            &root,
-            true,
-            &block_path,
-            NULL,
-            0)
-        != 0) {
-        goto cleanup;
-    }
-
-    struct stat st;
-    if (stat(block_path, &st) == 0) {
-        rc = 0;
-        goto cleanup;
-    }
-
-    size_t encoded_size = 0;
-    if (lantern_ssz_encode_signed_block(block, NULL, 0, &encoded_size) != SSZ_SUCCESS
-        || encoded_size == 0) {
-        lantern_log_warn(
-            "storage",
-            &(const struct lantern_log_metadata){0},
-            "store_block size estimate failed slot=%" PRIu64 " attestations=%zu proof_len=%zu",
-            block->block.slot,
-            block->block.body.attestations.length,
-            block->proof.length);
-        goto cleanup;
-    }
-    buffer = malloc(encoded_size);
-    if (!buffer) {
-        goto cleanup;
-    }
-    size_t written_size = 0;
-    const ssz_error_t encode_rc = lantern_ssz_encode_signed_block(block, buffer, encoded_size, &written_size);
-    if (encode_rc != 0
-        || written_size == 0
-        || written_size > encoded_size) {
-        lantern_log_warn(
-            "storage",
-            &(const struct lantern_log_metadata){0},
-            "store_block encode failed slot=%" PRIu64 " rc=%d estimated=%zu written=%zu",
-            block->block.slot,
-            encode_rc,
-            encoded_size,
-            written_size);
-        goto cleanup;
-    }
-
-    rc = write_atomic_file(block_path, buffer, written_size);
-
-cleanup:
-    free(buffer);
-    free(block_path);
-    return rc;
-}
-
-/**
- * Store a signed block under `data_dir/blocks/<root>.ssz`.
- *
- * The operation is idempotent: if the block already exists on disk, this
- * function returns success without modifying it.
- *
- * @param data_dir Base directory path.
- * @param block Block to persist.
- * @return 0 on success.
- * @return -1 on invalid parameters, encoding failure, or filesystem errors.
- */
-int lantern_storage_store_block(const char *data_dir, const LanternSignedBlock *block) {
-    return storage_store_block_internal(data_dir, block, NULL);
-}
-
-int lantern_storage_store_block_for_root(
-    const char *data_dir,
-    const LanternRoot *root,
-    const LanternSignedBlock *block) {
-    if (!root) {
-        return -1;
-    }
-    return storage_store_block_internal(data_dir, block, root);
-}
-
-/**
- * Persist `state` under `data_dir/states` using the given `root` as filename.
- *
- * @param data_dir Base directory path.
- * @param root Root used to build the on-disk filename.
- * @param state State to persist.
- * @return 0 on success.
- * @return -1 on invalid parameters, encoding failure, or filesystem errors.
- */
-int lantern_storage_store_state_for_root(
-    const char *data_dir,
-    const LanternRoot *root,
-    const LanternState *state) {
-    if (!data_dir || !root || !state || state->validator_count == 0) {
-        return -1;
-    }
-
-    char *state_path = NULL;
-    int rc = storage_root_file_path(
-        data_dir,
-        STORAGE_DIR_STATES,
-        root,
-        true,
-        &state_path,
-        NULL,
-        0);
-    if (rc == 0) {
-        rc = storage_write_state_path(state_path, state);
-    }
-    free(state_path);
-    return rc;
-}
-
-/**
- * Load the raw persisted SSZ bytes for a state stored under `data_dir/states`.
- *
- * @param data_dir Base directory path.
- * @param root Root used to build the on-disk filename.
- * @param out_data Output buffer (caller must free) on success.
- * @param out_len Output length on success.
- * @return 0 on success.
- * @return 1 if the state file is missing or empty.
- * @return -1 on invalid parameters or filesystem errors.
- */
-int lantern_storage_load_state_bytes_for_root(
-    const char *data_dir,
-    const LanternRoot *root,
-    uint8_t **out_data,
-    size_t *out_len) {
-    return storage_load_root_bytes(data_dir, STORAGE_DIR_STATES, root, out_data, out_len);
-}
-
-/**
- * Load the raw persisted SSZ bytes for a block stored under `data_dir/blocks`.
- *
- * @param data_dir Base directory path.
- * @param root Root used to build the on-disk filename.
- * @param out_data Output buffer (caller must free) on success.
- * @param out_len Output length on success.
- * @return 0 on success.
- * @return 1 if the block file is missing or empty.
- * @return -1 on invalid parameters or filesystem errors.
- */
-int lantern_storage_load_block_bytes_for_root(
-    const char *data_dir,
-    const LanternRoot *root,
-    uint8_t **out_data,
-    size_t *out_len) {
-    return storage_load_root_bytes(data_dir, STORAGE_DIR_BLOCKS, root, out_data, out_len);
+    return remove_error == ENOENT ? 0 : -1;
 }
 
 struct prune_context {
-    const char *data_dir;
+    struct storage_context *storage;
     uint64_t slot;
     const LanternRoot *keep_roots;
     size_t keep_root_count;
-    int pruned;
+    int count;
 };
 
-static int prune_block_state_pair(
-    const LanternSignedBlock *block,
-    const LanternRoot *root,
-    void *context) {
+static int prune_block(const LanternSignedBlock *block, const LanternRoot *root, void *context)
+{
     struct prune_context *prune = context;
-    if (!block || !root || !prune) {
-        return -1;
-    }
     if (block->block.slot >= prune->slot
-        || storage_root_is_kept(root, prune->keep_roots, prune->keep_root_count)) {
+        || root_is_kept(root, prune->keep_roots, prune->keep_root_count))
+    {
         return 0;
     }
-
-    const enum storage_dir_kind dirs[] = {STORAGE_DIR_STATES, STORAGE_DIR_BLOCKS};
-    for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); ++i) {
-        char *path = NULL;
-        if (storage_root_file_path(
-                prune->data_dir,
-                dirs[i],
-                root,
-                false,
-                &path,
-                NULL,
-                0)
-                != 0
-            || remove_storage_path(path, &prune->pruned) != 0) {
-            free(path);
-            return -1;
-        }
-        free(path);
-    }
-    return 0;
+    return remove_root_file(prune->storage->states_dir, root, &prune->count) == 0
+            && remove_root_file(prune->storage->blocks_dir, root, &prune->count) == 0
+        ? 0
+        : -1;
 }
 
-/**
- * Remove persisted blocks/states strictly before `slot`, preserving keep_roots.
- *
- * Mirrors leanSpec's Database.prune_before_slot(): finalized advancement makes
- * earlier block/state entries unnecessary, except for roots the caller names
- * explicitly, such as the finalized block root itself.
- *
- * @param data_dir Base storage directory.
- * @param slot Prune entries with slot < this value.
- * @param keep_roots Roots to preserve regardless of slot.
- * @param keep_root_count Number of entries in keep_roots.
- * @return Non-negative count of removed files on success, -1 on error.
- */
 int lantern_storage_prune_before_slot(
-    const char *data_dir,
+    const struct lantern_storage *storage,
     uint64_t slot,
     const LanternRoot *keep_roots,
-    size_t keep_root_count) {
-    if (!data_dir || (!keep_roots && keep_root_count > 0)) {
+    size_t keep_root_count)
+{
+    struct storage_context *backend = get_context(storage);
+    if (!backend || (!keep_roots && keep_root_count > 0u)
+        || pthread_rwlock_wrlock(&backend->lock) != 0)
+    {
         return -1;
     }
-
     struct prune_context context = {
-        .data_dir = data_dir,
+        .storage = backend,
         .slot = slot,
         .keep_roots = keep_roots,
         .keep_root_count = keep_root_count,
     };
-    int rc = lantern_storage_iterate_blocks(data_dir, prune_block_state_pair, &context);
-    if (rc < 0) {
-        return -1;
-    }
-    return context.pruned;
-}
-
-/**
- * Collect signed blocks from disk that match the given set of roots.
- *
- * For each root in `roots`, looks up `data_dir/blocks/<hex>.ssz`, decodes
- * the block, and appends it to `out_blocks`.  Missing blocks are silently
- * skipped.
- *
- * @param data_dir   Base storage directory.
- * @param roots      Array of block roots to look up.
- * @param root_count Number of entries in `roots`.
- * @param out_blocks Output collection (resized to 0 on entry, filled on success).
- * @return 0 on success, -1 on error.
- */
-int lantern_storage_collect_blocks(
-    const char *data_dir,
-    const LanternRoot *roots,
-    size_t root_count,
-    LanternSignedBlockList *out_blocks) {
-    if (!data_dir || (!roots && root_count > 0) || !out_blocks) {
-        return -1;
-    }
-    if (lantern_signed_block_list_resize(out_blocks, 0) != 0) {
-        return -1;
-    }
-
-    int rc = -1;
-    const struct lantern_log_metadata meta = {0};
-    for (size_t i = 0; i < root_count; ++i) {
-        char root_hex[2u * LANTERN_ROOT_SIZE + 1u];
-        char *block_path = NULL;
-        if (storage_root_file_path(
-                data_dir,
-                STORAGE_DIR_BLOCKS,
-                &roots[i],
-                false,
-                &block_path,
-                root_hex,
-                sizeof(root_hex))
-            != 0) {
-            goto cleanup;
-        }
-        lantern_log_trace(
-            "storage",
-            &meta,
-            "collect_blocks search root=%s path=%s",
-            root_hex,
-            block_path ? block_path : "null");
-
-        uint8_t *data = NULL;
-        size_t data_len = 0;
-        const int read_rc = read_file_buffer(block_path, &data, &data_len);
-        free(block_path);
-        if (read_rc != 0) {
-            lantern_log_debug(
-                "storage",
-                &meta,
-                "collect_blocks miss root=%s rc=%d",
-                root_hex,
-                read_rc);
-            continue;
-        }
-
-        const size_t current = out_blocks->length;
-        if (lantern_signed_block_list_resize(out_blocks, current + 1) != 0) {
-            free(data);
-            goto cleanup;
-        }
-        LanternSignedBlock *dest = &out_blocks->blocks[current];
-        if (lantern_ssz_decode_signed_block(dest, data, data_len) != SSZ_SUCCESS) {
-            free(data);
-            goto cleanup;
-        }
-        LanternRoot computed;
-        if (lantern_hash_tree_root_block(&dest->block, &computed) != SSZ_SUCCESS) {
-            free(data);
-            goto cleanup;
-        }
-        if (memcmp(computed.bytes, roots[i].bytes, LANTERN_ROOT_SIZE) != 0) {
-            if (!block_is_synthetic_anchor_alias(dest)) {
-                free(data);
-                goto cleanup;
-            }
-            char computed_hex[2u * LANTERN_ROOT_SIZE + 1u];
-            if (lantern_bytes_to_hex(computed.bytes, LANTERN_ROOT_SIZE, computed_hex, sizeof(computed_hex), 0) != 0) {
-                computed_hex[0] = '\0';
-            }
-            lantern_log_warn(
-                "storage",
-                &meta,
-                "collect_blocks accepted synthetic anchor alias requested=%s computed=%s",
-                root_hex,
-                computed_hex[0] ? computed_hex : "unknown");
-        }
-        lantern_log_trace(
-            "storage",
-            &meta,
-            "collect_blocks loaded root=%s slot=%" PRIu64 " attestations=%zu",
-            root_hex,
-            dest->block.slot,
-            dest->block.body.attestations.length);
-        free(data);
-    }
-    rc = 0;
-
-cleanup:
-    return rc;
-}
-
-/**
- * Iterate over every persisted block in the blocks directory.
- *
- * Opens `data_dir/blocks/`, reads each `.ssz` file, decodes the signed
- * block, derives its canonical root key from filename, and calls `visitor` with the block,
- * root, and caller-supplied `context`.  Iteration stops early if the
- * visitor returns non-zero (its return value is propagated).
- *
- * @param data_dir Base storage directory.
- * @param visitor  Callback invoked for each block.
- * @param context  Opaque pointer forwarded to the visitor.
- * @return 0 on success (all blocks visited).
- * @return 1 if the blocks directory does not exist.
- * @return -1 on I/O or decoding errors; positive visitor return values
- *         are forwarded as-is.
- */
-int lantern_storage_iterate_blocks(
-    const char *data_dir,
-    lantern_storage_block_visitor_fn visitor,
-    void *context) {
-    if (!data_dir || !visitor) {
-        return -1;
-    }
-
-    int rc = -1;
-    char *blocks_dir = NULL;
-    DIR *dir = NULL;
-
-    if (storage_dir_path(data_dir, STORAGE_DIR_BLOCKS, &blocks_dir) != 0) {
-        goto cleanup;
-    }
-    dir = opendir(blocks_dir);
-    if (!dir) {
-        rc = (errno == ENOENT) ? 1 : -1;
-        goto cleanup;
-    }
-
-    rc = 0;
-    const struct lantern_log_metadata meta = {0};
-    struct dirent *entry = NULL;
-    while ((entry = readdir(dir)) != NULL) {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
-        const size_t len = strlen(entry->d_name);
-        if (len < 5 || strcmp(entry->d_name + len - 4, ".ssz") != 0) {
-            continue;
-        }
-        char *block_path = NULL;
-        if (join_path(blocks_dir, entry->d_name, &block_path) != 0) {
-            rc = -1;
-            break;
-        }
-        uint8_t *data = NULL;
-        size_t data_len = 0;
-        const int read_rc = read_file_buffer(block_path, &data, &data_len);
-        free(block_path);
-        if (read_rc != 0) {
-            if (read_rc == 1) {
-                continue;
-            }
-            rc = -1;
-            break;
-        }
-        LanternSignedBlock block;
-        lantern_signed_block_init(&block);
-        if (lantern_ssz_decode_signed_block(&block, data, data_len) != SSZ_SUCCESS) {
-            lantern_signed_block_reset(&block);
-            free(data);
-            rc = -1;
-            break;
-        }
-        LanternRoot computed_root;
-        if (lantern_hash_tree_root_block(&block.block, &computed_root) != SSZ_SUCCESS) {
-            lantern_signed_block_reset(&block);
-            free(data);
-            rc = -1;
-            break;
-        }
-        LanternRoot root_from_filename = {0};
-        bool have_root_from_filename = false;
-        if (len == ((2u * LANTERN_ROOT_SIZE) + 4u)) {
-            char filename_hex[(2u * LANTERN_ROOT_SIZE) + 1u];
-            memcpy(filename_hex, entry->d_name, 2u * LANTERN_ROOT_SIZE);
-            filename_hex[2u * LANTERN_ROOT_SIZE] = '\0';
-            have_root_from_filename =
-                lantern_hex_decode(filename_hex, root_from_filename.bytes, LANTERN_ROOT_SIZE)
-                == 0;
-        }
-        const LanternRoot *root_for_visitor = &computed_root;
-        if (have_root_from_filename) {
-            root_for_visitor = &root_from_filename;
-            if (memcmp(computed_root.bytes, root_from_filename.bytes, LANTERN_ROOT_SIZE) != 0) {
-                if (!block_is_synthetic_anchor_alias(&block)) {
-                    lantern_signed_block_reset(&block);
-                    free(data);
-                    rc = -1;
-                    break;
-                }
-                char computed_hex[2u * LANTERN_ROOT_SIZE + 1u];
-                char filename_hex[2u * LANTERN_ROOT_SIZE + 1u];
-                if (lantern_bytes_to_hex(
-                        computed_root.bytes,
-                        LANTERN_ROOT_SIZE,
-                        computed_hex,
-                        sizeof(computed_hex),
-                        0)
-                    != 0) {
-                    computed_hex[0] = '\0';
-                }
-                if (lantern_bytes_to_hex(
-                        root_from_filename.bytes,
-                        LANTERN_ROOT_SIZE,
-                        filename_hex,
-                        sizeof(filename_hex),
-                        0)
-                    != 0) {
-                    filename_hex[0] = '\0';
-                }
-                lantern_log_warn(
-                    "storage",
-                    &meta,
-                    "iterate_blocks accepted synthetic anchor alias filename_root=%s computed=%s",
-                    filename_hex[0] ? filename_hex : "unknown",
-                    computed_hex[0] ? computed_hex : "unknown");
-            }
-        }
-        const int visit_rc = visitor(&block, root_for_visitor, context);
-        lantern_signed_block_reset(&block);
-        free(data);
-        if (visit_rc != 0) {
-            rc = visit_rc;
-            break;
-        }
-    }
-
-cleanup:
-    if (dir) {
-        closedir(dir);
-    }
-    free(blocks_dir);
-    return rc;
+    int result = scan_blocks(backend, prune_block, &context);
+    pthread_rwlock_unlock(&backend->lock);
+    return result == 0 ? context.count : -1;
 }

--- a/tests/integration/consensus_fixture_runner.c
+++ b/tests/integration/consensus_fixture_runner.c
@@ -408,14 +408,13 @@ static int process_gossip_attestation_step(
     if (lantern_hash_tree_root_attestation_data(&vote.data.data, &data_root) != SSZ_SUCCESS) {
         return -1;
     }
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
     if (!validate_attestation_constraints(
             fork_choice, &vote.data.data, mapping, mapping_count)
         || vote.data.validator_id >= validator_count) {
         return -1;
     }
-    const uint8_t *pubkey = lantern_state_validator_attestation_pubkey(
-        state, (size_t)vote.data.validator_id);
+    const uint8_t *pubkey = state->validators[vote.data.validator_id].attestation_pubkey;
     if (!pubkey
         || !lantern_signature_verify(
             pubkey,
@@ -478,7 +477,7 @@ static int process_gossip_aggregated_attestation_step(
     if (!validate_attestation_constraints(fork_choice, &data, mapping, mapping_count)) {
         goto cleanup;
     }
-    size_t validator_count = lantern_state_validator_count(state);
+    size_t validator_count = state->validators ? state->validator_count : 0u;
     if (proof.participants.bit_length > validator_count) {
         goto cleanup;
     }
@@ -491,7 +490,7 @@ static int process_gossip_aggregated_attestation_step(
         if (!lantern_bitlist_get(&proof.participants, i)) {
             continue;
         }
-        pubkeys[pubkey_count] = lantern_state_validator_attestation_pubkey(state, i);
+        pubkeys[pubkey_count] = state->validators[i].attestation_pubkey;
         if (!pubkeys[pubkey_count]) {
             free(pubkeys);
             goto cleanup;

--- a/tests/support/fixture_loader.c
+++ b/tests/support/fixture_loader.c
@@ -16,6 +16,7 @@
 #include "lantern/support/strings.h"
 #include "pq-bindings-c-rust.h"
 #include "state_store_adapter.h"
+#include "validator_registry.h"
 
 #define JSON_INITIAL_TOKENS 256
 #define LANTERN_XMSS_FP_BYTES 4u
@@ -1382,7 +1383,7 @@ int lantern_fixture_parse_anchor_state(
         free(proposal_pubkeys);
         return -1;
     }
-    if (lantern_state_set_validator_pubkeys_dual(
+    if (lantern_test_state_set_validator_pubkeys_dual(
             state,
             attestation_pubkeys,
             proposal_pubkeys,

--- a/tests/support/storage_cleanup.h
+++ b/tests/support/storage_cleanup.h
@@ -1,0 +1,74 @@
+#ifndef LANTERN_TEST_STORAGE_CLEANUP_H
+#define LANTERN_TEST_STORAGE_CLEANUP_H
+
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int lantern_test_remove_file(const char *path)
+{
+    return unlink(path) == 0 || errno == ENOENT ? 0 : -1;
+}
+
+static int lantern_test_remove_storage_dir(const char *directory)
+{
+    if (!directory)
+    {
+        return -1;
+    }
+    static const char *const root_files[] = {"state.ssz", "state.ssz.tmp"};
+    char path[PATH_MAX];
+    for (size_t i = 0; i < sizeof(root_files) / sizeof(root_files[0]); ++i)
+    {
+        int written = snprintf(path, sizeof(path), "%s/%s", directory, root_files[i]);
+        if (written <= 0 || (size_t)written >= sizeof(path)
+            || lantern_test_remove_file(path) != 0)
+        {
+            return -1;
+        }
+    }
+    static const char *const namespaces[] = {"blocks", "states"};
+    for (size_t i = 0; i < sizeof(namespaces) / sizeof(namespaces[0]); ++i)
+    {
+        int written = snprintf(path, sizeof(path), "%s/%s", directory, namespaces[i]);
+        if (written <= 0 || (size_t)written >= sizeof(path))
+        {
+            return -1;
+        }
+        DIR *stream = opendir(path);
+        if (!stream)
+        {
+            if (errno == ENOENT)
+            {
+                continue;
+            }
+            return -1;
+        }
+        struct dirent *entry;
+        while ((entry = readdir(stream)) != NULL)
+        {
+            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            {
+                continue;
+            }
+            char child[PATH_MAX];
+            written = snprintf(child, sizeof(child), "%s/%s", path, entry->d_name);
+            if (written <= 0 || (size_t)written >= sizeof(child)
+                || lantern_test_remove_file(child) != 0)
+            {
+                closedir(stream);
+                return -1;
+            }
+        }
+        if (closedir(stream) != 0 || rmdir(path) != 0)
+        {
+            return -1;
+        }
+    }
+    return rmdir(directory);
+}
+
+#endif /* LANTERN_TEST_STORAGE_CLEANUP_H */

--- a/tests/support/validator_registry.h
+++ b/tests/support/validator_registry.h
@@ -1,0 +1,40 @@
+#ifndef LANTERN_TESTS_VALIDATOR_REGISTRY_H
+#define LANTERN_TESTS_VALIDATOR_REGISTRY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "lantern/consensus/state.h"
+
+static inline int lantern_test_state_set_validator_pubkeys_dual(
+    LanternState *state,
+    const uint8_t *attestation_pubkeys,
+    const uint8_t *proposal_pubkeys,
+    size_t count) {
+    if (!state || count > LANTERN_VALIDATOR_REGISTRY_LIMIT
+        || count != state->validator_count
+        || (count > 0u && (!state->validators || !attestation_pubkeys || !proposal_pubkeys))) {
+        return -1;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        memcpy(
+            state->validators[i].attestation_pubkey,
+            attestation_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
+            LANTERN_VALIDATOR_PUBKEY_SIZE);
+        memcpy(
+            state->validators[i].proposal_pubkey,
+            proposal_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
+            LANTERN_VALIDATOR_PUBKEY_SIZE);
+    }
+    return 0;
+}
+
+static inline int lantern_test_state_set_validator_pubkeys(
+    LanternState *state,
+    const uint8_t *pubkeys,
+    size_t count) {
+    return lantern_test_state_set_validator_pubkeys_dual(state, pubkeys, pubkeys, count);
+}
+
+#endif /* LANTERN_TESTS_VALIDATOR_REGISTRY_H */

--- a/tests/unit/client_test_helpers.c
+++ b/tests/unit/client_test_helpers.c
@@ -16,6 +16,7 @@
 #include "lantern/crypto/xmss.h"
 #include "lantern/support/time.h"
 #include "lantern/support/strings.h"
+#include "../support/validator_registry.h"
 
 static int client_test_load_fixture_genesis_time(uint64_t *out_time);
 
@@ -471,7 +472,7 @@ static int client_test_setup_vote_validation_client_common(
             LANTERN_VALIDATOR_PUBKEY_SIZE);
     }
 
-    if (lantern_state_set_validator_pubkeys_dual(
+    if (lantern_test_state_set_validator_pubkeys_dual(
             &client->state,
             serialized_pubkeys,
             serialized_pubkeys,
@@ -480,7 +481,7 @@ static int client_test_setup_vote_validation_client_common(
         fprintf(stderr, "failed to set dual validator pubkeys for vote test\n");
         goto finish;
     }
-    const uint8_t *stored_pub = lantern_state_validator_attestation_pubkey(&client->state, 0);
+    const uint8_t *stored_pub = client->state.validators[0].attestation_pubkey;
     if (!stored_pub) {
         fprintf(stderr, "stored validator attestation pubkey missing after load\n");
         goto finish;

--- a/tests/unit/test_checkpoint_sync_api.c
+++ b/tests/unit/test_checkpoint_sync_api.c
@@ -17,13 +17,17 @@
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/state.h"
 #include "lantern/consensus/ssz.h"
+#include "lantern/http/client.h"
 #include "lantern/http/server.h"
 #include "lantern/storage/storage.h"
 #include "lantern/support/strings.h"
+#include "../support/storage_cleanup.h"
+#include "../support/validator_registry.h"
 
 struct checkpoint_fixture
 {
     char *data_dir;
+    struct lantern_storage storage;
     LanternState state;
     LanternRoot root;
     uint8_t *ssz_bytes;
@@ -70,32 +74,6 @@ static void expect_true(bool value, const char *label)
     }
 }
 
-static void cleanup_path(const char *path)
-{
-    if (!path)
-    {
-        return;
-    }
-    if (unlink(path) != 0 && errno != ENOENT)
-    {
-        fprintf(stderr, "failed to remove %s: %s\n", path, strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-}
-
-static void cleanup_dir(const char *path)
-{
-    if (!path)
-    {
-        return;
-    }
-    if (rmdir(path) != 0 && errno != ENOENT)
-    {
-        fprintf(stderr, "failed to remove dir %s: %s\n", path, strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-}
-
 static int build_checkpoint_fixture(struct checkpoint_fixture *fixture)
 {
     if (!fixture)
@@ -117,6 +95,10 @@ static int build_checkpoint_fixture(struct checkpoint_fixture *fixture)
         perror("strdup");
         return 1;
     }
+    if (lantern_storage_open(&fixture->storage, fixture->data_dir) != 0)
+    {
+        return 1;
+    }
 
     lantern_state_init(&fixture->state);
     if (lantern_state_generate_genesis(&fixture->state, 1234u, 4u) != 0)
@@ -130,7 +112,7 @@ static int build_checkpoint_fixture(struct checkpoint_fixture *fixture)
     {
         pubkeys[i] = (uint8_t)(0x20 + (i & 0x3Fu));
     }
-    if (lantern_state_set_validator_pubkeys(&fixture->state, pubkeys, 4u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&fixture->state, pubkeys, 4u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys\n");
         return 1;
@@ -140,14 +122,14 @@ static int build_checkpoint_fixture(struct checkpoint_fixture *fixture)
     fixture->state.latest_finalized.root = fixture->root;
     fixture->state.latest_finalized.slot = 0;
 
-    if (lantern_storage_store_state_for_root(fixture->data_dir, &fixture->root, &fixture->state) != 0)
+    if (lantern_storage_store_state_for_root(&fixture->storage, &fixture->root, &fixture->state) != 0)
     {
         fprintf(stderr, "failed to store state for root\n");
         return 1;
     }
 
     if (lantern_storage_load_state_bytes_for_root(
-            fixture->data_dir,
+            &fixture->storage,
             &fixture->root,
             &fixture->ssz_bytes,
             &fixture->ssz_len)
@@ -227,58 +209,12 @@ static void cleanup_checkpoint_fixture(struct checkpoint_fixture *fixture)
 
     if (fixture->data_dir)
     {
-        char root_hex[2u * LANTERN_ROOT_SIZE + 1u];
-        if (lantern_bytes_to_hex(
-                fixture->root.bytes,
-                LANTERN_ROOT_SIZE,
-                root_hex,
-                sizeof(root_hex),
-                0)
-            == 0)
+        lantern_storage_close(&fixture->storage);
+        if (lantern_test_remove_storage_dir(fixture->data_dir) != 0)
         {
-            char states_dir[PATH_MAX];
-            int dir_written = snprintf(states_dir, sizeof(states_dir), "%s/states", fixture->data_dir);
-            if (dir_written > 0 && (size_t)dir_written < sizeof(states_dir))
-            {
-                char state_path[PATH_MAX];
-                char meta_path[PATH_MAX];
-                int state_written = snprintf(state_path, sizeof(state_path), "%s/%s.ssz", states_dir, root_hex);
-                int meta_written = snprintf(meta_path, sizeof(meta_path), "%s/%s.meta", states_dir, root_hex);
-                if (state_written > 0 && (size_t)state_written < sizeof(state_path))
-                {
-                    cleanup_path(state_path);
-                }
-                if (meta_written > 0 && (size_t)meta_written < sizeof(meta_path))
-                {
-                    cleanup_path(meta_path);
-                }
-                cleanup_dir(states_dir);
-            }
-
-            char block_root_hex[2u * LANTERN_ROOT_SIZE + 1u];
-            if (lantern_bytes_to_hex(
-                    fixture->block_root.bytes,
-                    LANTERN_ROOT_SIZE,
-                    block_root_hex,
-                    sizeof(block_root_hex),
-                    0)
-                == 0)
-            {
-                char blocks_dir[PATH_MAX];
-                int dir_written = snprintf(blocks_dir, sizeof(blocks_dir), "%s/blocks", fixture->data_dir);
-                if (dir_written > 0 && (size_t)dir_written < sizeof(blocks_dir))
-                {
-                    char block_path[PATH_MAX];
-                    int block_written = snprintf(block_path, sizeof(block_path), "%s/%s.ssz", blocks_dir, block_root_hex);
-                    if (block_written > 0 && (size_t)block_written < sizeof(block_path))
-                    {
-                        cleanup_path(block_path);
-                    }
-                    cleanup_dir(blocks_dir);
-                }
-            }
+            fprintf(stderr, "failed to remove storage dir %s: %s\n", fixture->data_dir, strerror(errno));
+            exit(EXIT_FAILURE);
         }
-        cleanup_dir(fixture->data_dir);
         free(fixture->data_dir);
         fixture->data_dir = NULL;
     }
@@ -730,7 +666,7 @@ static int test_storage_block_bytes(void)
         "decode block fixture");
     expect_zero(
         lantern_storage_store_block_for_root(
-            fixture.data_dir,
+            &fixture.storage,
             &fixture.block_root,
             &block),
         "store block");
@@ -740,7 +676,7 @@ static int test_storage_block_bytes(void)
     size_t loaded_len = 0;
     expect_zero(
         lantern_storage_load_block_bytes_for_root(
-            fixture.data_dir,
+            &fixture.storage,
             &fixture.block_root,
             &loaded,
             &loaded_len),
@@ -1141,6 +1077,61 @@ static int test_health_endpoint(void)
     return 0;
 }
 
+static int test_http_client(void)
+{
+    struct lantern_http_fetch_result result = {0};
+    expect_true(
+        lantern_http_get_bytes("http://", NULL, 1024u, &result) == LANTERN_HTTP_CLIENT_ERR,
+        "HTTP client initializes before libevent");
+    struct lantern_http_server server;
+    lantern_http_server_init(&server);
+    struct lantern_http_server_config config = {0};
+    if (lantern_http_server_start(&server, &config) != 0)
+    {
+        return 1;
+    }
+    struct sockaddr_in address;
+    socklen_t address_len = sizeof(address);
+    if (getsockname(
+            server.core.listen_fd,
+            (struct sockaddr *)&address,
+            &address_len)
+        != 0)
+    {
+        lantern_http_server_stop(&server);
+        return 1;
+    }
+    char url[128];
+    snprintf(
+        url,
+        sizeof(url),
+        "http://127.0.0.1:%u/lean/v0/health",
+        (unsigned int)ntohs(address.sin_port));
+    expect_zero(
+        lantern_http_get_bytes(url, "application/json", 1024u, &result),
+        "HTTP client fetch");
+    expect_true(result.status_code == 200 && result.body_len > 0u, "HTTP client response");
+    lantern_http_fetch_result_reset(&result);
+
+    expect_true(
+        lantern_http_get_bytes(url, "application/json", 2u, &result)
+            == LANTERN_HTTP_CLIENT_ERR,
+        "HTTP client response limit");
+    snprintf(
+        url,
+        sizeof(url),
+        "http://127.0.0.1:%u/unknown",
+        (unsigned int)ntohs(address.sin_port));
+    expect_true(
+        lantern_http_get_bytes(url, NULL, 1024u, &result)
+            == LANTERN_HTTP_CLIENT_STATUS_ERROR
+            && result.status_code == 404,
+        "HTTP client status response");
+    lantern_http_fetch_result_reset(&result);
+    lantern_http_server_stop(&server);
+    return 0;
+}
+
 static int test_unknown_route_endpoint(void)
 {
     struct lantern_http_server server;
@@ -1204,6 +1195,10 @@ static int test_unknown_route_endpoint(void)
 
 int main(void)
 {
+    if (test_http_client() != 0)
+    {
+        return 1;
+    }
     if (test_storage_state_bytes() != 0)
     {
         return 1;

--- a/tests/unit/test_client_gossip.c
+++ b/tests/unit/test_client_gossip.c
@@ -198,7 +198,9 @@ static int sign_single_participant_aggregated_attestation(
         return -1;
     }
 
-    const uint8_t *validator_pubkey = lantern_state_validator_attestation_pubkey(&client->state, 0u);
+    const uint8_t *validator_pubkey = client->state.validators
+        ? client->state.validators[0].attestation_pubkey
+        : NULL;
     if (!validator_pubkey) {
         lantern_signed_aggregated_attestation_reset(out_attestation);
         return -1;
@@ -634,7 +636,9 @@ static int test_gossip_aggregated_attestation_rejects_invalid_proof(void)
         fprintf(stderr, "aggregated attestation proof unexpectedly empty\n");
         goto cleanup_attestation;
     }
-    validator_pubkey = lantern_state_validator_attestation_pubkey(&client.state, 0u);
+    validator_pubkey = client.state.validators
+        ? client.state.validators[0].attestation_pubkey
+        : NULL;
     if (!validator_pubkey) {
         fprintf(stderr, "aggregated attestation validator pubkey missing\n");
         goto cleanup_attestation;

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -35,7 +35,7 @@ static int enable_signature_verification_keys(
     if (!client || !out_validators) {
         return -1;
     }
-    size_t validator_count = lantern_state_validator_count(&client->state);
+    size_t validator_count = client->state.validators ? client->state.validator_count : 0u;
     if (validator_count == 0) {
         return -1;
     }
@@ -47,12 +47,8 @@ static int enable_signature_verification_keys(
         return -1;
     }
     for (size_t i = 0; i < validator_count; ++i) {
-        const uint8_t *attestation = lantern_state_validator_attestation_pubkey(&client->state, i);
-        const uint8_t *proposal = lantern_state_validator_proposal_pubkey(&client->state, i);
-        if (!attestation || !proposal) {
-            free(validators);
-            return -1;
-        }
+        const uint8_t *attestation = client->state.validators[i].attestation_pubkey;
+        const uint8_t *proposal = client->state.validators[i].proposal_pubkey;
         memcpy(validators[i].attestation_pubkey, attestation, LANTERN_VALIDATOR_PUBKEY_SIZE);
         memcpy(validators[i].proposal_pubkey, proposal, LANTERN_VALIDATOR_PUBKEY_SIZE);
         validators[i].index = i;
@@ -96,11 +92,10 @@ static int build_devnet5_block_proof(
     lantern_bitlist_init(&proposer_participants);
 
     size_t proposer_index = (size_t)block->block.proposer_index;
-    const uint8_t *proposer_pubkey =
-        lantern_state_validator_proposal_pubkey(state, proposer_index);
-    if (!proposer_pubkey) {
+    if (!state->validators || proposer_index >= state->validator_count) {
         goto cleanup;
     }
+    const uint8_t *proposer_pubkey = state->validators[proposer_index].proposal_pubkey;
     if (lantern_bitlist_resize(&proposer_participants, proposer_index + 1u) != 0
         || lantern_bitlist_set(&proposer_participants, proposer_index, true) != 0) {
         goto cleanup;
@@ -168,7 +163,8 @@ static int setup_block_signature_fixture(
         sizeof(fixture->data_dir_template),
         "/tmp/lantern_block_sig_XXXXXX");
     fixture->client.data_dir = mkdtemp(fixture->data_dir_template);
-    if (!fixture->client.data_dir) {
+    if (!fixture->client.data_dir
+        || lantern_storage_open(&fixture->client.storage, fixture->client.data_dir) != 0) {
         disable_signature_verification_keys(&fixture->client, &fixture->validators);
         client_test_teardown_vote_validation_client(&fixture->client, fixture->pub, fixture->secret);
         fixture->pub = NULL;
@@ -184,6 +180,7 @@ static void teardown_block_signature_fixture(struct block_signature_fixture *fix
         return;
     }
     disable_signature_verification_keys(&fixture->client, &fixture->validators);
+    lantern_storage_close(&fixture->client.storage);
     if (fixture->client.data_dir && fixture->client.data_dir[0] != '\0') {
         char cleanup_cmd[TEST_TEMP_PATH_CAPACITY + 16];
         int written = snprintf(cleanup_cmd, sizeof(cleanup_cmd), "rm -rf %s", fixture->client.data_dir);
@@ -329,7 +326,7 @@ static int build_signed_block_for_import(
         goto cleanup;
     }
     if (lantern_storage_store_state_for_root(
-            fixture->client.data_dir,
+            &fixture->client.storage,
             &out_block->block.parent_root,
             &fixture->client.state)
         != 0) {
@@ -379,10 +376,10 @@ static int build_signed_block_for_import(
             || lantern_bitlist_set(&proof->participants, 0u, true) != 0) {
             goto cleanup;
         }
-        const uint8_t *pubkey = lantern_state_validator_attestation_pubkey(&fixture->client.state, 0u);
-        if (!pubkey) {
+        if (!fixture->client.state.validators) {
             goto cleanup;
         }
+        const uint8_t *pubkey = fixture->client.state.validators[0].attestation_pubkey;
         LanternRoot attestation_root;
         if (lantern_hash_tree_root_attestation_data(&attestation->data, &attestation_root) != SSZ_SUCCESS) {
             goto cleanup;
@@ -468,7 +465,7 @@ static int persist_post_state_for_block(
     if (lantern_state_clone(&fixture->client.state, &post_state) == 0
         && lantern_state_transition(&post_state, block) == 0
         && lantern_storage_store_state_for_root(
-               fixture->client.data_dir,
+               &fixture->client.storage,
                block_root,
                &post_state)
             == 0) {
@@ -583,10 +580,10 @@ static int resign_matching_block_attestations(
         goto cleanup;
     }
 
-    const uint8_t *pubkey = lantern_state_validator_attestation_pubkey(&fixture->client.state, 0u);
-    if (!pubkey) {
+    if (!fixture->client.state.validators) {
         goto cleanup;
     }
+    const uint8_t *pubkey = fixture->client.state.validators[0].attestation_pubkey;
     LanternRoot attestation_root;
     if (lantern_hash_tree_root_attestation_data(&attestation->data, &attestation_root) != SSZ_SUCCESS) {
         goto cleanup;
@@ -1967,7 +1964,7 @@ static int test_import_persists_finalized_post_state(void)
         goto cleanup;
     }
     if (lantern_storage_store_state_for_root(
-            fixture.client.data_dir,
+            &fixture.client.storage,
             &initial_head_root,
             &fixture.client.state)
         != 0) {
@@ -2013,7 +2010,7 @@ static int test_import_persists_finalized_post_state(void)
     uint8_t *state_bytes = NULL;
     size_t state_len = 0u;
     if (lantern_storage_load_state_bytes_for_root(
-            fixture.client.data_dir,
+            &fixture.client.storage,
             &advanced_finalized.root,
             &state_bytes,
             &state_len)
@@ -2120,12 +2117,12 @@ static int test_retained_side_branch_reloads_evicted_parent_state(void)
                &branch_b_state)
                != 0
         || lantern_storage_store_state_for_root(
-               fixture.client.data_dir,
+               &fixture.client.storage,
                &branch_a_root,
                &branch_a_state)
                != 0
         || lantern_storage_store_state_for_root(
-               fixture.client.data_dir,
+               &fixture.client.storage,
                &branch_b_root,
                &branch_b_state)
                != 0) {
@@ -2180,7 +2177,7 @@ static int test_retained_side_branch_reloads_evicted_parent_state(void)
     uint8_t *persisted_bytes = NULL;
     size_t persisted_len = 0u;
     if (lantern_storage_load_state_bytes_for_root(
-            fixture.client.data_dir,
+            &fixture.client.storage,
             side_root,
             &persisted_bytes,
             &persisted_len)
@@ -2601,7 +2598,7 @@ static int test_restore_persisted_blocks_caches_known_attestation_proofs(void)
         fprintf(stderr, "failed to build block fixture for restore known proofs test\n");
         goto cleanup;
     }
-    if (lantern_storage_store_block(fixture.client.data_dir, &block) != 0) {
+    if (lantern_storage_store_block(&fixture.client.storage, &block) != 0) {
         fprintf(stderr, "failed to persist block fixture for restore known proofs test\n");
         goto cleanup;
     }
@@ -2688,7 +2685,7 @@ static int test_restore_persisted_blocks_skips_proposer_attestation_cache(void)
         goto cleanup;
     }
     lantern_aggregated_payload_pool_reset(&empty_attestation_payloads);
-    if (lantern_storage_store_block(fixture.client.data_dir, &block) != 0) {
+    if (lantern_storage_store_block(&fixture.client.storage, &block) != 0) {
         fprintf(stderr, "failed to persist proposer-only block fixture for restore test\n");
         goto cleanup;
     }

--- a/tests/unit/test_client_vote.c
+++ b/tests/unit/test_client_vote.c
@@ -546,10 +546,10 @@ static int build_proposer_only_block_proof(
     lantern_bitlist_init(&proposer_participants);
 
     size_t proposer_index = (size_t)block->block.proposer_index;
-    const uint8_t *proposer_pubkey = lantern_state_validator_proposal_pubkey(state, proposer_index);
-    if (!proposer_pubkey) {
+    if (!state->validators || proposer_index >= state->validator_count) {
         goto cleanup;
     }
+    const uint8_t *proposer_pubkey = state->validators[proposer_index].proposal_pubkey;
     if (lantern_bitlist_resize(&proposer_participants, proposer_index + 1u) != 0
         || lantern_bitlist_set(&proposer_participants, proposer_index, true) != 0) {
         goto cleanup;
@@ -1129,12 +1129,13 @@ static int test_record_vote_replays_buffered_vote_after_block_import(void) {
         goto cleanup;
     }
     client.data_dir = data_dir_template;
-    if (mkdir(client.data_dir, 0700) != 0) {
+    if (mkdir(client.data_dir, 0700) != 0
+        || lantern_storage_open(&client.storage, client.data_dir) != 0) {
         fprintf(stderr, "failed to create temp dir for buffered vote replay test\n");
         goto cleanup;
     }
     if (lantern_storage_store_state_for_root(
-            client.data_dir,
+            &client.storage,
             &grandchild_block.block.parent_root,
             &client.state)
         != 0) {
@@ -1190,6 +1191,7 @@ static int test_record_vote_replays_buffered_vote_after_block_import(void) {
     rc = 0;
 
 cleanup:
+    lantern_storage_close(&client.storage);
     if (client.data_dir && client.data_dir[0] != '\0') {
         char cleanup_cmd[320];
         int written = snprintf(cleanup_cmd, sizeof(cleanup_cmd), "rm -rf %s", client.data_dir);

--- a/tests/unit/test_fork_choice.c
+++ b/tests/unit/test_fork_choice.c
@@ -9,6 +9,7 @@
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/store.h"
 #include "lantern/consensus/state.h"
+#include "../support/validator_registry.h"
 #include "../support/vote_list.h"
 
 #ifdef NDEBUG
@@ -273,7 +274,7 @@ static void seed_state_allocations(
     for (size_t i = 0; i < pubkey_bytes; ++i) {
         pubkeys[i] = (uint8_t)(seed + (uint8_t)i);
     }
-    assert(lantern_state_set_validator_pubkeys(state, pubkeys, validator_count) == 0);
+    assert(lantern_test_state_set_validator_pubkeys(state, pubkeys, validator_count) == 0);
     free(pubkeys);
 
     assert(lantern_root_list_resize(&state->historical_block_hashes, history_len) == 0);

--- a/tests/unit/test_genesis_anchor.c
+++ b/tests/unit/test_genesis_anchor.c
@@ -17,6 +17,8 @@
 #include "lantern/storage/storage.h"
 #include "lantern/support/strings.h"
 
+#include "../support/validator_registry.h"
+#include "../support/storage_cleanup.h"
 #include "client_test_helpers.h"
 #include "../../src/core/client_internal.h"
 #include "../../src/core/client_services_internal.h"
@@ -67,18 +69,6 @@ static void cleanup_path(const char *path)
     }
 }
 
-static void cleanup_dir(const char *path)
-{
-    if (!path)
-    {
-        return;
-    }
-    if (rmdir(path) != 0 && errno != ENOENT && errno != ENOTEMPTY && errno != EEXIST)
-    {
-        fprintf(stderr, "failed to remove dir %s: %s\n", path, strerror(errno));
-    }
-}
-
 static void build_fixture_path(char *buffer, size_t length, const char *relative)
 {
     if (!buffer || length == 0u || !relative)
@@ -121,61 +111,10 @@ static void cleanup_init_data_dir(const char *data_dir)
     {
         return;
     }
-
-    static const char *const files[] = {
-        "state.ssz",
-    };
-    for (size_t i = 0; i < sizeof(files) / sizeof(files[0]); ++i)
+    if (lantern_test_remove_storage_dir(data_dir) != 0)
     {
-        char path[PATH_MAX];
-        int written = snprintf(path, sizeof(path), "%s/%s", data_dir, files[i]);
-        if (written > 0 && (size_t)written < sizeof(path))
-        {
-            cleanup_path(path);
-        }
+        fprintf(stderr, "failed to remove storage dir %s: %s\n", data_dir, strerror(errno));
     }
-
-    static const char *const dirs[] = {
-        "blocks",
-        "states",
-    };
-    char path[PATH_MAX];
-    int written = 0;
-    for (size_t i = 0; i < sizeof(dirs) / sizeof(dirs[0]); ++i)
-    {
-        written = snprintf(path, sizeof(path), "%s/%s", data_dir, dirs[i]);
-        if (written > 0 && (size_t)written < sizeof(path))
-        {
-            cleanup_dir(path);
-        }
-    }
-    cleanup_dir(data_dir);
-}
-
-static void cleanup_storage_root_file(
-    const char *data_dir,
-    const char *subdir,
-    const LanternRoot *root,
-    const char *ext)
-{
-    if (!data_dir || !subdir || !root || !ext)
-    {
-        return;
-    }
-
-    char root_hex[(2u * LANTERN_ROOT_SIZE) + 1u];
-    if (lantern_bytes_to_hex(root->bytes, LANTERN_ROOT_SIZE, root_hex, sizeof(root_hex), 0) != 0)
-    {
-        return;
-    }
-
-    char path[PATH_MAX];
-    int written = snprintf(path, sizeof(path), "%s/%s/%s.%s", data_dir, subdir, root_hex, ext);
-    if (written <= 0 || (size_t)written >= sizeof(path))
-    {
-        return;
-    }
-    cleanup_path(path);
 }
 
 static int test_checkpoint_consumers_use_fork_choice_store(void)
@@ -222,8 +161,12 @@ static int test_checkpoint_consumers_use_fork_choice_store(void)
         goto cleanup;
     }
     client.data_dir = data_dir;
+    if (lantern_storage_open(&client.storage, data_dir) != 0)
+    {
+        goto cleanup;
+    }
 
-    if (lantern_storage_store_state_for_root(data_dir, &child_root, &client.state) != 0)
+    if (lantern_storage_store_state_for_root(&client.storage, &child_root, &client.state) != 0)
     {
         fprintf(stderr, "failed to store child state snapshot for checkpoint consumer regression\n");
         goto cleanup;
@@ -276,7 +219,7 @@ static int test_checkpoint_consumers_use_fork_choice_store(void)
         goto cleanup;
     }
     if (lantern_storage_load_state_bytes_for_root(
-            data_dir,
+            &client.storage,
             &child_root,
             &expected_bytes,
             &expected_len)
@@ -304,22 +247,9 @@ cleanup:
     free(expected_bytes);
     if (data_dir)
     {
-        cleanup_storage_root_file(data_dir, "states", &child_root, "ssz");
-        cleanup_storage_root_file(data_dir, "states", &child_root, "meta");
-        char states_dir[PATH_MAX];
-        char blocks_dir[PATH_MAX];
-        int states_written = snprintf(states_dir, sizeof(states_dir), "%s/states", data_dir);
-        int blocks_written = snprintf(blocks_dir, sizeof(blocks_dir), "%s/blocks", data_dir);
-        if (states_written > 0 && (size_t)states_written < sizeof(states_dir))
-        {
-            cleanup_dir(states_dir);
-        }
-        if (blocks_written > 0 && (size_t)blocks_written < sizeof(blocks_dir))
-        {
-            cleanup_dir(blocks_dir);
-        }
+        lantern_storage_close(&client.storage);
         client.data_dir = NULL;
-        cleanup_dir(data_dir);
+        cleanup_init_data_dir(data_dir);
         free(data_dir);
     }
     client_test_teardown_vote_validation_client(&client, pub, secret);
@@ -381,8 +311,12 @@ static int test_http_checkpoint_callbacks_do_not_take_state_lock(void)
         goto cleanup;
     }
     client.data_dir = data_dir;
+    if (lantern_storage_open(&client.storage, data_dir) != 0)
+    {
+        goto cleanup;
+    }
 
-    if (lantern_storage_store_state_for_root(data_dir, &finalized.root, &client.state) != 0)
+    if (lantern_storage_store_state_for_root(&client.storage, &finalized.root, &client.state) != 0)
     {
         fprintf(stderr, "failed to store finalized state for HTTP checkpoint snapshot regression\n");
         goto cleanup;
@@ -430,96 +364,13 @@ cleanup:
     free(state_bytes);
     if (data_dir)
     {
-        cleanup_storage_root_file(data_dir, "states", &finalized.root, "ssz");
-        cleanup_storage_root_file(data_dir, "states", &finalized.root, "meta");
-        char states_dir[PATH_MAX];
-        int states_written = snprintf(states_dir, sizeof(states_dir), "%s/states", data_dir);
-        if (states_written > 0 && (size_t)states_written < sizeof(states_dir))
-        {
-            cleanup_dir(states_dir);
-        }
-        cleanup_dir(data_dir);
+        lantern_storage_close(&client.storage);
+        cleanup_init_data_dir(data_dir);
     }
     client.data_dir = NULL;
     free(data_dir);
     client_test_teardown_vote_validation_client(&client, pub, secret);
     return rc;
-}
-
-static int test_checkpoint_sync_parse_url_scheme_handling(void)
-{
-    struct lantern_http_url url = {0};
-
-    if (lantern_http_url_parse(
-            "http://checkpoint.example:5052/lean/v0/states/finalized",
-            &url)
-        != 0)
-    {
-        fprintf(stderr, "failed to parse http checkpoint sync url\n");
-        goto fail;
-    }
-    if (!url.host || strcmp(url.host, "checkpoint.example") != 0)
-    {
-        fprintf(stderr, "unexpected checkpoint sync host\n");
-        goto fail;
-    }
-    if (url.port != 5052u)
-    {
-        fprintf(stderr, "unexpected checkpoint sync port\n");
-        goto fail;
-    }
-    if (!url.path || strcmp(url.path, "/lean/v0/states/finalized") != 0)
-    {
-        fprintf(stderr, "unexpected checkpoint sync base path\n");
-        goto fail;
-    }
-
-    lantern_http_url_reset(&url);
-
-    if (lantern_http_url_parse(
-            "http://127.0.0.1:/lean/v0/states/finalized",
-            &url)
-        == 0)
-    {
-        fprintf(stderr, "checkpoint sync URL with empty port should be rejected\n");
-        goto fail;
-    }
-    if (url.host || url.path || url.port != 0)
-    {
-        fprintf(stderr, "empty-port checkpoint sync parse should not return partial output\n");
-        goto fail;
-    }
-
-    if (lantern_http_url_parse(
-            "https://checkpoint.example/lean/v0/states/finalized",
-            &url)
-        != 0)
-    {
-        fprintf(stderr, "failed to parse https checkpoint sync url for downgrade\n");
-        goto fail;
-    }
-    if (!url.host || strcmp(url.host, "checkpoint.example") != 0)
-    {
-        fprintf(stderr, "unexpected downgraded checkpoint sync host\n");
-        goto fail;
-    }
-    if (url.port != 80u)
-    {
-        fprintf(stderr, "unexpected downgraded checkpoint sync port\n");
-        goto fail;
-    }
-    if (!url.path || strcmp(url.path, "/lean/v0/states/finalized") != 0)
-    {
-        fprintf(stderr, "unexpected downgraded checkpoint sync base path\n");
-        goto fail;
-    }
-
-    lantern_http_url_reset(&url);
-    return 0;
-
-fail:
-    lantern_http_url_reset(&url);
-    return 1;
 }
 
 static int test_pre_anchor_block_is_rejected_below_anchor_finalization(void)
@@ -558,7 +409,7 @@ static int test_pre_anchor_block_is_rejected_below_anchor_finalization(void)
 
     uint8_t pubkeys[4u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_pubkeys(pubkeys, 4u);
-    if (lantern_state_set_validator_pubkeys(&client.state, pubkeys, 4u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&client.state, pubkeys, 4u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys for pre-anchor regression\n");
         goto cleanup;
@@ -665,7 +516,7 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
 
     uint8_t pubkeys[5u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_pubkeys(pubkeys, 5u);
-    if (lantern_state_set_validator_pubkeys(&client.state, pubkeys, 5u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&client.state, pubkeys, 5u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys for checkpoint anchor restore regression\n");
         goto cleanup;
@@ -700,6 +551,10 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
         goto cleanup;
     }
     client.data_dir = data_dir;
+    if (lantern_storage_open(&client.storage, data_dir) != 0)
+    {
+        goto cleanup;
+    }
 
     persisted_anchor.block.slot = client.state.latest_block_header.slot;
     persisted_anchor.block.proposer_index = client.state.latest_block_header.proposer_index;
@@ -767,7 +622,7 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
         goto cleanup;
     }
     if (lantern_storage_store_block_for_root(
-            client.data_dir,
+            &client.storage,
             &expected_anchor_root,
             &persisted_anchor)
         != 0)
@@ -904,23 +759,9 @@ static int test_checkpoint_sync_anchor_checkpoint_restores(void)
 cleanup:
     if (data_dir)
     {
-        cleanup_storage_root_file(data_dir, "states", &expected_anchor_root, "ssz");
-        cleanup_storage_root_file(data_dir, "states", &expected_anchor_root, "meta");
-        cleanup_storage_root_file(data_dir, "blocks", &expected_anchor_root, "ssz");
-        char states_dir[PATH_MAX];
-        char blocks_dir[PATH_MAX];
-        int states_written = snprintf(states_dir, sizeof(states_dir), "%s/states", data_dir);
-        int blocks_written = snprintf(blocks_dir, sizeof(blocks_dir), "%s/blocks", data_dir);
-        if (states_written > 0 && (size_t)states_written < sizeof(states_dir))
-        {
-            cleanup_dir(states_dir);
-        }
-        if (blocks_written > 0 && (size_t)blocks_written < sizeof(blocks_dir))
-        {
-            cleanup_dir(blocks_dir);
-        }
+        lantern_storage_close(&client.storage);
         client.data_dir = NULL;
-        cleanup_dir(data_dir);
+        cleanup_init_data_dir(data_dir);
         free(data_dir);
     }
     lantern_store_reset(&client.store);
@@ -946,7 +787,7 @@ static int test_reqresp_status_uses_genesis_anchor_before_genesis(void)
 
     uint8_t pubkeys[4u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_pubkeys(pubkeys, 4u);
-    if (lantern_state_set_validator_pubkeys(&client.state, pubkeys, 4u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&client.state, pubkeys, 4u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys for status regression\n");
         goto cleanup;
@@ -1036,7 +877,7 @@ static int test_checkpoint_validator_pubkeys_checked_and_preserved(void)
     LanternRoot root_before;
     LanternRoot root_after;
     if (lantern_state_generate_genesis(&client.state, UINT64_C(1761717362), validator_count) != 0
-        || lantern_state_set_validator_pubkeys_dual(
+        || lantern_test_state_set_validator_pubkeys_dual(
                &client.state,
                attestation_pubkeys,
                proposal_pubkeys,
@@ -1190,7 +1031,7 @@ int main(void)
 
     uint8_t pubkeys[3u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_pubkeys(pubkeys, 3u);
-    if (lantern_state_set_validator_pubkeys(&client.state, pubkeys, 3u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&client.state, pubkeys, 3u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys\n");
         lantern_state_reset(&client.state);
@@ -1253,7 +1094,7 @@ int main(void)
 
     uint8_t restart_pubkeys[4u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_pubkeys(restart_pubkeys, 4u);
-    if (lantern_state_set_validator_pubkeys(&client.state, restart_pubkeys, 4u) != 0)
+    if (lantern_test_state_set_validator_pubkeys(&client.state, restart_pubkeys, 4u) != 0)
     {
         fprintf(stderr, "failed to set validator pubkeys for restart regression\n");
         lantern_state_reset(&client.state);
@@ -1349,12 +1190,6 @@ int main(void)
         return 1;
     }
     if (test_http_checkpoint_callbacks_do_not_take_state_lock() != 0)
-    {
-        lantern_state_reset(&client.state);
-        lantern_fork_choice_reset(&client.store);
-        return 1;
-    }
-    if (test_checkpoint_sync_parse_url_scheme_handling() != 0)
     {
         lantern_state_reset(&client.state);
         lantern_fork_choice_reset(&client.store);

--- a/tests/unit/test_genesis_bootstrap.c
+++ b/tests/unit/test_genesis_bootstrap.c
@@ -8,35 +8,6 @@
 #include "lantern/consensus/state.h"
 #include "lantern/genesis/genesis.h"
 #include "lantern/support/strings.h"
-#include "../../src/internal/yaml_parser.h"
-
-static int test_indentless_yaml_array(void) {
-    char path[PATH_MAX];
-    int written = snprintf(path, sizeof(path), "/tmp/lantern_indentless_yaml_%ld.yaml", (long)getpid());
-    if (written <= 0 || (size_t)written >= sizeof(path)) {
-        return -1;
-    }
-    FILE *file = fopen(path, "w");
-    if (!file) {
-        return -1;
-    }
-    fputs("GENESIS_VALIDATORS:\n- attestation_pubkey: 0x01\n  proposal_pubkey: 0x02\nNEXT_KEY: value\n", file);
-    fclose(file);
-
-    size_t count = 0u;
-    LanternYamlObject *objects = lantern_yaml_read_array(path, "GENESIS_VALIDATORS", &count);
-    unlink(path);
-    int result = objects && count == 1u && objects[0].num_pairs == 2u
-        && strcmp(objects[0].pairs[0].key, "attestation_pubkey") == 0
-        && strcmp(objects[0].pairs[0].value, "0x01") == 0
-        && strcmp(objects[0].pairs[1].key, "proposal_pubkey") == 0
-        && strcmp(objects[0].pairs[1].value, "0x02") == 0
-        ? 0
-        : -1;
-    lantern_yaml_free_objects(objects, count);
-    return result;
-}
-
 static int write_temp_nodes_file(char *buffer, size_t length) {
     if (!buffer || length == 0) {
         return -1;
@@ -98,10 +69,6 @@ static int expect_pubkey_hex(const uint8_t *actual, const char *expected_hex) {
 }
 
 int main(void) {
-    if (test_indentless_yaml_array() != 0) {
-        fprintf(stderr, "indentless YAML array parsing failed\n");
-        return 1;
-    }
     struct lantern_genesis_artifacts artifacts;
     lantern_genesis_artifacts_init(&artifacts);
     int rc = 1;
@@ -218,14 +185,14 @@ int main(void) {
         artifacts.chain_config.validators,
         generated_state.validator_count * sizeof(*generated_state.validators));
     if (expect_pubkey_hex(
-            lantern_state_validator_attestation_pubkey(&generated_state, 0u),
+            generated_state.validators[0].attestation_pubkey,
             "0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         != 0) {
         fprintf(stderr, "generated state attestation pubkey mismatch\n");
         goto cleanup;
     }
     if (expect_pubkey_hex(
-            lantern_state_validator_proposal_pubkey(&generated_state, 0u),
+            generated_state.validators[0].proposal_pubkey,
             "0x81818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181818181")
         != 0) {
         fprintf(stderr, "generated state proposal pubkey mismatch\n");

--- a/tests/unit/test_libp2p.c
+++ b/tests/unit/test_libp2p.c
@@ -1,6 +1,7 @@
 #include "../../src/core/client_network_internal.h"
 
 #include "lantern/core/client.h"
+#include "lantern/metrics/lean_metrics.h"
 #include "lantern/networking/enr.h"
 #include "lantern/networking/libp2p.h"
 #include "lantern/support/string_list.h"
@@ -117,23 +118,23 @@ static int connection_counter_keeps_peer_until_last_connection_closes(void) {
     const void *conn2 = (const void *)0x2;
     const void *unknown_conn = (const void *)0x3;
 
-    connection_counter_update(&client, 1, conn1, &peer, true, LIBP2P_HOST_OK);
-    connection_counter_update(&client, 1, conn2, &peer, false, LIBP2P_HOST_OK);
+    connection_counter_update(&client, 1, conn1, &peer, true, LIBP2P_HOST_OK, false, 0U);
+    connection_counter_update(&client, 1, conn2, &peer, false, LIBP2P_HOST_OK, false, 0U);
     int failed = !lantern_client_is_peer_connected(&client, peer_text)
         || client.connected_peers != 1u
         || client.connection_peer_ref_count != 2u;
 
-    connection_counter_update(&client, -1, conn1, NULL, false, LIBP2P_HOST_OK);
+    connection_counter_update(&client, -1, conn1, NULL, false, LIBP2P_HOST_OK, true, 0U);
     failed = failed || !lantern_client_is_peer_connected(&client, peer_text)
         || client.connected_peers != 1u
         || client.connection_peer_ref_count != 1u;
 
-    connection_counter_update(&client, -1, unknown_conn, NULL, false, LIBP2P_HOST_OK);
+    connection_counter_update(&client, -1, unknown_conn, NULL, false, LIBP2P_HOST_OK, true, 0U);
     failed = failed || !lantern_client_is_peer_connected(&client, peer_text)
         || client.connected_peers != 1u
         || client.connection_peer_ref_count != 1u;
 
-    connection_counter_update(&client, -1, conn2, NULL, false, LIBP2P_HOST_OK);
+    connection_counter_update(&client, -1, conn2, NULL, false, LIBP2P_HOST_OK, true, 0U);
     failed = failed || lantern_client_is_peer_connected(&client, peer_text)
         || client.connected_peers != 0u
         || client.connection_peer_ref_count != 0u;
@@ -165,6 +166,56 @@ static int connection_tie_break_is_symmetric(void) {
     failed = failed || !connection_tie_break_prefers_inbound(high_local, sizeof(high_local), &low_peer);
     failed = failed || connection_tie_break_prefers_inbound(low_local, sizeof(low_local), &longer_peer);
     failed = failed || !connection_tie_break_prefers_inbound(longer_peer.bytes, longer_peer.len, &low_peer);
+    return failed;
+}
+
+static int connection_recovery_respects_close_origin(void) {
+    if (connection_close_should_redial(LIBP2P_HOST_ERR_CLOSED, true)) {
+        return 1;
+    }
+    if (!connection_close_should_redial(LIBP2P_HOST_ERR_CLOSED, false)) {
+        return 1;
+    }
+    return connection_close_should_redial(LIBP2P_HOST_OK, false) ? 1 : 0;
+}
+
+static int connection_metrics_classify_close_details(void) {
+    static const char *peer_text = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
+    struct lantern_client client;
+    struct lantern_peer_id peer;
+    int conns[3];
+
+    memset(&client, 0, sizeof(client));
+    if (pthread_mutex_init(&client.connection_lock, NULL) != 0) {
+        return 1;
+    }
+    client.connection_lock_initialized = true;
+    if (lantern_peer_id_from_text(peer_text, &peer) != 0) {
+        pthread_mutex_destroy(&client.connection_lock);
+        return 1;
+    }
+
+    lean_metrics_reset();
+
+    connection_counter_update(&client, 1, &conns[0], &peer, false, LIBP2P_HOST_OK, false, 0U);
+    connection_counter_update(&client, -1, &conns[0], NULL, false, LIBP2P_HOST_ERR_CLOSED, true, 73U);
+
+    connection_counter_update(&client, 1, &conns[1], &peer, false, LIBP2P_HOST_OK, false, 0U);
+    connection_counter_update(&client, -1, &conns[1], NULL, false, LIBP2P_HOST_ERR_CLOSED, false, 0U);
+
+    connection_counter_update(&client, 1, &conns[2], &peer, false, LIBP2P_HOST_OK, false, 0U);
+    connection_counter_update(&client, -1, &conns[2], NULL, false, LIBP2P_HOST_ERR_CLOSED, false, 73U);
+
+    struct lean_metrics_snapshot snapshot;
+    lean_metrics_snapshot(&snapshot);
+    const uint64_t *outbound = snapshot.peer_disconnection_events_total[LEAN_METRICS_DIR_OUTBOUND];
+    int failed = outbound[LEAN_METRICS_DISCONNECT_LOCAL_CLOSE] != 1U
+        || outbound[LEAN_METRICS_DISCONNECT_REMOTE_CLOSE] != 1U
+        || outbound[LEAN_METRICS_DISCONNECT_ERROR] != 1U
+        || outbound[LEAN_METRICS_DISCONNECT_TIMEOUT] != 0U;
+
+    pthread_mutex_destroy(&client.connection_lock);
+    free(client.connection_peer_refs);
     return failed;
 }
 
@@ -218,6 +269,14 @@ int main(void) {
     }
 
     if (connection_tie_break_is_symmetric() != 0) {
+        return 1;
+    }
+
+    if (connection_recovery_respects_close_origin() != 0) {
+        return 1;
+    }
+
+    if (connection_metrics_classify_close_details() != 0) {
         return 1;
     }
 

--- a/tests/unit/test_signature.c
+++ b/tests/unit/test_signature.c
@@ -4,6 +4,7 @@
 #include "lantern/consensus/state.h"
 #include "lantern/consensus/store.h"
 #include "lantern/metrics/lean_metrics.h"
+#include "../support/validator_registry.h"
 
 #include "pq-bindings-c-rust.h"
 
@@ -486,7 +487,7 @@ static int test_recursive_aggregated_signature_roundtrip(void) {
     }
 
     if (lantern_state_generate_genesis(&state, 0u, kSignerCount) != 0
-        || lantern_state_set_validator_pubkeys(&state, flattened_pubkeys, kSignerCount) != 0) {
+        || lantern_test_state_set_validator_pubkeys(&state, flattened_pubkeys, kSignerCount) != 0) {
         fprintf(stderr, "recursive aggregate: state pubkey setup failed\n");
         goto fail;
     }
@@ -760,7 +761,7 @@ static int test_block_type2_attestation_split_roundtrip(void) {
     }
 
     if (lantern_state_generate_genesis(&state, 0u, kValidatorCount) != 0
-        || lantern_state_set_validator_pubkeys(&state, flattened_pubkeys, kValidatorCount) != 0) {
+        || lantern_test_state_set_validator_pubkeys(&state, flattened_pubkeys, kValidatorCount) != 0) {
         fprintf(stderr, "block split: state pubkey setup failed\n");
         goto cleanup;
     }

--- a/tests/unit/test_ssz.c
+++ b/tests/unit/test_ssz.c
@@ -9,6 +9,7 @@
 #include "lantern/consensus/signature.h"
 #include "lantern/consensus/state.h"
 #include "lantern/consensus/ssz.h"
+#include "../support/validator_registry.h"
 
 #define SIGNED_BLOCK_TEST_BUFFER_SIZE 32768
 
@@ -463,7 +464,7 @@ static void test_state_roundtrip(void) {
     uint8_t validator_pubkeys[64u * LANTERN_VALIDATOR_PUBKEY_SIZE];
     fill_bytes(validator_pubkeys, sizeof(validator_pubkeys), 0x71);
     expect_ok(lantern_state_generate_genesis(&state, 123456789u, 64u), "state genesis");
-    expect_ok(lantern_state_set_validator_pubkeys(&state, validator_pubkeys, 64u), "state validators");
+    expect_ok(lantern_test_state_set_validator_pubkeys(&state, validator_pubkeys, 64u), "state validators");
     state.slot = 42;
     state.latest_block_header.slot = 41;
     state.latest_block_header.proposer_index = 3;
@@ -533,7 +534,7 @@ static void test_state_rejects_truncated_state_payload(void) {
     assert(genesis_attestation_pubkeys != NULL);
     assert(genesis_proposal_pubkeys != NULL);
     expect_ok(
-        lantern_state_set_validator_pubkeys_dual(
+        lantern_test_state_set_validator_pubkeys_dual(
             &genesis_state,
             genesis_attestation_pubkeys,
             genesis_proposal_pubkeys,

--- a/tests/unit/test_state.c
+++ b/tests/unit/test_state.c
@@ -14,6 +14,7 @@
 #include "lantern/metrics/lean_metrics.h"
 #include "pq-bindings-c-rust.h"
 #include "../support/state_store_adapter.h"
+#include "../support/validator_registry.h"
 
 typedef struct {
     LanternSignature *data;
@@ -125,7 +126,7 @@ static int set_test_validator_pubkey(
         pubkeys + (validator_index * LANTERN_VALIDATOR_PUBKEY_SIZE),
         serialized_pubkey,
         LANTERN_VALIDATOR_PUBKEY_SIZE);
-    int rc = lantern_state_set_validator_pubkeys(state, pubkeys, validator_count);
+    int rc = lantern_test_state_set_validator_pubkeys(state, pubkeys, validator_count);
     free(pubkeys);
     return rc;
 }
@@ -148,10 +149,10 @@ static int build_proposer_only_block_proof(
     lantern_bitlist_init(&proposer_participants);
 
     size_t proposer_index = (size_t)block->proposer_index;
-    const uint8_t *proposer_pubkey = lantern_state_validator_proposal_pubkey(state, proposer_index);
-    if (!proposer_pubkey) {
+    if (!state->validators || proposer_index >= state->validator_count) {
         goto cleanup;
     }
+    const uint8_t *proposer_pubkey = state->validators[proposer_index].proposal_pubkey;
     if (lantern_bitlist_resize(&proposer_participants, proposer_index + 1u) != 0
         || lantern_bitlist_set(&proposer_participants, proposer_index, true) != 0) {
         goto cleanup;
@@ -244,7 +245,7 @@ static int set_test_validator_pubkeys(
             LANTERN_VALIDATOR_PUBKEY_SIZE);
     }
 
-    int rc = lantern_state_set_validator_pubkeys_dual(
+    int rc = lantern_test_state_set_validator_pubkeys_dual(
         state,
         attestation_pubkeys,
         proposal_pubkeys,
@@ -549,8 +550,8 @@ static int test_validator_registry_limit_enforced(void) {
     assert(pubkeys != NULL);
 
     expect_zero(lantern_state_generate_genesis(&state, 999u, limit), "regenerate at limit");
-    expect_zero(lantern_state_set_validator_pubkeys(&state, pubkeys, pubkey_count), "set pubkeys at limit");
-    if (lantern_state_set_validator_pubkeys(&state, pubkeys, max_pubkey_count) == 0) {
+    expect_zero(lantern_test_state_set_validator_pubkeys(&state, pubkeys, pubkey_count), "set pubkeys at limit");
+    if (lantern_test_state_set_validator_pubkeys(&state, pubkeys, max_pubkey_count) == 0) {
         fprintf(stderr, "expected pubkey setter to reject counts above limit\n");
         free(pubkeys);
         lantern_state_reset(&state);
@@ -1147,7 +1148,7 @@ static int seed_known_payload_for_vote(
                     LANTERN_VALIDATOR_PUBKEY_SIZE);
             }
         }
-        if (lantern_state_set_validator_pubkeys_dual(
+        if (lantern_test_state_set_validator_pubkeys_dual(
                 state,
                 attestation_pubkeys,
                 proposal_pubkeys,

--- a/tests/unit/test_storage.c
+++ b/tests/unit/test_storage.c
@@ -1,9 +1,6 @@
 #include <assert.h>
-#include <stdbool.h>
-#include <dirent.h>
 #include <errno.h>
-#include <inttypes.h>
-#include <limits.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,386 +8,249 @@
 #include <unistd.h>
 
 #include "lantern/consensus/hash.h"
-#include "lantern/consensus/containers.h"
 #include "lantern/consensus/state.h"
-#include "lantern/consensus/ssz.h"
-#include "lantern/networking/messages.h"
 #include "lantern/storage/storage.h"
-#include "lantern/support/strings.h"
 #include "../support/state_store_adapter.h"
+#include "../support/storage_cleanup.h"
+#include "../support/validator_registry.h"
 
-static void expect_zero(int rc, const char *label) {
-    if (rc != 0) {
-        fprintf(stderr, "%s failed rc=%d (errno=%d)\n", label, rc, errno);
+static void expect_zero(int result, const char *label)
+{
+    if (result != 0)
+    {
+        fprintf(stderr, "%s failed rc=%d\n", label, result);
         exit(EXIT_FAILURE);
     }
 }
 
-static void expect_ssz_success(ssz_error_t err, const char *label) {
-    if (err != SSZ_SUCCESS) {
-        fprintf(stderr, "%s failed ssz_error=%d (errno=%d)\n", label, (int)err, errno);
+static void cleanup_storage(struct lantern_storage *storage, const char *directory)
+{
+    lantern_storage_close(storage);
+    if (lantern_test_remove_storage_dir(directory) != 0)
+    {
+        perror("remove storage directory");
         exit(EXIT_FAILURE);
     }
-}
-
-static void expect_true(bool value, const char *label) {
-    if (!value) {
-        fprintf(stderr, "%s expected true\n", label);
-        exit(EXIT_FAILURE);
-    }
-}
-
-static void cleanup_path(const char *path) {
-    if (!path) {
-        return;
-    }
-    if (unlink(path) != 0 && errno != ENOENT) {
-        fprintf(stderr, "failed to remove %s: %s\n", path, strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-}
-
-static void cleanup_dir(const char *path) {
-    if (!path) {
-        return;
-    }
-    if (rmdir(path) != 0 && errno != ENOENT) {
-        fprintf(stderr, "failed to remove dir %s: %s\n", path, strerror(errno));
-        exit(EXIT_FAILURE);
-    }
-}
-
-static void build_root_file_path(
-    char *path,
-    size_t path_len,
-    const char *base_dir,
-    const char *subdir,
-    const LanternRoot *root,
-    const char *ext) {
-    char root_hex[2u * LANTERN_ROOT_SIZE + 1u];
-    expect_zero(
-        lantern_bytes_to_hex(root->bytes, LANTERN_ROOT_SIZE, root_hex, sizeof(root_hex), 0),
-        "hex root path");
-    int written = snprintf(path, path_len, "%s/%s/%s.%s", base_dir, subdir, root_hex, ext);
-    assert(written > 0 && (size_t)written < path_len);
-}
-
-static bool path_exists(const char *path) {
-    return access(path, F_OK) == 0;
 }
 
 static void build_signed_block(
     const LanternState *state,
     uint64_t slot,
-    LanternSignedBlock *out_block,
-    LanternRoot *out_root) {
-    memset(out_block, 0, sizeof(*out_block));
-    out_block->block.slot = slot;
+    LanternSignedBlock *block,
+    LanternRoot *root)
+{
+    lantern_signed_block_init(block);
+    block->block.slot = slot;
     expect_zero(
-        lantern_proposer_for_slot(slot, state->validator_count, &out_block->block.proposer_index),
+        lantern_proposer_for_slot(slot, state->validator_count, &block->block.proposer_index),
         "compute proposer");
-    expect_ssz_success(
-        lantern_hash_tree_root_block_header(&state->latest_block_header, &out_block->block.parent_root),
+    expect_zero(
+        lantern_hash_tree_root_block_header(&state->latest_block_header, &block->block.parent_root),
         "hash parent header");
-    lantern_block_body_init(&out_block->block.body);
-    expect_ssz_success(
-        lantern_hash_tree_root_block(&out_block->block, out_root),
-        "hash block");
+    expect_zero(lantern_hash_tree_root_block(&block->block, root), "hash block");
 }
 
-struct iterate_ctx {
+static void populate_pubkeys(LanternState *state, uint8_t seed)
+{
+    size_t length = state->validator_count * LANTERN_VALIDATOR_PUBKEY_SIZE;
+    uint8_t *pubkeys = malloc(length);
+    assert(pubkeys);
+    for (size_t i = 0; i < state->validator_count; ++i)
+    {
+        memset(
+            pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
+            (int)(seed + i),
+            LANTERN_VALIDATOR_PUBKEY_SIZE);
+    }
+    expect_zero(
+        lantern_test_state_set_validator_pubkeys(state, pubkeys, state->validator_count),
+        "populate validator pubkeys");
+    free(pubkeys);
+}
+
+struct iterate_context {
     size_t count;
 };
 
-static int iterate_counter(const LanternSignedBlock *block, const LanternRoot *root, void *context) {
-    (void)block;
-    (void)root;
-    struct iterate_ctx *ctx = context;
-    ctx->count += 1;
+static int count_block(const LanternSignedBlock *block, const LanternRoot *root, void *context)
+{
+    if (!block || !root || !context)
+    {
+        return -1;
+    }
+    ((struct iterate_context *)context)->count += 1u;
     return 0;
 }
 
-static int test_storage_rejects_excess_validators(void) {
-    char dir_template[] = "/tmp/lantern_storage_limitXXXXXX";
-    char *limit_dir = mkdtemp(dir_template);
-    if (!limit_dir) {
-        perror("mkdtemp limit");
-        return 1;
-    }
-
+static int test_storage_rejects_excess_validators(void)
+{
+    char template[] = "/tmp/lantern_storage_limitXXXXXX";
+    char *directory = mkdtemp(template);
+    struct lantern_storage storage = {0};
     LanternState invalid;
     lantern_state_init(&invalid);
-    uint8_t *encoded = NULL;
-    char state_path[PATH_MAX];
-    state_path[0] = '\0';
-    int result = 1;
-
-    size_t too_many = (size_t)LANTERN_VALIDATOR_REGISTRY_LIMIT + 1u;
-    invalid.config.genesis_time = 555u;
-    invalid.validator_count = too_many;
-    invalid.validators = calloc(too_many, sizeof(LanternValidator));
-    if (!invalid.validators) {
-        perror("calloc validators");
-        goto cleanup;
+    if (!directory || lantern_storage_open(&storage, directory) != 0)
+    {
+        return 1;
     }
-    for (size_t i = 0; i < too_many; ++i) {
+    invalid.config.genesis_time = 555u;
+    invalid.validator_count = (size_t)LANTERN_VALIDATOR_REGISTRY_LIMIT + 1u;
+    invalid.validators = calloc(invalid.validator_count, sizeof(*invalid.validators));
+    if (!invalid.validators)
+    {
+        cleanup_storage(&storage, directory);
+        return 1;
+    }
+    for (size_t i = 0; i < invalid.validator_count; ++i)
+    {
         memset(
             invalid.validators[i].attestation_pubkey,
-            (int)(0x30 + (i & 0x3Fu)),
+            (int)(0x30u + (i & 0x3fu)),
             LANTERN_VALIDATOR_PUBKEY_SIZE);
         memset(
             invalid.validators[i].proposal_pubkey,
-            (int)(0x50 + (i & 0x3Fu)),
+            (int)(0x50u + (i & 0x3fu)),
             LANTERN_VALIDATOR_PUBKEY_SIZE);
     }
 
-    size_t buffer_size = 1024u * 1024u;
-    encoded = malloc(buffer_size);
-    if (!encoded) {
-        perror("malloc encoded state");
-        goto cleanup;
-    }
-    size_t written = 0;
-    expect_zero(lantern_ssz_encode_state(&invalid, encoded, buffer_size, &written), "encode invalid state");
-
-    int state_path_len = snprintf(state_path, sizeof(state_path), "%s/%s", limit_dir, "state.ssz");
-    assert(state_path_len > 0 && (size_t)state_path_len < sizeof(state_path));
-    FILE *fp = fopen(state_path, "wb");
-    if (!fp) {
-        perror("fopen invalid state file");
-        goto cleanup;
-    }
-    size_t file_written = fwrite(encoded, 1u, written, fp);
-    fclose(fp);
-    if (file_written != written) {
-        fprintf(stderr, "failed to write invalid state fixture\n");
-        goto cleanup;
-    }
-
+    int stored = lantern_storage_save_state(&storage, &invalid);
     LanternState loaded;
     lantern_state_init(&loaded);
-    int load_rc = lantern_storage_load_state(limit_dir, &loaded);
-    if (load_rc == 0) {
-        fprintf(stderr, "expected load_state to reject validator count > limit\n");
-        lantern_state_reset(&loaded);
-        goto cleanup;
-    }
+    int accepted = stored == 0 && lantern_storage_load_state(&storage, &loaded) == 0;
     lantern_state_reset(&loaded);
-
-    result = 0;
-
-cleanup:
-    free(encoded);
     lantern_state_reset(&invalid);
-    if (state_path[0] != '\0') {
-        cleanup_path(state_path);
-    }
-    cleanup_dir(limit_dir);
-    return result;
-}
-
-static int test_storage_prunes_before_slot(void) {
-    char dir_template[] = "/tmp/lantern_storage_pruneXXXXXX";
-    char *base_dir = mkdtemp(dir_template);
-    if (!base_dir) {
-        perror("mkdtemp prune");
+    cleanup_storage(&storage, directory);
+    if (accepted)
+    {
+        fprintf(stderr, "storage accepted a state beyond the validator registry limit\n");
         return 1;
     }
+    return 0;
+}
 
-    int rc = 1;
+static int test_storage_prunes_before_slot(void)
+{
+    char template[] = "/tmp/lantern_storage_pruneXXXXXX";
+    char *directory = mkdtemp(template);
+    struct lantern_storage storage = {0};
     LanternState state;
-    lantern_state_init(&state);
     LanternState snapshots[3];
     LanternSignedBlock blocks[3];
     LanternRoot roots[3];
-    bool blocks_ready[3] = {false, false, false};
-    bool states_ready[3] = {false, false, false};
     LanternSignedBlockList collected = {0};
-
-    expect_zero(lantern_storage_prepare(base_dir), "prepare prune storage");
-    expect_zero(lantern_state_generate_genesis(&state, 123456u, 4u), "generate prune genesis");
-
-    uint8_t pubkeys[4u * LANTERN_VALIDATOR_PUBKEY_SIZE];
-    for (size_t i = 0; i < 4u; ++i) {
-        memset(
-            pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE),
-            (int)(0xB0u + i),
-            LANTERN_VALIDATOR_PUBKEY_SIZE);
+    lantern_state_init(&state);
+    if (!directory || lantern_storage_open(&storage, directory) != 0)
+    {
+        return 1;
     }
-    expect_zero(lantern_state_set_validator_pubkeys(&state, pubkeys, 4u), "set prune pubkeys");
-
-    for (size_t i = 0; i < 3u; ++i) {
-        const uint64_t slot = (uint64_t)i + 1u;
+    expect_zero(lantern_state_generate_genesis(&state, 123456u, 4u), "generate prune genesis");
+    populate_pubkeys(&state, 0xB0u);
+    for (size_t i = 0; i < 3u; ++i)
+    {
+        uint64_t slot = (uint64_t)i + 1u;
         build_signed_block(&state, slot, &blocks[i], &roots[i]);
-        blocks_ready[i] = true;
-        expect_zero(lantern_storage_store_block_for_root(base_dir, &roots[i], &blocks[i]), "store prune block");
-
+        expect_zero(
+            lantern_storage_store_block_for_root(&storage, &roots[i], &blocks[i]),
+            "store prune block");
         lantern_state_init(&snapshots[i]);
-        states_ready[i] = true;
         expect_zero(lantern_state_clone(&state, &snapshots[i]), "clone prune state");
         snapshots[i].slot = slot;
         snapshots[i].latest_block_header.slot = slot;
-        snapshots[i].latest_block_header.proposer_index = blocks[i].block.proposer_index;
-        snapshots[i].latest_block_header.parent_root = blocks[i].block.parent_root;
-        snapshots[i].latest_block_header.state_root = blocks[i].block.state_root;
-        expect_zero(lantern_storage_store_state_for_root(base_dir, &roots[i], &snapshots[i]), "store prune state");
+        expect_zero(
+            lantern_storage_store_state_for_root(&storage, &roots[i], &snapshots[i]),
+            "store prune state");
     }
 
-    int pruned = lantern_storage_prune_before_slot(base_dir, 3u, &roots[1], 1u);
-    if (pruned != 2) {
+    int pruned = lantern_storage_prune_before_slot(&storage, 3u, &roots[1], 1u);
+    if (pruned != 2)
+    {
         fprintf(stderr, "expected prune count 2 got %d\n", pruned);
-        goto cleanup;
+        return 1;
+    }
+    expect_zero(
+        lantern_storage_collect_blocks(&storage, roots, 3u, &collected),
+        "collect pruned blocks");
+    if (collected.length != 2u || collected.blocks[0].block.slot != 2u
+        || collected.blocks[1].block.slot != 3u)
+    {
+        fprintf(stderr, "prune retained the wrong blocks\n");
+        return 1;
+    }
+    for (size_t i = 0; i < 3u; ++i)
+    {
+        uint8_t *bytes = NULL;
+        size_t length = 0u;
+        int result = lantern_storage_load_state_bytes_for_root(
+            &storage,
+            &roots[i],
+            &bytes,
+            &length);
+        free(bytes);
+        if ((i == 0u && result != 1) || (i != 0u && result != 0))
+        {
+            fprintf(stderr, "prune retained the wrong states\n");
+            return 1;
+        }
     }
 
-    expect_zero(lantern_storage_collect_blocks(base_dir, roots, 3u, &collected), "collect pruned blocks");
-    if (collected.length != 2u) {
-        fprintf(stderr, "expected two blocks after prune got %zu\n", collected.length);
-        goto cleanup;
-    }
-
-    char path[PATH_MAX];
-    build_root_file_path(path, sizeof(path), base_dir, "blocks", &roots[0], "ssz");
-    expect_true(!path_exists(path), "old block pruned");
-    build_root_file_path(path, sizeof(path), base_dir, "blocks", &roots[1], "ssz");
-    expect_true(path_exists(path), "kept root block preserved");
-    build_root_file_path(path, sizeof(path), base_dir, "blocks", &roots[2], "ssz");
-    expect_true(path_exists(path), "new block preserved");
-
-    build_root_file_path(path, sizeof(path), base_dir, "states", &roots[0], "ssz");
-    expect_true(!path_exists(path), "old state pruned");
-    build_root_file_path(path, sizeof(path), base_dir, "states", &roots[1], "ssz");
-    expect_true(path_exists(path), "kept root state preserved");
-    build_root_file_path(path, sizeof(path), base_dir, "states", &roots[2], "ssz");
-    expect_true(path_exists(path), "new state preserved");
-
-    rc = 0;
-
-cleanup:
     lantern_signed_block_list_reset(&collected);
-    for (size_t i = 0; i < 3u; ++i) {
-        if (blocks_ready[i]) {
-            lantern_block_body_reset(&blocks[i].block.body);
-        }
-        if (states_ready[i]) {
-            lantern_state_reset(&snapshots[i]);
-        }
+    for (size_t i = 0; i < 3u; ++i)
+    {
+        lantern_signed_block_reset(&blocks[i]);
+        lantern_state_reset(&snapshots[i]);
     }
     lantern_state_reset(&state);
-
-    char cleanup_file[PATH_MAX];
-    for (size_t i = 0; i < 3u; ++i) {
-        build_root_file_path(cleanup_file, sizeof(cleanup_file), base_dir, "blocks", &roots[i], "ssz");
-        cleanup_path(cleanup_file);
-        build_root_file_path(cleanup_file, sizeof(cleanup_file), base_dir, "states", &roots[i], "ssz");
-        cleanup_path(cleanup_file);
-    }
-
-    char blocks_dir[PATH_MAX];
-    char states_dir[PATH_MAX];
-    int written = snprintf(blocks_dir, sizeof(blocks_dir), "%s/blocks", base_dir);
-    assert(written > 0 && (size_t)written < sizeof(blocks_dir));
-    written = snprintf(states_dir, sizeof(states_dir), "%s/states", base_dir);
-    assert(written > 0 && (size_t)written < sizeof(states_dir));
-    cleanup_dir(blocks_dir);
-    cleanup_dir(states_dir);
-    cleanup_dir(base_dir);
-    return rc;
+    cleanup_storage(&storage, directory);
+    return 0;
 }
 
-int main(void) {
-    char dir_template[] = "/tmp/lantern_storage_testXXXXXX";
-    char *base_dir = mkdtemp(dir_template);
-    if (!base_dir) {
-        perror("mkdtemp");
+int main(void)
+{
+    char template[] = "/tmp/lantern_storage_testXXXXXX";
+    char *directory = mkdtemp(template);
+    struct lantern_storage storage = {0};
+    if (!directory)
+    {
         return EXIT_FAILURE;
     }
-
-    expect_zero(lantern_storage_prepare(base_dir), "prepare storage");
+    expect_zero(lantern_storage_open(&storage, directory), "open storage");
 
     LanternState state;
     lantern_state_init(&state);
     expect_zero(lantern_state_generate_genesis(&state, 123456u, 4u), "generate genesis");
-
-    /* Populate validator registry with deterministic pubkeys so SSZ encoding works */
-    const size_t genesis_validators = state.validator_count;
-    const size_t pubkey_bytes = genesis_validators * LANTERN_VALIDATOR_PUBKEY_SIZE;
-    uint8_t *dummy_pubkeys = calloc(pubkey_bytes, 1u);
-    assert(dummy_pubkeys != NULL);
-    for (size_t i = 0; i < genesis_validators; ++i) {
-        memset(dummy_pubkeys + (i * LANTERN_VALIDATOR_PUBKEY_SIZE), (int)(0xA0 + i), LANTERN_VALIDATOR_PUBKEY_SIZE);
-    }
-    expect_zero(
-        lantern_state_set_validator_pubkeys(&state, dummy_pubkeys, genesis_validators),
-        "populate validator pubkeys");
-    free(dummy_pubkeys);
-
-    expect_zero(lantern_storage_save_state(base_dir, &state), "save state");
-
-    LanternState loaded_state;
-    lantern_state_init(&loaded_state);
-    int load_state_rc = lantern_storage_load_state(base_dir, &loaded_state);
-    if (load_state_rc != 0) {
-        fprintf(stderr, "expected persisted state rc=0 got %d\n", load_state_rc);
-        return EXIT_FAILURE;
-    }
-    assert(loaded_state.validator_count == state.validator_count);
-    lantern_state_reset(&loaded_state);
+    populate_pubkeys(&state, 0xA0u);
+    expect_zero(lantern_storage_save_state(&storage, &state), "save state");
 
     LanternSignedBlock block;
-    LanternRoot block_root;
-    build_signed_block(&state, 1u, &block, &block_root);
-    expect_zero(lantern_storage_store_block(base_dir, &block), "store block");
-    /* store again to ensure idempotent */
-    expect_zero(lantern_storage_store_block(base_dir, &block), "store block duplicate");
-    LanternSignedBlockList response = {0};
+    LanternRoot root;
+    build_signed_block(&state, 1u, &block, &root);
+    expect_zero(lantern_storage_store_block(&storage, &block), "store block");
+    expect_zero(lantern_storage_store_block(&storage, &block), "store duplicate block");
+    lantern_storage_close(&storage);
+    expect_zero(lantern_storage_open(&storage, directory), "reopen storage");
+
+    LanternState loaded;
+    lantern_state_init(&loaded);
+    expect_zero(lantern_storage_load_state(&storage, &loaded), "load state after reopen");
+    assert(loaded.validator_count == state.validator_count);
+    lantern_state_reset(&loaded);
+    LanternSignedBlockList collected = {0};
     expect_zero(
-        lantern_storage_collect_blocks(base_dir, &block_root, 1u, &response),
-        "collect blocks");
-    assert(response.length == 1u);
-    assert(response.blocks[0].block.slot == block.block.slot);
-    assert(response.blocks[0].block.proposer_index == block.block.proposer_index);
+        lantern_storage_collect_blocks(&storage, &root, 1u, &collected),
+        "collect block");
+    assert(collected.length == 1u && collected.blocks[0].block.slot == 1u);
+    struct iterate_context context = {0};
+    expect_zero(lantern_storage_iterate_blocks(&storage, count_block, &context), "iterate blocks");
+    assert(context.count == 1u);
 
-    struct iterate_ctx ctx = {.count = 0};
-    expect_zero(lantern_storage_iterate_blocks(base_dir, iterate_counter, &ctx), "iterate blocks");
-    assert(ctx.count == 1u);
-
-    lantern_signed_block_list_reset(&response);
-    lantern_block_body_reset(&block.block.body);
-
+    lantern_signed_block_list_reset(&collected);
+    lantern_signed_block_reset(&block);
     lantern_state_reset(&state);
-
-    char state_path[PATH_MAX];
-    char meta_path[PATH_MAX];
-    char blocks_dir[PATH_MAX];
-    char states_dir[PATH_MAX];
-    int written = snprintf(state_path, sizeof(state_path), "%s/%s", base_dir, "state.ssz");
-    assert(written > 0 && (size_t)written < sizeof(state_path));
-    written = snprintf(meta_path, sizeof(meta_path), "%s/%s", base_dir, "state.meta");
-    assert(written > 0 && (size_t)written < sizeof(meta_path));
-    written = snprintf(blocks_dir, sizeof(blocks_dir), "%s/%s", base_dir, "blocks");
-    assert(written > 0 && (size_t)written < sizeof(blocks_dir));
-    written = snprintf(states_dir, sizeof(states_dir), "%s/%s", base_dir, "states");
-    assert(written > 0 && (size_t)written < sizeof(states_dir));
-
-    char block_path[PATH_MAX];
-    char root_hex[2u * LANTERN_ROOT_SIZE + 1u];
-    expect_zero(lantern_bytes_to_hex(block_root.bytes, LANTERN_ROOT_SIZE, root_hex, sizeof(root_hex), 0), "hex root");
-    written = snprintf(block_path, sizeof(block_path), "%s/%s.ssz", blocks_dir, root_hex);
-    assert(written > 0 && (size_t)written < sizeof(block_path));
-
-    cleanup_path(block_path);
-    cleanup_dir(blocks_dir);
-    cleanup_dir(states_dir);
-    cleanup_path(meta_path);
-    cleanup_path(state_path);
-    cleanup_dir(base_dir);
-
-    if (test_storage_rejects_excess_validators() != 0) {
+    cleanup_storage(&storage, directory);
+    if (test_storage_rejects_excess_validators() != 0
+        || test_storage_prunes_before_slot() != 0)
+    {
         return EXIT_FAILURE;
     }
-    if (test_storage_prunes_before_slot() != 0) {
-        return EXIT_FAILURE;
-    }
-
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Replace custom implementations with maintained libraries:

- HTTP: Switch from custom socket-based server/client to libevent (evhttp) for better async handling and reliability
- Storage: Refactor API from path-based to struct-based design with explicit open/close lifecycle and thread-safe operations
- YAML: Replace custom line-based parser with libYAML for spec compliance

Additionally:
- Simplify CLI argument parsing and remove redundant helper functions
- Improve connection close tracking to distinguish local vs. remote initiators and transport errors
- Remove public validator registry accessors; callers now access state->validators directly
- Add build dependencies: libcurl, libevent, libyaml
- Update all tests and internal code to use new APIs