### PR TITLE
Require network head resolution for sync completion

### DIFF
--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -102,8 +102,8 @@ static void log_status_failure(
     bool first_failure);
 static void peer_status_local_view(
     struct lantern_client *client,
-    const LanternRoot *head_root,
-    uint64_t *out_local_slot,
+    const LanternCheckpoint *head,
+    LanternCheckpoint *out_local_head,
     uint64_t *out_local_finalized_slot,
     bool *out_head_known);
 static struct lantern_peer_status_entry *lantern_client_update_peer_status_entry_locked(
@@ -115,7 +115,8 @@ static void lantern_client_peer_status_update(
     struct lantern_client *client,
     const LanternStatusMessage *peer_status,
     const char *peer_id_text,
-    uint64_t local_slot);
+    const LanternCheckpoint *local_head,
+    bool head_known);
 static const char *lantern_blocks_request_outcome_text(enum lantern_blocks_request_outcome outcome);
 static void reqresp_alias_anchor_checkpoint_if_unset(
     struct lantern_client *client,
@@ -221,22 +222,23 @@ static void log_status_failure(
  * @brief Determine local slot and whether a head root is known.
  *
  * @param client         Client instance
- * @param head_root      Head root to check
- * @param out_local_slot Output local slot snapshot
+ * @param head           Head checkpoint to check
+ * @param out_local_head Output local head checkpoint snapshot
+ * @param out_local_finalized_slot Output local finalized slot snapshot
  * @param out_head_known Output true if head is known locally
  *
  * @note Thread safety: This function may acquire state_lock
  */
 static void peer_status_local_view(
     struct lantern_client *client,
-    const LanternRoot *head_root,
-    uint64_t *out_local_slot,
+    const LanternCheckpoint *head,
+    LanternCheckpoint *out_local_head,
     uint64_t *out_local_finalized_slot,
     bool *out_head_known)
 {
-    if (out_local_slot)
+    if (out_local_head)
     {
-        *out_local_slot = 0;
+        *out_local_head = (LanternCheckpoint){0};
     }
     if (out_local_finalized_slot)
     {
@@ -247,7 +249,7 @@ static void peer_status_local_view(
         *out_head_known = false;
     }
 
-    if (!client || !head_root || !out_local_slot || !out_local_finalized_slot || !out_head_known)
+    if (!client || !head || !out_local_head || !out_local_finalized_slot || !out_head_known)
     {
         return;
     }
@@ -258,7 +260,7 @@ static void peer_status_local_view(
         return;
     }
 
-    uint64_t local_slot = client->state.validator_count > 0u
+    out_local_head->slot = client->state.validator_count > 0u
         ? client->state.latest_block_header.slot
         : 0u;
     uint64_t local_finalized_slot = client->state.validator_count > 0u
@@ -275,7 +277,8 @@ static void peer_status_local_view(
                    NULL)
                 == 0)
         {
-            local_slot = fork_slot;
+            out_local_head->root = client->store.head;
+            out_local_head->slot = fork_slot;
         }
         const LanternCheckpoint *fork_finalized = &client->store.latest_finalized;
         if (fork_finalized && !lantern_root_is_zero(&fork_finalized->root))
@@ -283,10 +286,11 @@ static void peer_status_local_view(
             local_finalized_slot = fork_finalized->slot;
         }
     }
-    bool head_known = lantern_client_block_known_locked(client, head_root, NULL);
+    uint64_t known_head_slot = 0u;
+    bool head_known = lantern_client_block_known_locked(client, &head->root, &known_head_slot)
+        && known_head_slot == head->slot;
     lantern_client_unlock_state(client, state_locked);
 
-    *out_local_slot = local_slot;
     *out_local_finalized_slot = local_finalized_slot;
     *out_head_known = head_known;
 
@@ -321,13 +325,14 @@ static void maybe_seed_head_request_from_status(
     }
 
     const bool peer_finalized_ahead = peer_status->finalized.slot > local_finalized_slot;
-    const bool peer_head_ahead = peer_status->head.slot > local_head_slot;
-    if (!peer_finalized_ahead && !peer_head_ahead && !historical_backfill_active)
+    const bool peer_head_unresolved = !head_known
+        && peer_status->head.slot > local_finalized_slot;
+    if (!peer_finalized_ahead && !peer_head_unresolved && !historical_backfill_active)
     {
         return;
     }
 
-    if (!historical_backfill_active && peer_head_ahead)
+    if (!historical_backfill_active && peer_head_unresolved)
     {
         historical_backfill_active = lantern_client_ensure_historical_backfill(
             client,
@@ -375,7 +380,7 @@ static void maybe_seed_head_request_from_status(
         &(const struct lantern_log_metadata){
             .validator = client->node_id,
             .peer = peer_id_text},
-        "peer is ahead; requesting sync block root=%s peer_head_slot=%" PRIu64
+        "peer head unresolved; requesting sync block root=%s peer_head_slot=%" PRIu64
         " peer_finalized_slot=%" PRIu64 " local_head_slot=%" PRIu64 " local_finalized_slot=%" PRIu64,
         request_hex[0] ? request_hex : "0x0",
         peer_status->head.slot,
@@ -386,15 +391,27 @@ static void maybe_seed_head_request_from_status(
 
 static void update_network_view_from_peer_status_locked(
     struct lantern_client *client,
-    const LanternStatusMessage *peer_status)
+    const LanternStatusMessage *peer_status,
+    const LanternCheckpoint *local_head,
+    bool head_known)
 {
     if (!client || !peer_status)
     {
         return;
     }
 
+    /* Advance monotonically by slot. At the same slot, replace the local head
+     * once with an unresolved peer head, then keep that peer target stable. */
+    bool current_is_local_head = local_head
+        && !lantern_root_is_zero(&local_head->root)
+        && client->network_view.head.slot == local_head->slot
+        && lantern_root_equal(&client->network_view.head.root, &local_head->root);
+    bool equal_slot_recovery = !head_known
+        && peer_status->head.slot == client->network_view.head.slot
+        && current_is_local_head;
     if (lantern_root_is_zero(&client->network_view.head.root)
-        || peer_status->head.slot > client->network_view.head.slot)
+        || peer_status->head.slot > client->network_view.head.slot
+        || equal_slot_recovery)
     {
         client->network_view.head = peer_status->head;
     }
@@ -457,6 +474,7 @@ static void maybe_log_sync_progress(
     size_t orphan_count = 0;
     uint64_t local_head_slot = local_slot;
     uint64_t local_finalized_slot = 0;
+    bool network_head_known = false;
     char pending_peer[sizeof(((struct lantern_pending_block *)0)->peer_text)];
     pending_peer[0] = '\0';
     char orphan_peer[sizeof(((struct lantern_pending_block *)0)->peer_text)];
@@ -514,6 +532,13 @@ static void maybe_log_sync_progress(
                 local_head_slot = fork_slot;
             }
             local_finalized_slot = client->store.latest_finalized.slot;
+            uint64_t known_head_slot = 0u;
+            network_head_known = has_network_head
+                && lantern_client_block_known_locked(
+                    client,
+                    &network_view->head.root,
+                    &known_head_slot)
+                && known_head_slot == network_head_slot;
         }
         else if (state_locked && client->state.validator_count > 0u)
         {
@@ -538,7 +563,13 @@ static void maybe_log_sync_progress(
     bool behind_finalized = has_network_finalized && network_finalized > local_head_slot;
     bool finalized_caught_up =
         has_network_finalized && local_finalized_slot >= network_finalized;
-    bool synced = has_network_finalized && !behind_finalized && finalized_caught_up && !has_orphans;
+    bool head_resolved = has_network_head
+        && (network_head_slot <= local_finalized_slot || network_head_known);
+    bool synced = has_network_finalized
+        && !behind_finalized
+        && finalized_caught_up
+        && head_resolved
+        && !has_orphans;
     bool syncing = !synced;
 
     struct lantern_log_metadata meta = {.validator = client->node_id};
@@ -564,7 +595,7 @@ static void maybe_log_sync_progress(
                 &meta);
             return;
         }
-        lantern_client_set_sync_state_logged(client, LANTERN_SYNC_STATE_SYNCED, "head caught finalized");
+        lantern_client_set_sync_state_logged(client, LANTERN_SYNC_STATE_SYNCED, "head ancestry resolved");
         if (client->sync_started_ms != 0u)
         {
             uint64_t target_slot =
@@ -759,7 +790,7 @@ static struct lantern_peer_status_entry *lantern_client_update_peer_status_entry
  * @param client       Client instance
  * @param peer_status  Peer status message
  * @param peer_id_text Peer ID string for tracking/logging
- * @param local_slot   Local slot snapshot
+ * @param local_head   Local head checkpoint snapshot
  *
  * @note Thread safety: This function acquires status_lock
  */
@@ -767,9 +798,10 @@ static void lantern_client_peer_status_update(
     struct lantern_client *client,
     const LanternStatusMessage *peer_status,
     const char *peer_id_text,
-    uint64_t local_slot)
+    const LanternCheckpoint *local_head,
+    bool head_known)
 {
-    if (!client || !peer_status || !peer_id_text)
+    if (!client || !peer_status || !peer_id_text || !local_head)
     {
         return;
     }
@@ -789,14 +821,14 @@ static void lantern_client_peer_status_update(
         return;
     }
 
-    update_network_view_from_peer_status_locked(client, peer_status);
+    update_network_view_from_peer_status_locked(client, peer_status, local_head, head_known);
     LanternStatusMessage network_view = client->network_view;
 
     pthread_mutex_unlock(&client->status_lock);
 
     maybe_log_sync_progress(
         client,
-        local_slot,
+        local_head->slot,
         &network_view,
         true);
 }
@@ -1986,13 +2018,13 @@ static void lantern_client_on_peer_status(
     char peer_copy[sizeof(((struct lantern_peer_status_entry *)0)->peer_id)];
     (void)lantern_string_copy(peer_copy, sizeof(peer_copy), peer_id);
 
-    uint64_t local_slot = 0;
+    LanternCheckpoint local_head = {0};
     uint64_t local_finalized_slot = 0;
     bool head_known = false;
     peer_status_local_view(
         client,
-        &peer_status->head.root,
-        &local_slot,
+        &peer_status->head,
+        &local_head,
         &local_finalized_slot,
         &head_known);
 
@@ -2007,18 +2039,19 @@ static void lantern_client_on_peer_status(
         peer_status->head.slot,
         peer_status->finalized.slot,
         head_known ? "true" : "false",
-        local_slot);
+        local_head.slot);
 
     lantern_client_peer_status_update(
         client,
         peer_status,
         peer_copy,
-        local_slot);
+        &local_head,
+        head_known);
     maybe_seed_head_request_from_status(
         client,
         peer_status,
         peer_copy,
-        local_slot,
+        local_head.slot,
         local_finalized_slot,
         head_known);
 }

--- a/src/core/client_validator.c
+++ b/src/core/client_validator.c
@@ -353,9 +353,19 @@ static bool validator_duty_gate_allows(
         return false;
     }
 
+    LanternCheckpoint network_head = {0};
+    if (client->status_lock_initialized
+        && pthread_mutex_lock(&client->status_lock) == 0)
+    {
+        network_head = client->network_view.head;
+        pthread_mutex_unlock(&client->status_lock);
+    }
+
     uint64_t head_slot = 0u;
     uint64_t max_seen_slot = 0u;
+    uint64_t finalized_slot = 0u;
     bool have_head_slot = false;
+    bool network_head_known = false;
     bool state_locked = lantern_client_lock_state(client);
     if (!state_locked)
     {
@@ -373,6 +383,7 @@ static bool validator_duty_gate_allows(
             return false;
         }
         head_root = client->store.head;
+        finalized_slot = client->store.latest_finalized.slot;
         if (lantern_fork_choice_block_info(
                    &client->store,
                    &head_root,
@@ -396,6 +407,13 @@ static bool validator_duty_gate_allows(
                 }
             }
         }
+        uint64_t known_network_head_slot = 0u;
+        network_head_known = !lantern_root_is_zero(&network_head.root)
+            && lantern_client_block_known_locked(
+                client,
+                &network_head.root,
+                &known_network_head_slot)
+            && known_network_head_slot == network_head.slot;
     }
     else if (client->state.validator_count > 0u)
     {
@@ -404,6 +422,14 @@ static bool validator_duty_gate_allows(
         have_head_slot = true;
     }
     lantern_client_unlock_state(client, state_locked);
+
+    if (!lantern_root_is_zero(&network_head.root)
+        && network_head.slot > finalized_slot
+        && !network_head_known)
+    {
+        validator_log_duty_skipped(client, slot, "network_head_unresolved");
+        return false;
+    }
 
     if (!have_head_slot)
     {

--- a/src/networking/libp2p.c
+++ b/src/networking/libp2p.c
@@ -205,6 +205,12 @@ void lantern_libp2p_host_stop(struct lantern_libp2p_host *state) {
     }
     if (state->started) {
         (void)libp2p_host_close(state->host, 0);
+        (void)libp2p_host_drive(
+            state->host,
+            lantern_libp2p_now_us(),
+            LIBP2P_HOST_READY_APP,
+            NULL);
+        drain_host_events(state);
     }
     state->started = 0;
 }

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -1104,7 +1104,7 @@ cleanup:
     return rc;
 }
 
-static int test_sync_completion_uses_network_finalized_threshold(void)
+static int test_sync_completion_requires_resolved_head_and_finalized_threshold(void)
 {
     struct lantern_client client;
     struct PQSignatureSchemePublicKey *pub = NULL;
@@ -1195,12 +1195,12 @@ static int test_sync_completion_uses_network_finalized_threshold(void)
         goto cleanup;
     }
 
-    client.network_view.head.slot = local_head_slot + 1024u;
+    client.network_view.head.slot = local_head_slot;
     client.network_view.finalized.slot = client.state.latest_finalized.slot;
     client.sync_state = LANTERN_SYNC_STATE_SYNCING;
     lantern_client_update_sync_progress(&client, local_head_slot);
     if (client.sync_state != LANTERN_SYNC_STATE_SYNCED) {
-        fprintf(stderr, "sync should complete at network finalized threshold\n");
+        fprintf(stderr, "sync should complete once the network head and finality are resolved\n");
         goto cleanup;
     }
 
@@ -1216,6 +1216,121 @@ cleanup:
         pthread_mutex_destroy(&client.status_lock);
         client.status_lock_initialized = false;
     }
+    client_test_teardown_vote_validation_client(&client, pub, secret);
+    return rc;
+}
+
+static int test_mixed_peer_heads_keep_network_target_stable(void)
+{
+    struct lantern_client client;
+    struct PQSignatureSchemePublicKey *pub = NULL;
+    struct PQSignatureSchemeSecretKey *secret = NULL;
+    LanternRoot local_head;
+    LanternRoot peer_head;
+    LanternRoot competing_head;
+    LanternRoot higher_head;
+    LanternRoot lower_head;
+    const char *peer_a = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
+    const char *peer_b = "16Uiu2HAkutTMoTzDw1tCvSRtu6YoixJwS46S1ZFxW8hSx9fWHiPs";
+    int rc = 1;
+
+    if (client_test_setup_vote_validation_client(
+            &client,
+            "sync_unknown_equal_slot_head",
+            &pub,
+            &secret,
+            NULL,
+            &local_head)
+        != 0) {
+        return 1;
+    }
+    if (enable_sync_test_peer(&client, peer_a) != 0
+        || set_sync_test_connected_peers(&client, peer_a, peer_b) != 0) {
+        fprintf(stderr, "failed to enable mixed-head sync test peers\n");
+        goto cleanup;
+    }
+
+    client_test_fill_root(&peer_head, 0x5du);
+    client_test_fill_root(&competing_head, 0x6du);
+    client_test_fill_root(&higher_head, 0x7du);
+    client_test_fill_root(&lower_head, 0x8du);
+    client.network_view.head = (LanternCheckpoint){
+        .root = local_head,
+        .slot = client.state.slot,
+    };
+    client.network_view.finalized = client.store.latest_finalized;
+    client.sync_state = LANTERN_SYNC_STATE_SYNCED;
+
+    LanternStatusMessage status = {
+        .head = {
+            .root = peer_head,
+            .slot = client.state.slot,
+        },
+        .finalized = client.store.latest_finalized,
+    };
+    uint64_t request_id_before = client.next_blocks_request_id;
+    if (reqresp_handle_status(&client, &status, peer_a) != LANTERN_CLIENT_OK) {
+        fprintf(stderr, "equal-slot peer status update failed\n");
+        goto cleanup;
+    }
+    if (client.next_blocks_request_id == request_id_before) {
+        fprintf(stderr, "unknown equal-slot peer head did not trigger blocks_by_root\n");
+        goto cleanup;
+    }
+    if (client.sync_state != LANTERN_SYNC_STATE_SYNCING) {
+        fprintf(stderr, "unknown equal-slot peer head should make sync incomplete\n");
+        goto cleanup;
+    }
+    if (!lantern_root_equal(&client.network_view.head.root, &peer_head)) {
+        fprintf(stderr, "unknown equal-slot peer head did not become the sync target\n");
+        goto cleanup;
+    }
+
+    status.head = (LanternCheckpoint){
+        .root = local_head,
+        .slot = client.state.slot,
+    };
+    if (reqresp_handle_status(&client, &status, peer_b) != LANTERN_CLIENT_OK
+        || !lantern_root_equal(&client.network_view.head.root, &peer_head)) {
+        fprintf(stderr, "known equal-slot peer head replaced the unresolved sync target\n");
+        goto cleanup;
+    }
+
+    status.head.root = competing_head;
+    request_id_before = client.next_blocks_request_id;
+    if (reqresp_handle_status(&client, &status, peer_b) != LANTERN_CLIENT_OK
+        || client.next_blocks_request_id == request_id_before
+        || !lantern_root_equal(&client.network_view.head.root, &peer_head)) {
+        fprintf(stderr, "competing equal-slot head changed the active unresolved target\n");
+        goto cleanup;
+    }
+
+    status.head = (LanternCheckpoint){
+        .root = higher_head,
+        .slot = client.state.slot + 2u,
+    };
+    if (reqresp_handle_status(&client, &status, peer_b) != LANTERN_CLIENT_OK
+        || !lantern_root_equal(&client.network_view.head.root, &higher_head)) {
+        fprintf(stderr, "higher peer head did not advance the active sync target\n");
+        goto cleanup;
+    }
+
+    status.head = (LanternCheckpoint){
+        .root = lower_head,
+        .slot = client.state.slot + 1u,
+    };
+    request_id_before = client.next_blocks_request_id;
+    if (reqresp_handle_status(&client, &status, peer_a) != LANTERN_CLIENT_OK
+        || client.next_blocks_request_id == request_id_before
+        || client.network_view.head.slot != client.state.slot + 2u
+        || !lantern_root_equal(&client.network_view.head.root, &higher_head)) {
+        fprintf(stderr, "lower unknown peer head regressed the active sync target\n");
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    disable_sync_test_peer(&client);
     client_test_teardown_vote_validation_client(&client, pub, secret);
     return rc;
 }
@@ -3426,7 +3541,10 @@ int main(void) {
     if (test_pending_block_queue_sync_drops_incoming() != 0) {
         return 1;
     }
-    if (test_sync_completion_uses_network_finalized_threshold() != 0) {
+    if (test_sync_completion_requires_resolved_head_and_finalized_threshold() != 0) {
+        return 1;
+    }
+    if (test_mixed_peer_heads_keep_network_target_stable() != 0) {
         return 1;
     }
     if (test_idle_status_triggers_syncing_before_gossip_backfill() != 0) {

--- a/tests/unit/test_client_vote.c
+++ b/tests/unit/test_client_vote.c
@@ -3382,7 +3382,7 @@ cleanup:
     return rc;
 }
 
-static int test_publish_attestations_ignores_peer_status_gate_inputs(void) {
+static int test_publish_attestations_gate_on_unresolved_network_head(void) {
     struct lantern_client client;
     struct PQSignatureSchemePublicKey *pub = NULL;
     struct PQSignatureSchemeSecretKey *secret = NULL;
@@ -3460,6 +3460,30 @@ static int test_publish_attestations_ignores_peer_status_gate_inputs(void) {
     }
     if (capture.calls != 1u) {
         fprintf(stderr, "fresh mismatched peer head did not produce exactly one attestation\n");
+        goto cleanup;
+    }
+
+    capture.calls = 0u;
+    capture.payload_len = 0u;
+    client.network_view.finalized = client.store.latest_finalized;
+    client.network_view.head.slot = client.state.slot;
+    client_test_fill_root(&client.network_view.head.root, 0xcdu);
+
+    uint64_t unresolved_slot = mismatched_slot + 1u;
+    if (validator_publish_attestations(&client, unresolved_slot)
+            != LANTERN_CLIENT_ERR_RUNTIME
+        || capture.calls != 0u) {
+        fprintf(stderr, "unresolved network head should block validator attestation\n");
+        goto cleanup;
+    }
+
+    client.network_view.head = (LanternCheckpoint){
+        .root = client.store.head,
+        .slot = client.state.slot,
+    };
+    if (validator_publish_attestations(&client, unresolved_slot) != LANTERN_CLIENT_OK
+        || capture.calls != 1u) {
+        fprintf(stderr, "resolved network head should reopen validator attestation\n");
         goto cleanup;
     }
 
@@ -4098,7 +4122,7 @@ int main(void) {
     if (test_publish_attestations_includes_proposer() != 0) {
         return 1;
     }
-    if (test_publish_attestations_ignores_peer_status_gate_inputs() != 0) {
+    if (test_publish_attestations_gate_on_unresolved_network_head() != 0) {
         return 1;
     }
     if (test_validator_duties_ignore_binary_sync_state() != 0) {

--- a/tests/unit/test_libp2p.c
+++ b/tests/unit/test_libp2p.c
@@ -9,8 +9,10 @@
 #include <pthread.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 static const uint8_t kHostSecret[32] = {
     0xb7, 0x1c, 0x71, 0xa6, 0x7e, 0x11, 0x77, 0xad,
@@ -18,6 +20,45 @@ static const uint8_t kHostSecret[32] = {
     0x17, 0xae, 0x16, 0xc6, 0x66, 0x8d, 0x31, 0x3e,
     0xac, 0x2f, 0x96, 0xdb, 0xcd, 0xa3, 0xf2, 0x91,
 };
+
+static const uint8_t kPeerSecret[32] = {
+    0x31, 0xb4, 0xc8, 0x67, 0x02, 0x89, 0x5e, 0x1d,
+    0xa6, 0x73, 0xf0, 0x42, 0x9b, 0xcd, 0x16, 0x75,
+    0xe8, 0x54, 0x2f, 0x90, 0x6a, 0x13, 0xdc, 0x48,
+    0x7f, 0x25, 0xb9, 0x01, 0x5c, 0xee, 0x3a, 0x64,
+};
+
+struct connection_event_counts {
+    int established;
+    int closed;
+};
+
+static void count_connection_events(
+    struct lantern_libp2p_host *network,
+    const libp2p_host_event_t *event,
+    void *user_data) {
+    (void)network;
+    struct connection_event_counts *counts = user_data;
+    if (!event || !counts) {
+        return;
+    }
+    if (event->type == LIBP2P_HOST_EVENT_CONN_ESTABLISHED) {
+        (void)__atomic_add_fetch(&counts->established, 1, __ATOMIC_RELAXED);
+    } else if (event->type == LIBP2P_HOST_EVENT_CONN_CLOSED) {
+        (void)__atomic_add_fetch(&counts->closed, 1, __ATOMIC_RELAXED);
+    }
+}
+
+static int wait_for_event_count(const int *count, int expected) {
+    const struct timespec pause = {.tv_sec = 0, .tv_nsec = 5000000};
+    for (size_t attempt = 0; attempt < 600u; ++attempt) {
+        if (__atomic_load_n(count, __ATOMIC_RELAXED) >= expected) {
+            return 0;
+        }
+        (void)nanosleep(&pause, NULL);
+    }
+    return -1;
+}
 
 static const char *kQuicOnlyEnr =
     "enr:-IW4QKbT-CoCAKBpbYNfzfFcPfYjkqHyH-5sFlVkaKlNEPN1M5M34vIYb8HyCg56m7-V13pKWZqH9ThdYtXjjavDrP4BgmlkgnY0"
@@ -257,6 +298,82 @@ static int peer_maintenance_uses_drive_schedule(void) {
     return client.peer_maintenance_next_us != 100u + (2u * interval_us);
 }
 
+static int graceful_stop_precedes_same_identity_restart(void) {
+    struct lantern_libp2p_host restarting;
+    struct lantern_libp2p_host peer;
+    struct connection_event_counts peer_events = {0};
+    const char *restarting_listen = "/ip4/127.0.0.1/udp/19310/quic-v1";
+    const char *peer_listen = "/ip4/127.0.0.1/udp/19311/quic-v1";
+    char peer_multiaddr[256];
+    char peer_text[LANTERN_LIBP2P_PEER_TEXT_MAX_BYTES];
+    struct lantern_peer_id peer_id;
+    int rc = 1;
+
+    lantern_libp2p_host_init(&restarting);
+    lantern_libp2p_host_init(&peer);
+    struct lantern_libp2p_config restarting_config = {
+        .listen_multiaddr = restarting_listen,
+        .secp256k1_secret = kHostSecret,
+        .secret_len = sizeof(kHostSecret),
+    };
+    struct lantern_libp2p_config peer_config = {
+        .listen_multiaddr = peer_listen,
+        .secp256k1_secret = kPeerSecret,
+        .secret_len = sizeof(kPeerSecret),
+    };
+
+    if (lantern_libp2p_host_prepare(&peer, &peer_config) != 0) {
+        fprintf(stderr, "failed to prepare persistent libp2p peer\n");
+        goto cleanup;
+    }
+    memset(&peer_id, 0, sizeof(peer_id));
+    memcpy(peer_id.bytes, peer.local_peer_id, peer.local_peer_id_len);
+    peer_id.len = peer.local_peer_id_len;
+    if (lantern_peer_id_to_text(&peer_id, peer_text, sizeof(peer_text)) < 0
+        || snprintf(
+               peer_multiaddr,
+               sizeof(peer_multiaddr),
+               "%s/p2p/%s",
+               peer_listen,
+               peer_text)
+            < 0
+        || lantern_libp2p_host_register_event_handler(
+               &peer,
+               count_connection_events,
+               &peer_events)
+            != 0
+        || lantern_libp2p_host_prepare(&restarting, &restarting_config) != 0
+        || lantern_libp2p_host_launch(&peer) != 0
+        || lantern_libp2p_host_launch(&restarting) != 0
+        || lantern_libp2p_host_dial_multiaddr(&restarting, peer_multiaddr) != 0
+        || wait_for_event_count(&peer_events.established, 1) != 0) {
+        fprintf(stderr, "failed to establish initial libp2p connection\n");
+        goto cleanup;
+    }
+
+    lantern_libp2p_host_stop(&restarting);
+    if (wait_for_event_count(&peer_events.closed, 1) != 0) {
+        fprintf(stderr, "peer did not observe graceful close before restart\n");
+        goto cleanup;
+    }
+
+    lantern_libp2p_host_reset(&restarting);
+    if (lantern_libp2p_host_prepare(&restarting, &restarting_config) != 0
+        || lantern_libp2p_host_launch(&restarting) != 0
+        || lantern_libp2p_host_dial_multiaddr(&restarting, peer_multiaddr) != 0
+        || wait_for_event_count(&peer_events.established, 2) != 0) {
+        fprintf(stderr, "same-identity libp2p restart did not reconnect\n");
+        goto cleanup;
+    }
+
+    rc = 0;
+
+cleanup:
+    lantern_libp2p_host_reset(&restarting);
+    lantern_libp2p_host_reset(&peer);
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kQuickstartGenesisEnrs) / sizeof(kQuickstartGenesisEnrs[0]); ++i) {
         if (validation_accepts_quickstart_enr(kQuickstartGenesisEnrs[i]) != 0) {
@@ -281,6 +398,10 @@ int main(void) {
     }
 
     if (peer_maintenance_uses_drive_schedule() != 0) {
+        return 1;
+    }
+
+    if (graceful_stop_precedes_same_identity_restart() != 0) {
         return 1;
     }
 


### PR DESCRIPTION
Ensure validators only consider sync complete and participate in duties when the network head checkpoint is resolved (either finalized or confirmed locally). This prevents operating on unresolved peer heads that could cause validation failures.

Changes:
- Track network head as a checkpoint (slot + root) instead of just slot
- At equal slots, unresolved peer heads become sync targets; known heads keep target stable
- Validator duties are skipped if network head is above finalized but unresolved
- Sync completion requires both finalized threshold AND head resolution
- Improve libp2p graceful shutdown by draining events after close