### PR TITLE
Remove reactive peer redial; track pending stream opens

### DIFF
--- a/src/core/client_network.c
+++ b/src/core/client_network.c
@@ -843,92 +843,6 @@ void identify_dial_multiaddr(
 }
 
 
-/**
- * Attempt to redial a disconnected genesis peer.
- *
- * @param client  Client instance
- * @param peer    Peer ID to redial
- *
- * @note Thread safety: This function acquires connection_lock
- */
-void redial_peer(struct lantern_client *client, const struct lantern_peer_id *peer)
-{
-    if (!client || !client->network.host || !peer)
-    {
-        return;
-    }
-
-    const struct lantern_enr_record_list *enrs = &client->genesis.enrs;
-    if (!enrs || enrs->count == 0)
-    {
-        return;
-    }
-
-    char peer_text[128];
-    format_peer_id_text(peer, peer_text, sizeof(peer_text));
-
-    /* Check if we're still connected to this peer (e.g., via another connection).
-     * If so, skip the redial to avoid creating duplicate connections. */
-    if (peer_text[0] && lantern_client_is_peer_connected(client, peer_text))
-    {
-        lantern_log_debug(
-            "network",
-            &(const struct lantern_log_metadata){
-                .validator = client->node_id,
-                .peer = peer_text,
-            },
-            "peer still connected via another connection, skipping redial");
-        return;
-    }
-
-    /* Search for the peer in genesis ENRs */
-    for (size_t idx = 0; idx < enrs->count; ++idx)
-    {
-        const struct lantern_enr_record *record = &enrs->records[idx];
-        if (!record || !record->encoded)
-        {
-            continue;
-        }
-
-        char multiaddr[256];
-        struct lantern_peer_id enr_peer_id;
-        if (lantern_libp2p_enr_to_multiaddr(
-                record,
-                multiaddr,
-                sizeof(multiaddr),
-                &enr_peer_id) != 0)
-        {
-            continue;
-        }
-
-        if (lantern_peer_id_equal(peer, &enr_peer_id))
-        {
-            /* Found matching peer in genesis, redial */
-            lantern_log_info(
-                "network",
-                &(const struct lantern_log_metadata){
-                    .validator = client->node_id,
-                    .peer = peer_text[0] ? peer_text : NULL,
-                },
-                "redialing peer addr=%s",
-                multiaddr);
-
-            (void)lantern_libp2p_host_dial_multiaddr(&client->network, multiaddr);
-            identify_dial_multiaddr(client, multiaddr, peer_text[0] ? peer_text : record->encoded);
-            return;
-        }
-    }
-
-    /* Peer not found in genesis ENRs - cannot redial */
-    lantern_log_trace(
-        "network",
-        &(const struct lantern_log_metadata){
-            .validator = client->node_id,
-            .peer = peer_text[0] ? peer_text : NULL,
-        },
-        "peer not in genesis ENRs, skipping redial");
-}
-
 /* ============================================================================
  * Peer Dialer Helpers
  * ============================================================================ */
@@ -1368,18 +1282,7 @@ static void handle_connection_closed_event(
             app_error_code,
             transport_error_code);
     }
-
-    if (connection_close_should_redial(reason, locally_initiated))
-    {
-        redial_peer(client, peer);
-    }
 }
-
-bool connection_close_should_redial(int reason, bool locally_initiated)
-{
-    return !locally_initiated && reason != LIBP2P_HOST_OK;
-}
-
 
 /**
  * Handle outgoing connection error events.

--- a/src/core/client_network_internal.h
+++ b/src/core/client_network_internal.h
@@ -225,9 +225,6 @@ void connection_counter_update(
     bool locally_initiated,
     uint64_t transport_error_code);
 
-/** Return whether a close event should trigger reactive peer recovery. */
-bool connection_close_should_redial(int reason, bool locally_initiated);
-
 bool connection_tie_break_prefers_inbound(
     const uint8_t *local_peer_id,
     size_t local_peer_id_len,
@@ -294,16 +291,6 @@ void adopt_validator_listen_address(struct lantern_client *client);
  */
 void identify_dial_multiaddr(struct lantern_client *client, const char *multiaddr, const char *peer_label);
 
-
-/**
- * Attempt to redial a disconnected genesis peer.
- *
- * @param client  Client instance
- * @param peer    Peer ID to redial
- *
- * @note Thread safety: This function acquires connection_lock
- */
-void redial_peer(struct lantern_client *client, const struct lantern_peer_id *peer);
 
 /**
  * Attempt to dial peers from genesis ENRs.

--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -873,16 +873,6 @@ void reqresp_status_failure(void *context, const char *peer_id, int error)
         || lantern_client_status_request_failed(client, peer_copy);
     log_status_failure(client, peer_copy, error, first_failure);
 
-    if (peer_copy[0] != '\0' && error == LANTERN_REQRESP_ERR_STREAM_WRITE
-        && !lantern_client_is_peer_connected(client, peer_copy))
-    {
-        struct lantern_peer_id peer;
-        if (lantern_peer_id_from_text(peer_copy, &peer) == 0)
-        {
-            redial_peer(client, &peer);
-        }
-    }
-
     if (peer_copy[0] != '\0' && first_failure
         && lantern_client_is_peer_connected(client, peer_copy))
     {

--- a/src/networking/reqresp_service.c
+++ b/src/networking/reqresp_service.c
@@ -46,6 +46,7 @@ struct lantern_reqresp_exchange {
     LanternRoot last_range_root;
     uint64_t request_id;
     libp2p_host_time_us_t deadline_us;
+    libp2p_host_stream_open_t *open;
     uint64_t total_read_bytes;
     int completed;
     int cancelled;
@@ -824,6 +825,17 @@ static bool exchange_is_outbound_blocks_request(
             || exchange->kind == LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE);
 }
 
+static void exchange_refresh_blocks_deadline(
+    struct lantern_reqresp_exchange *exchange,
+    libp2p_host_time_us_t now_us) {
+    if (!exchange_is_outbound_blocks_request(exchange)) {
+        return;
+    }
+    exchange->deadline_us = now_us > UINT64_MAX - LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US
+        ? UINT64_MAX
+        : now_us + LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US;
+}
+
 static bool exchange_blocks_request_success(const struct lantern_reqresp_exchange *exchange) {
     return exchange && exchange->kind == LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_ROOT
         && exchange->roots_matched
@@ -951,7 +963,7 @@ static struct lantern_reqresp_exchange *service_claim_cancelled_range_exchange(
         if (exchange->outbound
             && exchange->kind == LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE
             && exchange->cancelled
-            && exchange->stream) {
+            && (exchange->stream || exchange->open)) {
             exchange->cancelled = 0;
             cancelled = exchange;
             break;
@@ -971,6 +983,19 @@ static void exchange_abort_stream(struct lantern_reqresp_exchange *exchange) {
     (void)libp2p_host_stream_reset(exchange->host, exchange->stream, 0u);
 }
 
+static bool exchange_cancel_pending_open(struct lantern_reqresp_exchange *exchange) {
+    if (!exchange || !exchange->host || !exchange->open || exchange->stream) {
+        return false;
+    }
+    libp2p_host_err_t err =
+        libp2p_host_stream_open_cancel(exchange->host, exchange->open, exchange);
+    if (err != LIBP2P_HOST_OK && err != LIBP2P_HOST_ERR_NOT_FOUND) {
+        return false;
+    }
+    exchange->open = NULL;
+    return true;
+}
+
 static void reqresp_drive(
     struct lantern_libp2p_host *network,
     libp2p_host_time_us_t now_us,
@@ -979,9 +1004,18 @@ static void reqresp_drive(
     struct lantern_reqresp_service *service = user_data;
     struct lantern_reqresp_exchange *exchange = NULL;
     while ((exchange = service_claim_cancelled_range_exchange(service)) != NULL) {
-        exchange_abort_stream(exchange);
+        if (exchange_cancel_pending_open(exchange)) {
+            service_remove_exchange(service, exchange);
+            exchange_free(exchange);
+        } else {
+            exchange_abort_stream(exchange);
+        }
     }
     while ((exchange = service_claim_timed_out_blocks_exchange(service, now_us)) != NULL) {
+        bool pending_open_cancelled = exchange_cancel_pending_open(exchange);
+        if (pending_open_cancelled) {
+            service_remove_exchange(service, exchange);
+        }
         lantern_log_warn(
             "reqresp",
             &(const struct lantern_log_metadata){
@@ -999,7 +1033,11 @@ static void reqresp_drive(
         } else {
             exchange_fail(exchange, LANTERN_REQRESP_ERR_STREAM_READ);
         }
-        exchange_abort_stream(exchange);
+        if (pending_open_cancelled) {
+            exchange_free(exchange);
+        } else {
+            exchange_abort_stream(exchange);
+        }
     }
 }
 
@@ -1234,13 +1272,9 @@ static libp2p_host_err_t reqresp_on_open(
     }
     exchange->host = host;
     exchange->stream = stream;
+    exchange->open = NULL;
     exchange_set_peer_text_from_conn(exchange, conn);
-    if (exchange_is_outbound_blocks_request(exchange)) {
-        libp2p_host_time_us_t now_us = lantern_libp2p_now_us();
-        exchange->deadline_us = now_us > UINT64_MAX - LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US
-            ? UINT64_MAX
-            : now_us + LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US;
-    }
+    exchange_refresh_blocks_deadline(exchange, lantern_libp2p_now_us());
     (void)libp2p_host_stream_set_user_data(stream, exchange);
     return LIBP2P_HOST_OK;
 }
@@ -1477,6 +1511,7 @@ static int service_open_exchange(
         }
         exchange->root_count = root_count;
     }
+    exchange_refresh_blocks_deadline(exchange, lantern_libp2p_now_us());
     service_add_exchange(service, exchange);
     const char *protocol = kReqrespProtocolIds[kind];
     libp2p_host_stream_open_t *open = NULL;
@@ -1492,6 +1527,7 @@ static int service_open_exchange(
         exchange_free(exchange);
         return -1;
     }
+    exchange->open = open;
     return 0;
 }
 

--- a/tests/unit/test_libp2p.c
+++ b/tests/unit/test_libp2p.c
@@ -210,16 +210,6 @@ static int connection_tie_break_is_symmetric(void) {
     return failed;
 }
 
-static int connection_recovery_respects_close_origin(void) {
-    if (connection_close_should_redial(LIBP2P_HOST_ERR_CLOSED, true)) {
-        return 1;
-    }
-    if (!connection_close_should_redial(LIBP2P_HOST_ERR_CLOSED, false)) {
-        return 1;
-    }
-    return connection_close_should_redial(LIBP2P_HOST_OK, false) ? 1 : 0;
-}
-
 static int connection_metrics_classify_close_details(void) {
     static const char *peer_text = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
     struct lantern_client client;
@@ -386,10 +376,6 @@ int main(void) {
     }
 
     if (connection_tie_break_is_symmetric() != 0) {
-        return 1;
-    }
-
-    if (connection_recovery_respects_close_origin() != 0) {
         return 1;
     }
 

--- a/tests/unit/test_reqresp_service.c
+++ b/tests/unit/test_reqresp_service.c
@@ -500,6 +500,116 @@ static void test_blocks_by_root_timeout_completes_failure_once(void) {
     service.exchanges = NULL;
 }
 
+static void test_pre_open_blocks_timeout_completes_failure_once(void) {
+    struct test_blocks_context test_context = {0};
+    struct lantern_reqresp_service service = {0};
+    service.callbacks.context = &test_context;
+    service.callbacks.blocks_request_complete = test_blocks_request_complete;
+
+    struct lantern_reqresp_exchange *exchange = calloc(1u, sizeof(*exchange));
+    CHECK(exchange != NULL);
+    exchange->service = &service;
+    exchange->kind = LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE;
+    exchange->outbound = 1;
+    exchange->request_id = 4242u;
+    exchange_refresh_blocks_deadline(exchange, 100u);
+    service.exchanges = exchange;
+
+    libp2p_host_t host = {
+        .magic = HOST_MAGIC,
+        .state = HOST_STATE_STARTED,
+    };
+    libp2p_host_stream_open_t open = {
+        .host = &host,
+        .state = HOST_OPEN_EVENTED,
+        .user_data = exchange,
+    };
+    exchange->host = &host;
+    exchange->open = &open;
+
+    CHECK(exchange->stream == NULL);
+    CHECK(exchange->deadline_us == 100u + LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US);
+
+    reqresp_drive(NULL, exchange->deadline_us - 1u, &service);
+    CHECK(test_context.complete_called == 0);
+
+    reqresp_drive(NULL, exchange->deadline_us, &service);
+    CHECK(test_context.complete_called == 1);
+    CHECK(test_context.complete_result == LANTERN_REQRESP_BLOCKS_REQUEST_RESULT_FAILED);
+    CHECK(exchange->completed == 1);
+    CHECK(exchange->deadline_us == 0u);
+    CHECK(service.exchanges == exchange);
+
+    reqresp_drive(NULL, UINT64_MAX, &service);
+    CHECK(test_context.complete_called == 1);
+
+    libp2p_host_event_t event = {
+        .type = LIBP2P_HOST_EVENT_STREAM_OPEN_FAILED,
+        .user_data = exchange,
+        .reason = LIBP2P_HOST_ERR_CLOSED,
+    };
+    reqresp_host_event(NULL, &event, &service);
+    CHECK(service.exchanges == NULL);
+    CHECK(test_context.complete_called == 1);
+}
+
+static void test_pre_open_cancel_releases_host_attempt(void) {
+    struct test_blocks_context test_context = {0};
+    struct lantern_reqresp_service service = {0};
+    service.callbacks.context = &test_context;
+    service.callbacks.blocks_request_complete = test_blocks_request_complete;
+
+    struct lantern_reqresp_exchange *exchange = calloc(1u, sizeof(*exchange));
+    CHECK(exchange != NULL);
+    exchange->service = &service;
+    exchange->kind = LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE;
+    exchange->outbound = 1;
+    exchange->request_id = 4243u;
+    exchange_refresh_blocks_deadline(exchange, 100u);
+    service.exchanges = exchange;
+
+    struct test_transport transport = {
+        .read_result = LIBP2P_HOST_ERR_WOULD_BLOCK,
+    };
+    libp2p_host_t host;
+    libp2p_host_stream_t stream;
+    libp2p_host_stream_open_t open = {0};
+    init_test_host_stream(&host, &stream, &transport);
+    host.streams = &stream;
+    host.stream_capacity = 1u;
+    stream.state = HOST_STREAM_NEGOTIATING;
+    stream.open_attempt = &open;
+    open.host = &host;
+    open.state = HOST_OPEN_NEGOTIATING;
+    open.user_data = exchange;
+    exchange->host = &host;
+    exchange->open = &open;
+
+    CHECK(lantern_reqresp_service_cancel_blocks_by_range_for_test(&service, 4243u));
+    reqresp_drive(NULL, 100u, &service);
+    CHECK(service.exchanges == NULL);
+    CHECK(test_context.complete_called == 0);
+    CHECK(transport.reset_called == 1u);
+    CHECK(open.state == HOST_OPEN_FREE);
+    CHECK(stream.state == HOST_STREAM_FREE);
+}
+
+static void test_blocks_deadline_refresh_preserves_full_response_window(void) {
+    struct lantern_reqresp_service service = {0};
+    struct lantern_reqresp_exchange exchange = {
+        .service = &service,
+        .kind = LANTERN_REQRESP_PROTOCOL_BLOCKS_BY_RANGE,
+        .outbound = 1,
+    };
+
+    exchange_refresh_blocks_deadline(&exchange, 100u);
+    CHECK(exchange.deadline_us == 100u + LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US);
+    exchange_refresh_blocks_deadline(&exchange, 500u);
+    CHECK(exchange.deadline_us == 500u + LANTERN_REQRESP_BLOCKS_REQUEST_TIMEOUT_US);
+    exchange_refresh_blocks_deadline(&exchange, UINT64_MAX);
+    CHECK(exchange.deadline_us == UINT64_MAX);
+}
+
 static void test_blocks_by_range_timeout_distinguishes_received_data(void) {
     enum lantern_reqresp_blocks_request_result expected_results[] = {
         LANTERN_REQRESP_BLOCKS_REQUEST_RESULT_FAILED,
@@ -893,6 +1003,9 @@ int main(void) {
     test_blocks_by_root_unrequested_block_fails_before_callback();
     test_blocks_by_root_empty_batch_is_reported();
     test_blocks_by_root_timeout_completes_failure_once();
+    test_pre_open_blocks_timeout_completes_failure_once();
+    test_pre_open_cancel_releases_host_attempt();
+    test_blocks_deadline_refresh_preserves_full_response_window();
     test_blocks_by_range_timeout_distinguishes_received_data();
     test_blocks_by_range_closed_read_completes_success();
     test_cancelled_range_does_not_timeout_or_complete();


### PR DESCRIPTION
Remove automatic peer redial logic triggered by connection close events and reqresp failures. This simplifies peer recovery by delegating it to higher-level components.

Add infrastructure to track pending stream open attempts (exchange->open) before they complete. Implement proper timeout and cancellation handling for in-flight opens via exchange_refresh_blocks_deadline() and exchange_cancel_pending_open(). This enables safe cleanup of requests that timeout or are cancelled while the stream is still opening.

Update submodule c-lean-libp2p and add comprehensive tests for pre-open timeout and cancellation scenarios.