### PR TITLE
Track range request response progress

### DIFF
--- a/include/lantern/core/client.h
+++ b/include/lantern/core/client.h
@@ -130,6 +130,7 @@ struct lantern_range_sync_state {
     uint64_t request_id;
     uint64_t request_start_slot;
     uint64_t request_count;
+    uint64_t request_next_slot;
     char request_peer[128];
     struct lantern_string_list failed_peers;
     bool peers_exhausted;

--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -1697,11 +1697,19 @@ int reqresp_handle_block_response(
         {
             return LANTERN_CLIENT_ERR_RUNTIME;
         }
-        return import_block_response_now(
+        int rc = import_block_response_now(
             client,
             block,
             &block_root,
             peer_id);
+        if (rc == LANTERN_CLIENT_OK)
+        {
+            lantern_client_note_range_response(
+                client,
+                request_id,
+                block->block.slot);
+        }
+        return rc;
     }
 
     struct lantern_async_block_import_job *job = calloc(1u, sizeof(*job));
@@ -1718,6 +1726,10 @@ int reqresp_handle_block_response(
     }
     if (enqueue_block_import_job(client, job) == 0)
     {
+        lantern_client_note_range_response(
+            client,
+            request_id,
+            block->block.slot);
         return LANTERN_CLIENT_OK;
     }
     block_import_job_free(job);

--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -1624,6 +1624,7 @@ bool lantern_client_schedule_next_range_request(struct lantern_client *client)
     range->request_id = next_blocks_request_id_locked(client);
     range->request_start_slot = range->next_slot;
     range->request_count = count;
+    range->request_next_slot = 0u;
     (void)lantern_string_copy(
         range->request_peer,
         sizeof(range->request_peer),
@@ -1714,6 +1715,29 @@ void lantern_client_update_range_sync_target(
     (void)lantern_client_schedule_next_range_request(client);
 }
 
+void lantern_client_note_range_response(
+    struct lantern_client *client,
+    uint64_t request_id,
+    uint64_t block_slot)
+{
+    if (!client || request_id == 0u || block_slot == UINT64_MAX
+        || !client->status_lock_initialized
+        || pthread_mutex_lock(&client->status_lock) != 0)
+    {
+        return;
+    }
+
+    struct lantern_range_sync_state *range = &client->range_sync;
+    if (range->request_id == request_id
+        && block_slot >= range->request_start_slot
+        && block_slot - range->request_start_slot < range->request_count
+        && block_slot + 1u > range->request_next_slot)
+    {
+        range->request_next_slot = block_slot + 1u;
+    }
+    pthread_mutex_unlock(&client->status_lock);
+}
+
 bool lantern_client_complete_range_request(
     struct lantern_client *client,
     uint64_t request_id,
@@ -1734,11 +1758,13 @@ bool lantern_client_complete_range_request(
 
     uint64_t start_slot = range->request_start_slot;
     uint64_t count = range->request_count;
+    uint64_t request_next_slot = range->request_next_slot;
     char peer_text[PEER_TEXT_BUFFER_LEN];
     (void)lantern_string_copy(peer_text, sizeof(peer_text), range->request_peer);
     range->request_id = 0u;
     range->request_start_slot = 0u;
     range->request_count = 0u;
+    range->request_next_slot = 0u;
     range->request_peer[0] = '\0';
 
     if (count == 0u || start_slot > UINT64_MAX - count)
@@ -1769,8 +1795,20 @@ bool lantern_client_complete_range_request(
             range_batch_policy_timed_out_with_data(range);
         }
         range->peers_exhausted = false;
-        should_continue =
+        bool peer_recorded =
             lantern_string_list_append_unique(&range->failed_peers, peer_text) == 0;
+        if (request_next_slot > range->next_slot)
+        {
+            range->next_slot = request_next_slot;
+        }
+        if (range->next_slot <= range->target_slot)
+        {
+            should_continue = peer_recorded;
+        }
+        else
+        {
+            range_completed = true;
+        }
     }
     pthread_mutex_unlock(&client->status_lock);
 

--- a/src/core/client_sync_internal.h
+++ b/src/core/client_sync_internal.h
@@ -656,6 +656,12 @@ void lantern_client_update_range_sync_target(
 /** Schedule the next batch for an already-discovered range target. */
 bool lantern_client_schedule_next_range_request(struct lantern_client *client);
 
+/** Record the exclusive sync frontier reached by an active range response. */
+void lantern_client_note_range_response(
+    struct lantern_client *client,
+    uint64_t request_id,
+    uint64_t block_slot);
+
 /** Complete a tracked blocks-by-range request. */
 bool lantern_client_complete_range_request(
     struct lantern_client *client,

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -2938,11 +2938,50 @@ static void set_range_request_for_test(
     client->range_sync.request_id = request_id;
     client->range_sync.request_start_slot = client->range_sync.next_slot;
     client->range_sync.request_count = count;
+    client->range_sync.request_next_slot = 0u;
     (void)snprintf(
         client->range_sync.request_peer,
         sizeof(client->range_sync.request_peer),
         "%s",
         peer_id);
+}
+
+static int test_partial_range_failure_preserves_received_progress(void)
+{
+    struct lantern_client client;
+    const char *peer_id = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
+    int rc = 1;
+
+    memset(&client, 0, sizeof(client));
+    client.node_id = "partial_range_progress";
+    if (enable_sync_test_peer(&client, peer_id) != 0)
+    {
+        goto cleanup;
+    }
+
+    client.range_sync.next_slot = 20u;
+    client.range_sync.target_slot = 30u;
+    set_range_request_for_test(&client, 100u, 8u, peer_id);
+    lantern_client_note_range_response(&client, 100u, 20u);
+    lantern_client_note_range_response(&client, 100u, 22u);
+
+    if (!lantern_client_complete_range_request(
+            &client,
+            100u,
+            LANTERN_BLOCKS_REQUEST_FAILED)
+        || client.range_sync.next_slot != 23u
+        || client.range_sync.request_id != 0u
+        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_id))
+    {
+        fprintf(stderr, "partial range failure discarded received progress\n");
+        goto cleanup;
+    }
+
+    rc = 0;
+
+cleanup:
+    disable_sync_test_peer(&client);
+    return rc;
 }
 
 static int test_range_batch_size_adapts_and_locks_after_data_timeout(void)
@@ -3919,6 +3958,9 @@ int main(void) {
         return 1;
     }
     if (test_range_response_bounds_and_completion_progress() != 0) {
+        return 1;
+    }
+    if (test_partial_range_failure_preserves_received_progress() != 0) {
         return 1;
     }
     if (test_range_batch_size_adapts_and_locks_after_data_timeout() != 0) {


### PR DESCRIPTION
Add request_next_slot tracking to preserve progress when a blocks-by-range request partially fails. When blocks are successfully imported, note_range_response() updates the highest slot received. On request completion, even if the request fails, the sync frontier advances to include all received blocks rather than discarding them.