### PR TITLE
Handle empty range as progress without policy success

### DIFF
--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -1774,9 +1774,13 @@ bool lantern_client_complete_range_request(
 
     bool should_continue = false;
     bool range_completed = false;
-    if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS)
+    if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS
+        || outcome == LANTERN_BLOCKS_REQUEST_EMPTY)
     {
-        range_batch_policy_succeeded(range);
+        if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS)
+        {
+            range_batch_policy_succeeded(range);
+        }
         range->peers_exhausted = false;
         range->next_slot = start_slot + count;
         if (range->next_slot <= range->target_slot)

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -3031,13 +3031,14 @@ static int test_range_batch_size_adapts_and_locks_after_data_timeout(void)
             &client,
             request_id - 1u,
             LANTERN_BLOCKS_REQUEST_EMPTY)
-        || client.range_sync.next_slot != retry_slot
+        || client.range_sync.next_slot != retry_slot + 64u
         || client.range_sync.batch_size != 64u
         || client.range_sync.batch_size_locked)
     {
         fprintf(stderr, "empty range response changed the batch policy\n");
         goto cleanup;
     }
+    retry_slot = client.range_sync.next_slot;
 
     set_range_request_for_test(&client, request_id++, 64u, peer_id);
     if (!lantern_client_complete_range_request(
@@ -3149,73 +3150,22 @@ cleanup:
     return rc;
 }
 
-static int test_empty_range_rotates_peers_and_waits_for_status_refresh(void)
+static int test_empty_range_advances_authoritative_coverage(void)
 {
     struct lantern_client client;
-    const char *peer_a = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
-    const char *peer_b = "16Uiu2HAkutTMoTzDw1tCvSRtu6YoixJwS46S1ZFxW8hSx9fWHiPs";
-    LanternRoot peer_head;
+    const char *peer_id = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
     int rc = 1;
 
     memset(&client, 0, sizeof(client));
-    client.node_id = "empty_range_rotation";
-    client_test_fill_root(&peer_head, 0x87u);
-    if (enable_sync_test_peer(&client, peer_a) != 0
-        || set_sync_test_connected_peers(&client, peer_a, peer_b) != 0)
-    {
-        goto cleanup;
-    }
-
-    if (pthread_mutex_lock(&client.status_lock) != 0)
-    {
-        goto cleanup;
-    }
-    struct lantern_peer_status_entry *status_a =
-        lantern_client_ensure_status_entry_locked(&client, peer_a);
-    struct lantern_peer_status_entry *status_b =
-        lantern_client_ensure_status_entry_locked(&client, peer_b);
-    status_a = lantern_client_find_status_entry_locked(&client, peer_a);
-    status_b = lantern_client_find_status_entry_locked(&client, peer_b);
-    if (status_a && status_b)
-    {
-        status_a->status.head = (LanternCheckpoint){
-            .root = peer_head,
-            .slot = 24u,
-        };
-        status_b->status = status_a->status;
-        status_a->last_status_ms = 1u;
-        status_b->last_status_ms = 1u;
-    }
-    pthread_mutex_unlock(&client.status_lock);
-    if (!status_a || !status_b)
+    client.node_id = "empty_range_coverage";
+    if (enable_sync_test_peer(&client, peer_id) != 0)
     {
         goto cleanup;
     }
 
     client.range_sync.next_slot = 20u;
     client.range_sync.target_slot = 24u;
-    client.next_blocks_request_id = 1u;
-    if (lantern_string_list_append_unique(
-            &client.range_sync.failed_peers,
-            peer_a)
-        != 0)
-    {
-        goto cleanup;
-    }
-    uint64_t request_id_before = client.next_blocks_request_id;
-    LanternStatusMessage refreshed = status_a->status;
-    if (reqresp_handle_status(&client, &refreshed, peer_a) != LANTERN_CLIENT_OK
-        || client.next_blocks_request_id != request_id_before + 1u
-        || !client.range_sync.peers_exhausted
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_a)
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_b))
-    {
-        fprintf(stderr, "status refresh interrupted range peer rotation\n");
-        goto cleanup;
-    }
-
-    lantern_string_list_reset(&client.range_sync.failed_peers);
-    client.range_sync.peers_exhausted = false;
+    client.range_sync.batch_size = 8u;
     client.range_sync.request_id = 90u;
     client.range_sync.request_start_slot = 20u;
     client.range_sync.request_count = 5u;
@@ -3223,42 +3173,20 @@ static int test_empty_range_rotates_peers_and_waits_for_status_refresh(void)
         client.range_sync.request_peer,
         sizeof(client.range_sync.request_peer),
         "%s",
-        peer_a);
+        peer_id);
 
-    request_id_before = client.next_blocks_request_id;
     if (!lantern_client_complete_range_request(
             &client,
             90u,
             LANTERN_BLOCKS_REQUEST_EMPTY)
-        || client.range_sync.next_slot != 20u
+        || client.range_sync.next_slot != 25u
         || client.range_sync.request_id != 0u
-        || client.next_blocks_request_id != request_id_before + 1u
-        || !client.range_sync.peers_exhausted
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_a)
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_b))
+        || client.range_sync.batch_size != 8u
+        || client.range_sync.batch_size_locked
+        || client.range_sync.peers_exhausted
+        || client.range_sync.failed_peers.len != 0u)
     {
-        fprintf(stderr, "empty range did not rotate once and preserve its retry slot\n");
-        goto cleanup;
-    }
-
-    request_id_before = client.next_blocks_request_id;
-    if (lantern_client_schedule_next_range_request(&client)
-        || lantern_client_schedule_next_range_request(&client)
-        || client.next_blocks_request_id != request_id_before)
-    {
-        fprintf(stderr, "exhausted range peers retried without refreshed eligibility\n");
-        goto cleanup;
-    }
-
-    if (reqresp_handle_status(&client, &refreshed, peer_a) != LANTERN_CLIENT_OK
-        || client.range_sync.next_slot != 20u
-        || client.range_sync.request_id != 0u
-        || client.next_blocks_request_id != request_id_before + 1u
-        || !client.range_sync.peers_exhausted
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_a)
-        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_b))
-    {
-        fprintf(stderr, "fresh status did not permit exactly one backed-off range retry\n");
+        fprintf(stderr, "empty range did not advance authoritative coverage\n");
         goto cleanup;
     }
 
@@ -3966,7 +3894,7 @@ int main(void) {
     if (test_range_batch_size_adapts_and_locks_after_data_timeout() != 0) {
         return 1;
     }
-    if (test_empty_range_rotates_peers_and_waits_for_status_refresh() != 0) {
+    if (test_empty_range_advances_authoritative_coverage() != 0) {
         return 1;
     }
     if (test_terminal_range_recovery_requests_unresolved_parent() != 0) {


### PR DESCRIPTION
When a blocks request returns LANTERN_BLOCKS_REQUEST_EMPTY, treat the range as progressed (clear peers_exhausted and advance next_slot) but only invoke range_batch_policy_succeeded for real SUCCESS. This preserves batch-size/backoff policy on empty responses while still advancing authoritative coverage. Updated unit tests to match the new behavior: adjusted expectations, simplified the empty-range test (renamed to test_empty_range_advances_authoritative_coverage), and updated assertions around next_slot, batch_size locking, peers_exhausted, and failed_peers.