### PR TITLE
Defer empty range advancement until all peers agree

### DIFF
--- a/include/lantern/core/client.h
+++ b/include/lantern/core/client.h
@@ -133,6 +133,7 @@ struct lantern_range_sync_state {
     uint64_t request_next_slot;
     char request_peer[128];
     struct lantern_string_list failed_peers;
+    struct lantern_string_list empty_peers;
     bool peers_exhausted;
     bool batch_size_locked;
 };

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -2460,6 +2460,7 @@ void lantern_shutdown(struct lantern_client *client)
     free(client->active_blocks_requests);
     free(client->block_fetches);
     lantern_string_list_reset(&client->range_sync.failed_peers);
+    lantern_string_list_reset(&client->range_sync.empty_peers);
     if (status_locked)
     {
         pthread_mutex_unlock(&client->status_lock);

--- a/src/core/client_reqresp.c
+++ b/src/core/client_reqresp.c
@@ -530,6 +530,7 @@ void lantern_client_update_sync_progress(
         range_completed = true;
         retired_request_id = range->request_id;
         lantern_string_list_reset(&range->failed_peers);
+        lantern_string_list_reset(&range->empty_peers);
         *range = (struct lantern_range_sync_state){0};
     }
     LanternStatusMessage network_view = client->network_view;
@@ -653,7 +654,8 @@ static void lantern_client_peer_status_update(
         && range->next_slot != 0u
         && range->next_slot <= range->target_slot)
     {
-        if (lantern_string_list_remove(&range->failed_peers, peer_id_text))
+        if (!lantern_string_list_contains(&range->empty_peers, peer_id_text)
+            && lantern_string_list_remove(&range->failed_peers, peer_id_text))
         {
             range->peers_exhausted = false;
         }

--- a/src/core/client_sync.c
+++ b/src/core/client_sync.c
@@ -1575,6 +1575,46 @@ static void range_batch_policy_timed_out_with_data(
     range->batch_size_locked = true;
 }
 
+static void range_clear_empty_peer_failures(struct lantern_range_sync_state *range)
+{
+    if (!range)
+    {
+        return;
+    }
+    for (size_t i = 0; i < range->empty_peers.len; ++i)
+    {
+        (void)lantern_string_list_remove(
+            &range->failed_peers,
+            range->empty_peers.items[i]);
+    }
+    lantern_string_list_reset(&range->empty_peers);
+}
+
+static bool range_all_eligible_peers_empty_locked(
+    struct lantern_client *client,
+    uint64_t min_slot)
+{
+    bool found = false;
+    for (size_t i = 0; i < client->peer_status_count; ++i)
+    {
+        struct lantern_peer_status_entry *peer = &client->peer_status_entries[i];
+        if (!peer->peer_id[0]
+            || peer->status.head.slot < min_slot
+            || !lantern_client_is_peer_connected(client, peer->peer_id))
+        {
+            continue;
+        }
+        found = true;
+        if (!lantern_string_list_contains(
+                &client->range_sync.empty_peers,
+                peer->peer_id))
+        {
+            return false;
+        }
+    }
+    return found;
+}
+
 bool lantern_client_schedule_next_range_request(struct lantern_client *client)
 {
     if (!client || !client->status_lock_initialized
@@ -1704,6 +1744,7 @@ void lantern_client_update_range_sync_target(
         {
             range->next_slot = local_next_slot;
             lantern_string_list_reset(&range->failed_peers);
+            lantern_string_list_reset(&range->empty_peers);
             range->peers_exhausted = false;
         }
         if (bounded_target_slot > range->target_slot)
@@ -1774,13 +1815,10 @@ bool lantern_client_complete_range_request(
 
     bool should_continue = false;
     bool range_completed = false;
-    if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS
-        || outcome == LANTERN_BLOCKS_REQUEST_EMPTY)
+    if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS)
     {
-        if (outcome == LANTERN_BLOCKS_REQUEST_SUCCESS)
-        {
-            range_batch_policy_succeeded(range);
-        }
+        range_clear_empty_peer_failures(range);
+        range_batch_policy_succeeded(range);
         range->peers_exhausted = false;
         range->next_slot = start_slot + count;
         if (range->next_slot <= range->target_slot)
@@ -1799,15 +1837,35 @@ bool lantern_client_complete_range_request(
             range_batch_policy_timed_out_with_data(range);
         }
         range->peers_exhausted = false;
-        bool peer_recorded =
-            lantern_string_list_append_unique(&range->failed_peers, peer_text) == 0;
+        bool peer_recorded = peer_text[0]
+            && lantern_string_list_append_unique(
+                   &range->failed_peers,
+                   peer_text)
+                == 0;
+        bool empty_recorded = outcome != LANTERN_BLOCKS_REQUEST_EMPTY
+            || (peer_text[0]
+                && lantern_string_list_append_unique(
+                       &range->empty_peers,
+                       peer_text)
+                    == 0);
+        bool empty_range_confirmed = outcome == LANTERN_BLOCKS_REQUEST_EMPTY
+            && empty_recorded
+            && range_all_eligible_peers_empty_locked(
+                client,
+                start_slot + count - 1u);
+        if (empty_range_confirmed)
+        {
+            range_clear_empty_peer_failures(range);
+            range->next_slot = start_slot + count;
+        }
         if (request_next_slot > range->next_slot)
         {
+            range_clear_empty_peer_failures(range);
             range->next_slot = request_next_slot;
         }
         if (range->next_slot <= range->target_slot)
         {
-            should_continue = peer_recorded;
+            should_continue = peer_recorded && empty_recorded;
         }
         else
         {

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -280,6 +280,7 @@ static void disable_sync_test_peer(struct lantern_client *client)
     client->block_fetch_count = 0u;
     client->block_fetch_capacity = 0u;
     lantern_string_list_reset(&client->range_sync.failed_peers);
+    lantern_string_list_reset(&client->range_sync.empty_peers);
     client->range_sync = (struct lantern_range_sync_state){0};
     client->next_blocks_request_id = 0u;
     lantern_client_debug_pending_reset(client);
@@ -3026,6 +3027,22 @@ static int test_range_batch_size_adapts_and_locks_after_data_timeout(void)
     }
 
     uint64_t retry_slot = client.range_sync.next_slot;
+    if (pthread_mutex_lock(&client.status_lock) != 0)
+    {
+        goto cleanup;
+    }
+    struct lantern_peer_status_entry *status =
+        lantern_client_ensure_status_entry_locked(&client, peer_id);
+    if (status)
+    {
+        status->status.head.slot = 4096u;
+        status->last_status_ms = 1u;
+    }
+    pthread_mutex_unlock(&client.status_lock);
+    if (!status)
+    {
+        goto cleanup;
+    }
     set_range_request_for_test(&client, request_id++, 64u, peer_id);
     if (!lantern_client_complete_range_request(
             &client,
@@ -3113,6 +3130,7 @@ static int test_range_batch_size_adapts_and_locks_after_data_timeout(void)
     }
 
     lantern_string_list_reset(&client.range_sync.failed_peers);
+    lantern_string_list_reset(&client.range_sync.empty_peers);
     client.range_sync = (struct lantern_range_sync_state){0};
     lantern_client_update_range_sync_target(&client, 0u, 4096u);
     while (client.range_sync.batch_size < LANTERN_MAX_REQUEST_BLOCKS)
@@ -3150,15 +3168,38 @@ cleanup:
     return rc;
 }
 
-static int test_empty_range_advances_authoritative_coverage(void)
+static int test_empty_range_advances_after_all_eligible_peers_agree(void)
 {
     struct lantern_client client;
-    const char *peer_id = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
+    const char *peer_a = "16Uiu2HAmQj1RDNAxopeeeCFPRr3zhJYmH6DEPHYKmxLViLahWcFE";
+    const char *peer_b = "16Uiu2HAkutTMoTzDw1tCvSRtu6YoixJwS46S1ZFxW8hSx9fWHiPs";
     int rc = 1;
 
     memset(&client, 0, sizeof(client));
-    client.node_id = "empty_range_coverage";
-    if (enable_sync_test_peer(&client, peer_id) != 0)
+    client.node_id = "empty_range_peer_round";
+    if (enable_sync_test_peer(&client, peer_a) != 0
+        || set_sync_test_connected_peers(&client, peer_a, peer_b) != 0)
+    {
+        goto cleanup;
+    }
+
+    if (pthread_mutex_lock(&client.status_lock) != 0)
+    {
+        goto cleanup;
+    }
+    struct lantern_peer_status_entry *status_a =
+        lantern_client_ensure_status_entry_locked(&client, peer_a);
+    struct lantern_peer_status_entry *status_b =
+        lantern_client_ensure_status_entry_locked(&client, peer_b);
+    if (status_a && status_b)
+    {
+        status_a->status.head.slot = 24u;
+        status_b->status.head.slot = 24u;
+        status_a->last_status_ms = 1u;
+        status_b->last_status_ms = 1u;
+    }
+    pthread_mutex_unlock(&client.status_lock);
+    if (!status_a || !status_b)
     {
         goto cleanup;
     }
@@ -3173,20 +3214,56 @@ static int test_empty_range_advances_authoritative_coverage(void)
         client.range_sync.request_peer,
         sizeof(client.range_sync.request_peer),
         "%s",
-        peer_id);
+        peer_a);
 
     if (!lantern_client_complete_range_request(
             &client,
             90u,
+            LANTERN_BLOCKS_REQUEST_EMPTY)
+        || client.range_sync.next_slot != 20u
+        || client.range_sync.request_id != 0u
+        || !client.range_sync.peers_exhausted
+        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_a)
+        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_b)
+        || !lantern_string_list_contains(&client.range_sync.empty_peers, peer_a)
+        || lantern_string_list_contains(&client.range_sync.empty_peers, peer_b))
+    {
+        fprintf(stderr, "first empty response advanced before trying another peer\n");
+        goto cleanup;
+    }
+
+    LanternStatusMessage refreshed = status_a->status;
+    if (reqresp_handle_status(&client, &refreshed, peer_a) != LANTERN_CLIENT_OK
+        || !lantern_string_list_contains(&client.range_sync.failed_peers, peer_a)
+        || !lantern_string_list_contains(&client.range_sync.empty_peers, peer_a))
+    {
+        fprintf(stderr, "status refresh re-enabled an empty peer during rotation\n");
+        goto cleanup;
+    }
+
+    (void)lantern_string_list_remove(&client.range_sync.failed_peers, peer_b);
+    client.range_sync.peers_exhausted = false;
+    client.range_sync.request_id = 91u;
+    client.range_sync.request_start_slot = 20u;
+    client.range_sync.request_count = 5u;
+    (void)snprintf(
+        client.range_sync.request_peer,
+        sizeof(client.range_sync.request_peer),
+        "%s",
+        peer_b);
+    if (!lantern_client_complete_range_request(
+            &client,
+            91u,
             LANTERN_BLOCKS_REQUEST_EMPTY)
         || client.range_sync.next_slot != 25u
         || client.range_sync.request_id != 0u
         || client.range_sync.batch_size != 8u
         || client.range_sync.batch_size_locked
         || client.range_sync.peers_exhausted
-        || client.range_sync.failed_peers.len != 0u)
+        || client.range_sync.failed_peers.len != 0u
+        || client.range_sync.empty_peers.len != 0u)
     {
-        fprintf(stderr, "empty range did not advance authoritative coverage\n");
+        fprintf(stderr, "all-empty peer round did not advance range coverage\n");
         goto cleanup;
     }
 
@@ -3894,7 +3971,7 @@ int main(void) {
     if (test_range_batch_size_adapts_and_locks_after_data_timeout() != 0) {
         return 1;
     }
-    if (test_empty_range_advances_authoritative_coverage() != 0) {
+    if (test_empty_range_advances_after_all_eligible_peers_agree() != 0) {
         return 1;
     }
     if (test_terminal_range_recovery_requests_unresolved_parent() != 0) {


### PR DESCRIPTION
Add explicit tracking of empty peer responses to prevent prematurely advancing past ranges. A range now only advances on empty responses after all eligible peers have confirmed the range is empty, rather than advancing on the first peer's empty response. This prevents missing blocks when peers have different data availability.

Changes:
- Add empty_peers list to track peers reporting empty ranges
- Add range_clear_empty_peer_failures() to clean up failed_peers for empty confirmations
- Add range_all_eligible_peers_empty_locked() to verify all peers agree a range is empty
- Update range completion logic to handle EMPTY responses as failures until consensus
- Refactor test to validate the new consensus-based behavior