### PR TITLE
Use stdlib time() instead of custom wrapper

### DIFF
--- a/src/core/client.c
+++ b/src/core/client.c
@@ -776,8 +776,8 @@ lantern_client_error lantern_client_options_add_bootnodes_argument(
 static void client_reset_base(struct lantern_client *client)
 {
     memset(client, 0, sizeof(*client));
-    double now_seconds = lantern_time_now_seconds();
-    client->start_time_seconds = now_seconds > 0.0 ? (uint64_t)now_seconds : 0u;
+    time_t now_seconds = time(NULL);
+    client->start_time_seconds = now_seconds > 0 ? (uint64_t)now_seconds : 0u;
     lantern_metrics_server_init(&client->metrics_server);
     lantern_http_server_init(&client->http_server);
     lantern_store_init(&client->store);


### PR DESCRIPTION
Replace lantern_time_now_seconds() with standard C library time(NULL) in client_reset_base(). This simplifies the code by removing a custom time wrapper and using the standard time_t type with appropriate integer comparisons.