### PR TITLE
Add prover-arena option for XMSS prover

### DIFF
--- a/include/lantern/consensus/signature.h
+++ b/include/lantern/consensus/signature.h
@@ -26,6 +26,7 @@ typedef enum {
 bool lantern_signature_is_zero(const LanternSignature *signature);
 void lantern_signature_zero(LanternSignature *signature);
 void lantern_signature_prewarm_prover(void);
+void lantern_signature_configure_prover(bool use_arena);
 void lantern_signature_configure_shadow_costs(
     const double rates[LANTERN_SHADOW_OPERATION_COUNT],
     uint8_t configured_rates);

--- a/include/lantern/core/client.h
+++ b/include/lantern/core/client.h
@@ -78,6 +78,7 @@ struct lantern_client_options {
     const char *xmss_secret_template;
     uint64_t attestation_committee_count_override;
     bool is_aggregator;
+    bool prover_arena;
     size_t *aggregate_subnet_ids;
     size_t aggregate_subnet_id_count;
     size_t aggregate_subnet_id_capacity;

--- a/src/consensus/signature.c
+++ b/src/consensus/signature.c
@@ -101,9 +101,18 @@ struct lantern_recursive_child_input {
 
 static pthread_once_t g_xmss_verifier_setup_once = PTHREAD_ONCE_INIT;
 static pthread_once_t g_xmss_prover_setup_once = PTHREAD_ONCE_INIT;
+static bool g_xmss_prover_arena = false;
+
+void lantern_signature_configure_prover(bool use_arena) {
+    g_xmss_prover_arena = use_arena;
+}
 
 static void xmss_prover_setup_once(void) {
-    pq_xmss_aggregation_setup_prover();
+    if (g_xmss_prover_arena) {
+        pq_xmss_aggregation_setup_prover();
+    } else {
+        pq_xmss_aggregation_setup_prover_without_arena();
+    }
 }
 
 static void xmss_verifier_setup_once(void) {

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -2337,6 +2337,7 @@ lantern_client_error lantern_init(
     lantern_signature_configure_shadow_costs(
         options->shadow_xmss_rates,
         options->shadow_xmss_rates_set);
+    lantern_signature_configure_prover(options->prover_arena);
 
     client_reset_base(client);
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -43,6 +43,7 @@ enum {
     OPT_XMSS_SECRET_PATH,
     OPT_XMSS_SECRET_TEMPLATE,
     OPT_IS_AGGREGATOR,
+    OPT_PROVER_ARENA,
     OPT_ATTESTATION_COMMITTEE_COUNT,
     OPT_AGGREGATE_SUBNET_IDS,
     OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE,
@@ -80,6 +81,7 @@ static const struct option OPTIONS[] = {
     {"xmss-secret", required_argument, NULL, OPT_XMSS_SECRET_PATH},
     {"xmss-secret-template", required_argument, NULL, OPT_XMSS_SECRET_TEMPLATE},
     {"is-aggregator", no_argument, NULL, OPT_IS_AGGREGATOR},
+    {"prover-arena", no_argument, NULL, OPT_PROVER_ARENA},
     {"attestation-committee-count", required_argument, NULL, OPT_ATTESTATION_COMMITTEE_COUNT},
     {"aggregate-subnet-ids", required_argument, NULL, OPT_AGGREGATE_SUBNET_IDS},
     {"shadow-xmss-aggregate-signatures-rate", required_argument, NULL, OPT_SHADOW_XMSS_AGGREGATE_SIGNATURES_RATE},
@@ -328,6 +330,9 @@ static lantern_client_error apply_option(
     case OPT_IS_AGGREGATOR:
         options->is_aggregator = true;
         return LANTERN_CLIENT_OK;
+    case OPT_PROVER_ARENA:
+        options->prover_arena = true;
+        return LANTERN_CLIENT_OK;
     case OPT_ATTESTATION_COMMITTEE_COUNT:
         if (parse_unsigned(argument, SIZE_MAX, false, &number) != 0)
         {
@@ -423,6 +428,7 @@ static void print_usage(const char *program)
         "  --devnet NAME                Gossip topic devnet identifier\n"
         "  --attestation-committee-count N  Override committee count\n"
         "  --is-aggregator              Enable aggregation\n"
+        "  --prover-arena               Use faster, high-memory leanVM proving\n"
         "  --aggregate-subnet-ids IDS   Comma-separated imported subnets");
     lantern_log_info(
         "main",


### PR DESCRIPTION
Add support for selecting a high-memory "prover arena" mode for the XMSS prover. Exposed lantern_signature_configure_prover(bool) in the header, added a global flag used during prover setup to pick between pq_xmss_aggregation_setup_prover() and pq_xmss_aggregation_setup_prover_without_arena(). Wire the new option through lantern_client_options (prover_arena), CLI parsing (--prover-arena) and client init. Also update the c-leanvm-xmss submodule commit.