### PR TITLE
Retain latest votes across payload cache eviction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(lantern VERSION 0.1.0 LANGUAGES C)
+project(lantern LANGUAGES C)
 
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
@@ -352,6 +352,10 @@ if(LANTERN_BUILD_TESTS)
     add_executable(lantern_slot_clock_test tests/unit/test_slot_clock.c)
     target_link_libraries(lantern_slot_clock_test PRIVATE ${LANTERN_TEST_LINK_LIB})
     add_test(NAME lantern_slot_clock COMMAND lantern_slot_clock_test)
+
+    add_executable(lantern_support_test tests/unit/test_support.c)
+    target_link_libraries(lantern_support_test PRIVATE ${LANTERN_TEST_LINK_LIB})
+    add_test(NAME lantern_support COMMAND lantern_support_test)
 
     add_executable(lantern_snappy_test tests/unit/test_snappy.c)
     target_link_libraries(lantern_snappy_test PRIVATE ${LANTERN_TEST_LINK_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,31 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBYAML REQUIRED IMPORTED_TARGET yaml-0.1)
 pkg_check_modules(LIBEVENT REQUIRED IMPORTED_TARGET libevent_extra libevent_pthreads)
 
+# ---- Link time optimisation ------------------------------------------------
+option(LANTERN_ENABLE_LTO "Build lantern's own targets with link time optimisation" ON)
+
+set(LANTERN_LTO_ENABLED OFF)
+if(LANTERN_ENABLE_LTO)
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _lantern_ipo_ok OUTPUT _lantern_ipo_reason LANGUAGES C)
+    if(_lantern_ipo_ok)
+        set(LANTERN_LTO_ENABLED ON)
+    else()
+        message(STATUS "lantern: LTO unavailable, continuing without it: ${_lantern_ipo_reason}")
+    endif()
+endif()
+
+function(lantern_enable_lto target_name)
+    if(NOT LANTERN_LTO_ENABLED)
+        return()
+    endif()
+    set_target_properties(${target_name} PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+        INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON
+        INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON
+    )
+endfunction()
+
 set(LANTERN_LIBRARY_SOURCES
     src/consensus/containers.c
     src/consensus/fork_choice.c
@@ -102,6 +127,7 @@ function(lantern_define_library target_name wrapper_target)
             _DEFAULT_SOURCE
             _POSIX_C_SOURCE=200809L
     )
+    lantern_enable_lto(${target_name})
     lantern_configure_dependencies(${target_name} ${wrapper_target})
     target_link_libraries(${target_name} PRIVATE Threads::Threads CURL::libcurl PkgConfig::LIBYAML PkgConfig::LIBEVENT)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -135,6 +161,7 @@ add_custom_target(fixtures
 
 add_executable(lantern_cli src/core/main.c)
 target_link_libraries(lantern_cli PRIVATE lantern Threads::Threads)
+lantern_enable_lto(lantern_cli)
 if(NOT DEFINED LANTERN_GIT_COMMIT OR LANTERN_GIT_COMMIT STREQUAL "")
     execute_process(
         COMMAND git rev-parse --short HEAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,29 +65,29 @@ set(LANTERN_LIBRARY_SOURCES
     src/consensus/state.c
     src/consensus/store.c
     src/consensus/ssz.c
-    src/core/client.c
-    src/core/client_checkpoint.c
-    src/core/client_fork_choice.c
-    src/core/client_http.c
-    src/core/client_init.c
-    src/core/client_keys.c
-    src/core/client_network.c
-    src/core/client_options.c
-    src/core/client_peers.c
-    src/core/client_pending.c
-    src/core/client_reqresp.c
-    src/core/client_subnets.c
-    src/core/client_sync.c
-    src/core/client_sync_blocks.c
-    src/core/client_sync_votes.c
-	    src/core/client_utils.c
-		    src/core/client_validator.c
-		    src/genesis/genesis.c
-		    src/genesis/genesis_parse.c
-		    src/genesis/genesis_parse_helpers.c
-		    src/genesis/genesis_validator_config.c
-		    src/encoding/snappy.c
-	    src/networking/enr.c
+    src/core/client/lifecycle.c
+    src/core/client/checkpoint.c
+    src/core/client/fork_choice.c
+    src/core/client/http.c
+    src/core/client/init.c
+    src/core/client/keys.c
+    src/core/client/network.c
+    src/core/client/options.c
+    src/core/client/peers.c
+    src/core/client/pending.c
+    src/core/client/reqresp.c
+    src/core/client/subnets.c
+    src/core/client/sync.c
+    src/core/client/sync_blocks.c
+    src/core/client/sync_votes.c
+    src/core/client/utils.c
+    src/core/client/validator.c
+    src/genesis/genesis.c
+    src/genesis/genesis_parse.c
+    src/genesis/genesis_parse_helpers.c
+    src/genesis/genesis_validator_config.c
+    src/encoding/snappy.c
+    src/networking/enr.c
     src/networking/gossip.c
     src/networking/gossipsub_service.c
     src/networking/gossip_payloads.c

--- a/include/lantern/consensus/store.h
+++ b/include/lantern/consensus/store.h
@@ -41,6 +41,18 @@ struct lantern_aggregated_payload_pool {
     size_t capacity;
 };
 
+struct lantern_latest_vote_entry {
+    bool present;
+    LanternRoot data_root;
+    LanternAttestationData data;
+};
+
+struct lantern_latest_vote_map {
+    /* Fork-choice votes are retained independently of bounded proof caches. */
+    struct lantern_latest_vote_entry *entries;
+    size_t capacity;
+};
+
 void lantern_aggregated_payload_pool_reset(
     struct lantern_aggregated_payload_pool *pool);
 int lantern_aggregated_payload_pool_add(
@@ -57,6 +69,8 @@ struct lantern_fork_choice_block_entry {
     LanternState state;
 };
 
+struct lantern_fork_choice_root_index_entry;
+
 struct lantern_fork_choice_checkpoint_snapshot {
     atomic_uint_fast64_t sequence;
     atomic_uint_fast64_t justified_slot;
@@ -69,6 +83,8 @@ struct lantern_store {
     struct lantern_attestation_signature_map attestation_signatures;
     struct lantern_aggregated_payload_pool new_aggregated_payloads;
     struct lantern_aggregated_payload_pool known_aggregated_payloads;
+    struct lantern_latest_vote_map new_votes;
+    struct lantern_latest_vote_map known_votes;
 
     LanternCheckpoint anchor;
     uint64_t time_intervals;
@@ -81,6 +97,9 @@ struct lantern_store {
     struct lantern_fork_choice_block_entry *blocks;
     size_t block_len;
     size_t block_cap;
+    /* Root-to-block index used by fork-choice ancestry walks. */
+    struct lantern_fork_choice_root_index_entry *root_index;
+    size_t root_index_cap;
 };
 
 void lantern_store_init(LanternStore *store);

--- a/include/lantern/support/log.h
+++ b/include/lantern/support/log.h
@@ -3,68 +3,114 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdarg.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-enum LanternLogLevel {
-    LANTERN_LOG_LEVEL_TRACE = 0,
-    LANTERN_LOG_LEVEL_DEBUG,
-    LANTERN_LOG_LEVEL_INFO,
-    LANTERN_LOG_LEVEL_WARN,
-    LANTERN_LOG_LEVEL_ERROR,
-};
+    /** Log message severity. */
+    enum lantern_log_level
+    {
+        LANTERN_LOG_LEVEL_TRACE = 0,
+        LANTERN_LOG_LEVEL_DEBUG,
+        LANTERN_LOG_LEVEL_INFO,
+        LANTERN_LOG_LEVEL_WARN,
+        LANTERN_LOG_LEVEL_ERROR,
+    };
 
-struct lantern_log_metadata {
-    const char *validator;
-    const char *peer;
-    uint64_t slot;
-    bool has_slot;
-};
+    /** Borrowed context that remains valid for one log call. */
+    struct lantern_log_metadata
+    {
+        /** Validator or node identifier, or NULL when unavailable. */
+        const char *validator;
 
-void lantern_log_set_node_id(const char *node_id);
-void lantern_log_reset_node_id(void);
-void lantern_log_set_level(enum LanternLogLevel level);
-int lantern_log_set_level_from_string(const char *text, enum LanternLogLevel *out_level);
+        /** Peer identifier, or NULL when unavailable. */
+        const char *peer;
 
-void lantern_log_log(
-    enum LanternLogLevel level,
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    va_list args);
+        /** Consensus slot when has_slot is true. */
+        uint64_t slot;
 
-void lantern_log_trace(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) __attribute__((format(printf, 3, 4)));
+        /** True when slot contains a valid consensus slot. */
+        bool has_slot;
+    };
 
-void lantern_log_debug(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) __attribute__((format(printf, 3, 4)));
+    /**
+     * Set the minimum severity that the logger writes.
+     *
+     * This function is thread-safe.
+     *
+     * @param level Minimum severity.
+     *
+     * Values outside enum lantern_log_level do not change the current severity.
+     */
+    void lantern_log_set_level(enum lantern_log_level level);
 
-void lantern_log_info(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) __attribute__((format(printf, 3, 4)));
+    /**
+     * Parse and set the minimum log severity.
+     *
+     * This function is thread-safe.
+     *
+     * @param text Severity name.
+     * @param out_level Parsed severity, or NULL when it is not required.
+     * @return Zero on success, or -1 when text is invalid.
+     */
+    int lantern_log_set_level_from_string(const char *text,
+                                          enum lantern_log_level *out_level);
 
-void lantern_log_warn(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) __attribute__((format(printf, 3, 4)));
+#if defined(__GNUC__) || defined(__clang__)
+#define LANTERN_LOG_FORMAT(position, arguments)                                \
+    __attribute__((format(printf, position, arguments)))
+#else
+#define LANTERN_LOG_FORMAT(position, arguments)
+#endif
 
-void lantern_log_error(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) __attribute__((format(printf, 3, 4)));
+    /**
+     * Write a best-effort trace message with borrowed context.
+     *
+     * This function is thread-safe and borrows all pointers for the call.
+     */
+    void lantern_log_trace(const char *component,
+                           const struct lantern_log_metadata *metadata,
+                           const char *fmt, ...) LANTERN_LOG_FORMAT(3, 4);
+
+    /**
+     * Write a best-effort debug message with borrowed context.
+     *
+     * This function is thread-safe and borrows all pointers for the call.
+     */
+    void lantern_log_debug(const char *component,
+                           const struct lantern_log_metadata *metadata,
+                           const char *fmt, ...) LANTERN_LOG_FORMAT(3, 4);
+
+    /**
+     * Write a best-effort information message with borrowed context.
+     *
+     * This function is thread-safe and borrows all pointers for the call.
+     */
+    void lantern_log_info(const char *component,
+                          const struct lantern_log_metadata *metadata,
+                          const char *fmt, ...) LANTERN_LOG_FORMAT(3, 4);
+
+    /**
+     * Write a best-effort warning message with borrowed context.
+     *
+     * This function is thread-safe and borrows all pointers for the call.
+     */
+    void lantern_log_warn(const char *component,
+                          const struct lantern_log_metadata *metadata,
+                          const char *fmt, ...) LANTERN_LOG_FORMAT(3, 4);
+
+    /**
+     * Write a best-effort error message with borrowed context.
+     *
+     * This function is thread-safe and borrows all pointers for the call.
+     */
+    void lantern_log_error(const char *component,
+                           const struct lantern_log_metadata *metadata,
+                           const char *fmt, ...) LANTERN_LOG_FORMAT(3, 4);
+
+#undef LANTERN_LOG_FORMAT
 
 #ifdef __cplusplus
 }

--- a/include/lantern/support/secure_mem.h
+++ b/include/lantern/support/secure_mem.h
@@ -4,10 +4,19 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-void lantern_secure_zero(void *ptr, size_t len);
+    /**
+     * Clear a writable memory range with non-optimizable stores.
+     *
+     * This function is thread-safe for separate memory ranges.
+     *
+     * @param ptr Writable memory, or NULL when len is zero.
+     * @param len Number of bytes to clear.
+     */
+    void lantern_secure_zero(void *ptr, size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/lantern/support/string_list.h
+++ b/include/lantern/support/string_list.h
@@ -1,29 +1,64 @@
-#ifndef LANTERN_STRING_LIST_H
-#define LANTERN_STRING_LIST_H
+#ifndef LANTERN_SUPPORT_STRING_LIST_H
+#define LANTERN_SUPPORT_STRING_LIST_H
 
 #include <stdbool.h>
 #include <stddef.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-struct lantern_string_list {
-    char **items;
-    size_t len;
-    size_t capacity;
-};
+    /**
+     * An owning list of unique or repeated null-terminated strings.
+     *
+     * Use only this module to change fields. Synchronize shared mutable access.
+     */
+    struct lantern_string_list
+    {
+        /** Owned string pointers. */
+        char **items;
 
-void lantern_string_list_init(struct lantern_string_list *list);
-void lantern_string_list_reset(struct lantern_string_list *list);
-int lantern_string_list_append(struct lantern_string_list *list, const char *value);
-int lantern_string_list_append_unique(struct lantern_string_list *list, const char *value);
-bool lantern_string_list_contains(const struct lantern_string_list *list, const char *value);
-bool lantern_string_list_remove(struct lantern_string_list *list, const char *value);
-int lantern_string_list_copy(struct lantern_string_list *dst, const struct lantern_string_list *src);
+        /** Number of initialized string pointers. */
+        size_t len;
+
+        /** Number of allocated pointer entries. */
+        size_t capacity;
+    };
+
+    /** Initialize an empty list. */
+    void lantern_string_list_init(struct lantern_string_list *list);
+
+    /** Release all strings and restore an empty list. */
+    void lantern_string_list_reset(struct lantern_string_list *list);
+
+    /** Append an owned copy of value and return zero on success. */
+    int lantern_string_list_append(struct lantern_string_list *list,
+                                   const char *value);
+
+    /** Append value when it is nonempty and absent, and return zero on success.
+     */
+    int lantern_string_list_append_unique(struct lantern_string_list *list,
+                                          const char *value);
+
+    /** Return true when the list contains value. */
+    bool lantern_string_list_contains(const struct lantern_string_list *list,
+                                      const char *value);
+
+    /** Remove the first matching value and return true when it existed. */
+    bool lantern_string_list_remove(struct lantern_string_list *list,
+                                    const char *value);
+
+    /**
+     * Replace dst with an owned copy of src and return zero on success.
+     *
+     * A failed copy leaves dst unchanged. A self-copy has no effect.
+     */
+    int lantern_string_list_copy(struct lantern_string_list *dst,
+                                 const struct lantern_string_list *src);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* LANTERN_STRING_LIST_H */
+#endif /* LANTERN_SUPPORT_STRING_LIST_H */

--- a/include/lantern/support/strings.h
+++ b/include/lantern/support/strings.h
@@ -1,14 +1,44 @@
 #ifndef LANTERN_SUPPORT_STRINGS_H
 #define LANTERN_SUPPORT_STRINGS_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
-char *lantern_string_duplicate(const char *source);
-char *lantern_string_duplicate_len(const char *source, size_t length);
-size_t lantern_string_copy(char *dst, size_t dst_len, const char *src);
-char *lantern_trim_whitespace(char *value);
-int lantern_hex_decode(const char *hex, uint8_t *out, size_t out_len);
-int lantern_bytes_to_hex(const uint8_t *bytes, size_t len, char *out, size_t out_len, int include_prefix);
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @file
+     * String conversion and copy helpers.
+     *
+     * Functions are thread-safe when callers do not share writable buffers.
+     */
+
+    /** Return an owned duplicate, or NULL for invalid input or allocation
+     * failure. */
+    char *lantern_string_duplicate(const char *source);
+
+    /** Return an owned duplicate of length bytes, or NULL on failure. */
+    char *lantern_string_duplicate_len(const char *source, size_t length);
+
+    /** Copy src with termination and return its full length. */
+    size_t lantern_string_copy(char *dst, size_t dst_len, const char *src);
+
+    /** Trim value in place and return its first non-whitespace byte. */
+    char *lantern_trim_whitespace(char *value);
+
+    /** Decode exactly out_len bytes and return zero on success. */
+    int lantern_hex_decode(const char *hex, uint8_t *out, size_t out_len);
+
+    /** Encode len bytes and return zero on success. */
+    int lantern_bytes_to_hex(const uint8_t *bytes, size_t len, char *out,
+                             size_t out_len, bool include_prefix);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LANTERN_SUPPORT_STRINGS_H */

--- a/include/lantern/support/time.h
+++ b/include/lantern/support/time.h
@@ -2,10 +2,26 @@
 #define LANTERN_SUPPORT_TIME_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-double lantern_time_now_seconds(void);
+    /**
+     * Read monotonic seconds from a platform-defined origin.
+     *
+     * This function is thread-safe.
+     *
+     * @return Monotonic seconds, or -1.0 when the clock read fails.
+     */
+    double lantern_time_now_seconds(void);
+
+    /**
+     * Return elapsed seconds, or zero for invalid or reversed readings.
+     *
+     * This function is thread-safe.
+     */
+    double lantern_time_elapsed_seconds(double started_seconds,
+                                        double finished_seconds);
 
 #ifdef __cplusplus
 }

--- a/include/lantern/support/version.h
+++ b/include/lantern/support/version.h
@@ -1,15 +1,10 @@
 #ifndef LANTERN_SUPPORT_VERSION_H
 #define LANTERN_SUPPORT_VERSION_H
 
+/** User-visible Lantern release version. */
 #define LANTERN_VERSION "v0.0.5"
+
+/** User-visible Lantern client name. */
 #define LANTERN_CLIENT_NAME "lantern"
-
-#ifndef LANTERN_GIT_COMMIT
-#define LANTERN_GIT_COMMIT "unknown"
-#endif
-
-#ifndef LANTERN_GIT_BRANCH
-#define LANTERN_GIT_BRANCH "unknown"
-#endif
 
 #endif /* LANTERN_SUPPORT_VERSION_H */

--- a/src/consensus/fork_choice.c
+++ b/src/consensus/fork_choice.c
@@ -670,7 +670,10 @@ int lantern_fork_choice_add_block_with_state(
         goto rollback;
     }
     lantern_state_reset(&previous_state);
-    lean_metrics_record_fork_choice_block_time(lantern_time_now_seconds() - metrics_start);
+    lean_metrics_record_fork_choice_block_time(
+        lantern_time_elapsed_seconds(
+            metrics_start,
+            lantern_time_now_seconds()));
     fork_choice_publish_current_checkpoints(store);
     return 0;
 

--- a/src/consensus/fork_choice.c
+++ b/src/consensus/fork_choice.c
@@ -10,6 +10,12 @@
 #include "lantern/metrics/lean_metrics.h"
 #include "lantern/support/time.h"
 
+struct lantern_fork_choice_root_index_entry {
+    bool occupied;
+    LanternRoot root;
+    size_t block_index;
+};
+
 static void checkpoint_snapshot_publish_one(
     atomic_uint_fast64_t *slot,
     atomic_uchar *root,
@@ -48,9 +54,118 @@ static int root_compare(const LanternRoot *a, const LanternRoot *b) {
     return memcmp(a->bytes, b->bytes, sizeof(a->bytes));
 }
 
+static uint64_t root_hash(const LanternRoot *root) {
+    uint64_t hash = UINT64_C(14695981039346656037);
+    for (size_t i = 0u; i < LANTERN_ROOT_SIZE; ++i) {
+        hash ^= root->bytes[i];
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash;
+}
+
+static bool root_index_lookup(
+    const LanternStore *store,
+    const LanternRoot *root,
+    size_t *out_index) {
+    if (!store || !root || !store->root_index || store->root_index_cap == 0u) {
+        return false;
+    }
+    size_t slot = (size_t)(root_hash(root) % store->root_index_cap);
+    for (size_t checked = 0u; checked < store->root_index_cap; ++checked) {
+        const struct lantern_fork_choice_root_index_entry *entry =
+            &store->root_index[slot];
+        if (!entry->occupied) {
+            return false;
+        }
+        if (root_compare(&entry->root, root) == 0) {
+            if (out_index) {
+                *out_index = entry->block_index;
+            }
+            return true;
+        }
+        slot = (slot + 1u) % store->root_index_cap;
+    }
+    return false;
+}
+
+static void root_index_insert(
+    struct lantern_fork_choice_root_index_entry *entries,
+    size_t capacity,
+    const LanternRoot *root,
+    size_t block_index) {
+    size_t slot = (size_t)(root_hash(root) % capacity);
+    while (entries[slot].occupied) {
+        if (root_compare(&entries[slot].root, root) == 0) {
+            entries[slot].block_index = block_index;
+            return;
+        }
+        slot = (slot + 1u) % capacity;
+    }
+    entries[slot].occupied = true;
+    entries[slot].root = *root;
+    entries[slot].block_index = block_index;
+}
+
+static int rebuild_root_index(LanternStore *store, size_t required_blocks) {
+    if (!store) {
+        return -1;
+    }
+    if (required_blocks == 0u) {
+        free(store->root_index);
+        store->root_index = NULL;
+        store->root_index_cap = 0u;
+        return 0;
+    }
+    if (required_blocks > SIZE_MAX / 2u) {
+        return -1;
+    }
+    size_t capacity = 8u;
+    while (capacity < required_blocks * 2u) {
+        if (capacity > SIZE_MAX / 2u) {
+            return -1;
+        }
+        capacity *= 2u;
+    }
+    struct lantern_fork_choice_root_index_entry *entries =
+        calloc(capacity, sizeof(*entries));
+    if (!entries) {
+        return -1;
+    }
+    for (size_t i = 0u; i < store->block_len; ++i) {
+        root_index_insert(entries, capacity, &store->blocks[i].root, i);
+    }
+    free(store->root_index);
+    store->root_index = entries;
+    store->root_index_cap = capacity;
+    return 0;
+}
+
+static int ensure_root_index_capacity(LanternStore *store, size_t required_blocks) {
+    if (!store) {
+        return -1;
+    }
+    if (store->root_index
+        && required_blocks <= store->root_index_cap / 2u) {
+        return 0;
+    }
+    return rebuild_root_index(store, required_blocks);
+}
+
+static void refresh_root_index(LanternStore *store) {
+    if (!store || rebuild_root_index(store, store->block_len) == 0) {
+        return;
+    }
+    free(store->root_index);
+    store->root_index = NULL;
+    store->root_index_cap = 0u;
+}
+
 static bool find_block_index(const LanternStore *store, const LanternRoot *root, size_t *out_index) {
     if (!store || !root || !store->blocks) {
         return false;
+    }
+    if (store->root_index) {
+        return root_index_lookup(store, root, out_index);
     }
     for (size_t i = 0; i < store->block_len; ++i) {
         if (root_compare(&store->blocks[i].root, root) == 0) {
@@ -180,12 +295,17 @@ void lantern_fork_choice_reset(LanternStore *store) {
     struct lantern_attestation_signature_map attestation_signatures = store->attestation_signatures;
     struct lantern_aggregated_payload_pool new_payloads = store->new_aggregated_payloads;
     struct lantern_aggregated_payload_pool known_payloads = store->known_aggregated_payloads;
+    struct lantern_latest_vote_map new_votes = store->new_votes;
+    struct lantern_latest_vote_map known_votes = store->known_votes;
     block_states_reset(store);
     free(store->blocks);
+    free(store->root_index);
     lantern_store_init(store);
     store->attestation_signatures = attestation_signatures;
     store->new_aggregated_payloads = new_payloads;
     store->known_aggregated_payloads = known_payloads;
+    store->new_votes = new_votes;
+    store->known_votes = known_votes;
 }
 
 static int register_block(
@@ -207,10 +327,12 @@ static int register_block(
         }
         return 0;
     }
-    if (ensure_block_capacity(store, store->block_len + 1) != 0) {
+    if (ensure_root_index_capacity(store, store->block_len + 1u) != 0
+        || ensure_block_capacity(store, store->block_len + 1u) != 0) {
         return -1;
     }
-    struct lantern_fork_choice_block_entry *entry = &store->blocks[store->block_len];
+    size_t block_index = store->block_len;
+    struct lantern_fork_choice_block_entry *entry = &store->blocks[block_index];
     entry->root = *root;
     if (parent_root) {
         entry->parent_root = *parent_root;
@@ -220,6 +342,7 @@ static int register_block(
     entry->slot = slot;
     entry->proposer_index = proposer_index;
     store->block_len += 1;
+    root_index_insert(store->root_index, store->root_index_cap, root, block_index);
     return 0;
 }
 
@@ -329,6 +452,7 @@ int lantern_fork_choice_set_anchor_with_state(
             store->blocks[existing_index] = previous_entry;
         } else {
             store->block_len = previous_block_len;
+            refresh_root_index(store);
         }
         return -1;
     }
@@ -565,6 +689,7 @@ rollback:
         store->blocks[existing_index] = previous_entry;
     } else {
         store->block_len = previous_block_len;
+        refresh_root_index(store);
     }
 
     lantern_state_reset(&staged_state);
@@ -629,9 +754,6 @@ int lantern_fork_choice_restore_checkpoints(
 int lantern_fork_choice_prune_states(LanternStore *store) {
     if (!store || store->block_len == 0u) {
         return -1;
-    }
-    if (store->block_len == 0) {
-        return 0;
     }
     if (lantern_root_is_zero(&store->latest_finalized.root)) {
         return 0;
@@ -750,6 +872,7 @@ int lantern_fork_choice_prune_states(LanternStore *store) {
         store->block_len = blocks_kept;
         store->block_cap = blocks_kept;
         store->anchor = store->latest_finalized;
+        refresh_root_index(store);
 
         size_t safe_index = 0;
         if (!find_block_index(store, &store->safe_target, &safe_index)) {
@@ -889,68 +1012,12 @@ static int lmd_ghost_compute(
     return 0;
 }
 
-static void safe_target_consider_vote(
-    LanternCheckpoint *merged_votes,
-    uint64_t *latest_slots,
-    size_t vote_count,
-    size_t validator_index,
-    const LanternCheckpoint *head,
-    uint64_t attestation_slot) {
-    if (!merged_votes || !latest_slots || !head || validator_index >= vote_count) {
-        return;
-    }
-    LanternCheckpoint *merged = &merged_votes[validator_index];
-    if (lantern_root_is_zero(&merged->root)
-        || attestation_slot > latest_slots[validator_index]) {
-        *merged = *head;
-        latest_slots[validator_index] = attestation_slot;
-    }
-}
-
-static void safe_target_merge_payload_pool(
+static int collect_latest_votes(
     const LanternStore *store,
-    const struct lantern_aggregated_payload_pool *pool,
-    LanternCheckpoint *merged_votes,
-    uint64_t *latest_slots,
-    size_t vote_count) {
-    if (!store || !pool || !merged_votes || !latest_slots || !pool->entries) {
-        return;
-    }
-    for (size_t i = 0; i < pool->length; ++i) {
-        const struct lantern_aggregated_payload_entry *entry = &pool->entries[i];
-        const LanternAttestationData *attestation_data = &entry->data;
-        if (attestation_data->head.slot <= store->latest_finalized.slot) {
-            continue;
-        }
-        const struct lantern_bitlist *participants = &entry->proof.participants;
-        if (participants->bit_length == 0 || !participants->bytes) {
-            continue;
-        }
-        size_t limit = participants->bit_length;
-        if (limit > vote_count) {
-            limit = vote_count;
-        }
-        for (size_t validator = 0; validator < limit; ++validator) {
-            if (!lantern_bitlist_get(participants, validator)) {
-                continue;
-            }
-            safe_target_consider_vote(
-                merged_votes,
-                latest_slots,
-                vote_count,
-                validator,
-                &attestation_data->head,
-                attestation_data->slot);
-        }
-    }
-}
-
-static int collect_payload_pool_votes(
-    const LanternStore *store,
-    const struct lantern_aggregated_payload_pool *pool,
+    const struct lantern_latest_vote_map *latest_votes,
     LanternCheckpoint **out_votes,
     size_t *out_vote_count) {
-    if (!store || !out_votes || !out_vote_count) {
+    if (!store || !latest_votes || !out_votes || !out_vote_count) {
         return -1;
     }
     *out_votes = NULL;
@@ -960,18 +1027,23 @@ static int collect_payload_pool_votes(
         return -1;
     }
     LanternCheckpoint *votes = NULL;
-    uint64_t *latest_slots = NULL;
     if (vote_count > 0) {
         votes = calloc(vote_count, sizeof(*votes));
-        latest_slots = calloc(vote_count, sizeof(*latest_slots));
-        if (!votes || !latest_slots) {
-            free(votes);
-            free(latest_slots);
+        if (!votes) {
             return -1;
         }
-        safe_target_merge_payload_pool(store, pool, votes, latest_slots, vote_count);
+        size_t limit = latest_votes->capacity < vote_count
+            ? latest_votes->capacity
+            : vote_count;
+        for (size_t validator = 0u; validator < limit; ++validator) {
+            const struct lantern_latest_vote_entry *entry =
+                &latest_votes->entries[validator];
+            if (entry->present
+                && entry->data.head.slot > store->latest_finalized.slot) {
+                votes[validator] = entry->data.head;
+            }
+        }
     }
-    free(latest_slots);
     *out_votes = votes;
     *out_vote_count = vote_count;
     return 0;
@@ -984,9 +1056,9 @@ static int collect_known_weight_votes(
     if (!store || !out_votes || !out_vote_count) {
         return -1;
     }
-    return collect_payload_pool_votes(
+    return collect_latest_votes(
         store,
-        &store->known_aggregated_payloads,
+        &store->known_votes,
         out_votes,
         out_vote_count);
 }
@@ -1146,9 +1218,9 @@ int lantern_fork_choice_update_safe_target(LanternStore *store) {
     uint64_t threshold = lantern_consensus_quorum_threshold(validator_count);
     LanternCheckpoint *safe_votes = NULL;
     size_t safe_vote_count = 0;
-    if (collect_payload_pool_votes(
+    if (collect_latest_votes(
             store,
-            &store->new_aggregated_payloads,
+            &store->new_votes,
             &safe_votes,
             &safe_vote_count)
         != 0) {
@@ -1180,6 +1252,7 @@ static int tick_interval(LanternStore *store, bool has_proposal) {
     switch (current_interval) {
     case LANTERN_DUTY_PHASE_PROPOSAL:
         if (has_proposal) {
+            (void)lantern_store_promote_new_aggregated_payloads(store);
             return lantern_fork_choice_accept_new_aggregated_payloads(store);
         }
         return 0;
@@ -1192,6 +1265,7 @@ static int tick_interval(LanternStore *store, bool has_proposal) {
     case LANTERN_DUTY_PHASE_SAFE_TARGET:
         return lantern_fork_choice_update_safe_target(store);
     case LANTERN_DUTY_PHASE_VOTE_ACCEPT:
+        (void)lantern_store_promote_new_aggregated_payloads(store);
         return lantern_fork_choice_accept_new_aggregated_payloads(store);
     default:
         return 0;

--- a/src/consensus/state.c
+++ b/src/consensus/state.c
@@ -34,7 +34,9 @@ int lantern_proposer_for_slot(
 }
 
 static void record_attestation_validation_metric(double start_seconds, bool valid) {
-    lean_metrics_record_attestation_validation(lantern_time_now_seconds() - start_seconds, valid);
+    lean_metrics_record_attestation_validation(
+        lantern_time_elapsed_seconds(start_seconds, lantern_time_now_seconds()),
+        valid);
 }
 
 static uint64_t lantern_state_justified_slots_anchor(const LanternState *state) {
@@ -2013,7 +2015,11 @@ int lantern_state_process_attestations(
 
     state->latest_justified = latest_justified;
     state->latest_finalized = latest_finalized;
-    lean_metrics_record_state_transition_attestations(att_attempted, lantern_time_now_seconds() - att_batch_start);
+    lean_metrics_record_state_transition_attestations(
+        att_attempted,
+        lantern_time_elapsed_seconds(
+            att_batch_start,
+            lantern_time_now_seconds()));
     return 0;
 }
 
@@ -2031,7 +2037,10 @@ int lantern_state_process_block(
         return -1;
     }
 
-    lean_metrics_record_state_transition_block(lantern_time_now_seconds() - block_metrics_start);
+    lean_metrics_record_state_transition_block(
+        lantern_time_elapsed_seconds(
+            block_metrics_start,
+            lantern_time_now_seconds()));
     return 0;
 }
 
@@ -2065,7 +2074,9 @@ int lantern_state_transition(LanternState *state, const LanternSignedBlock *sign
     if (lantern_state_process_slots(state, block->slot) != 0) {
         STATE_FAIL("process slots failed current=%" PRIu64, state->slot);
     }
-    double slots_duration = lantern_time_now_seconds() - slots_metrics_start;
+    double slots_duration = lantern_time_elapsed_seconds(
+        slots_metrics_start,
+        lantern_time_now_seconds());
     uint64_t slots_processed = block->slot >= slot_before ? (block->slot - slot_before) : 0;
     lean_metrics_record_state_transition_slots(slots_processed, slots_duration);
     if (lantern_state_process_block(state, block) != 0) {
@@ -2154,7 +2165,10 @@ int lantern_state_transition(LanternState *state, const LanternSignedBlock *sign
     }
 
     state->slot = block->slot;
-    lean_metrics_record_state_transition(lantern_time_now_seconds() - transition_metrics_start);
+    lean_metrics_record_state_transition(
+        lantern_time_elapsed_seconds(
+            transition_metrics_start,
+            lantern_time_now_seconds()));
 #undef STATE_FAIL
     return 0;
 }

--- a/src/consensus/store.c
+++ b/src/consensus/store.c
@@ -7,6 +7,8 @@
 #include "lantern/consensus/signature.h"
 
 static const size_t LANTERN_AGG_PROOF_CACHE_LIMIT = 4096u;
+static const size_t LANTERN_NEW_AGG_PROOF_CACHE_LIMIT = 64u;
+static const size_t LANTERN_KNOWN_AGG_PROOF_CACHE_LIMIT = 512u;
 static const size_t LANTERN_ATTESTATION_SIGNATURE_LIMIT = LANTERN_VALIDATOR_REGISTRY_LIMIT;
 
 static bool signature_key_equals(
@@ -78,6 +80,118 @@ static bool proof_has_participant(const LanternAggregatedSignatureProof *proof) 
         }
     }
     return false;
+}
+
+static void latest_vote_map_reset(struct lantern_latest_vote_map *map) {
+    if (!map) {
+        return;
+    }
+    free(map->entries);
+    *map = (struct lantern_latest_vote_map){0};
+}
+
+static void latest_vote_map_clear(struct lantern_latest_vote_map *map) {
+    if (!map || !map->entries) {
+        return;
+    }
+    memset(map->entries, 0, map->capacity * sizeof(*map->entries));
+}
+
+static int latest_vote_map_reserve(
+    struct lantern_latest_vote_map *map,
+    size_t required) {
+    if (!map || required > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+        return -1;
+    }
+    if (map->capacity >= required) {
+        return 0;
+    }
+    size_t capacity = map->capacity == 0u ? 8u : map->capacity;
+    while (capacity < required) {
+        capacity *= 2u;
+    }
+    if (capacity > LANTERN_VALIDATOR_REGISTRY_LIMIT) {
+        capacity = LANTERN_VALIDATOR_REGISTRY_LIMIT;
+    }
+    struct lantern_latest_vote_entry *entries = realloc(
+        map->entries,
+        capacity * sizeof(*entries));
+    if (!entries) {
+        return -1;
+    }
+    memset(
+        &entries[map->capacity],
+        0,
+        (capacity - map->capacity) * sizeof(*entries));
+    map->entries = entries;
+    map->capacity = capacity;
+    return 0;
+}
+
+static bool latest_vote_should_replace(
+    const struct lantern_latest_vote_entry *current,
+    const LanternRoot *data_root,
+    const LanternAttestationData *data) {
+    if (!current || !data_root || !data) {
+        return false;
+    }
+    if (!current->present || data->slot > current->data.slot) {
+        return true;
+    }
+    return data->slot == current->data.slot
+        && memcmp(data_root->bytes, current->data_root.bytes, LANTERN_ROOT_SIZE) > 0;
+}
+
+static void latest_vote_map_record_proof(
+    struct lantern_latest_vote_map *map,
+    const LanternRoot *data_root,
+    const LanternAttestationData *data,
+    const LanternAggregatedSignatureProof *proof) {
+    if (!map || !map->entries || !data_root || !data || !proof) {
+        return;
+    }
+    size_t limit = proof_participant_limit(proof);
+    if (limit > map->capacity) {
+        limit = map->capacity;
+    }
+    for (size_t validator = 0u; validator < limit; ++validator) {
+        if (!lantern_bitlist_get(&proof->participants, validator)) {
+            continue;
+        }
+        struct lantern_latest_vote_entry *entry = &map->entries[validator];
+        if (latest_vote_should_replace(entry, data_root, data)) {
+            entry->present = true;
+            entry->data_root = *data_root;
+            entry->data = *data;
+        }
+    }
+}
+
+static int latest_vote_map_promote(
+    struct lantern_latest_vote_map *known,
+    struct lantern_latest_vote_map *pending) {
+    if (!known || !pending) {
+        return -1;
+    }
+    if (latest_vote_map_reserve(known, pending->capacity) != 0) {
+        return -1;
+    }
+    for (size_t validator = 0u; validator < pending->capacity; ++validator) {
+        const struct lantern_latest_vote_entry *candidate =
+            &pending->entries[validator];
+        if (!candidate->present) {
+            continue;
+        }
+        struct lantern_latest_vote_entry *current = &known->entries[validator];
+        if (latest_vote_should_replace(
+                current,
+                &candidate->data_root,
+                &candidate->data)) {
+            *current = *candidate;
+        }
+    }
+    latest_vote_map_clear(pending);
+    return 0;
 }
 
 static bool proof_participants_subset_of(
@@ -306,12 +420,13 @@ static void aggregated_payload_pool_prune_subsets_of_entry(
     }
 }
 
-int lantern_aggregated_payload_pool_add(
+static int aggregated_payload_pool_add_with_limit(
     struct lantern_aggregated_payload_pool *pool,
     const LanternRoot *data_root,
     const LanternAttestationData *data,
-    const LanternAggregatedSignatureProof *proof) {
-    if (!pool || !data_root || !data || !proof) {
+    const LanternAggregatedSignatureProof *proof,
+    size_t max_length) {
+    if (!pool || !data_root || !data || !proof || max_length == 0u) {
         return -1;
     }
     if (!proof_has_participant(proof) || proof->proof_data.length == 0) {
@@ -327,13 +442,13 @@ int lantern_aggregated_payload_pool_add(
     if (aggregated_payload_pool_covers_proof_participants(pool, data_root, proof)) {
         return 0;
     }
-    if (pool->length >= LANTERN_AGG_PROOF_CACHE_LIMIT) {
+    while (pool->length >= max_length) {
         aggregated_payload_pool_remove_index(pool, 0u);
     }
     if (pool->length >= pool->capacity) {
         size_t desired = pool->capacity == 0 ? 8u : pool->capacity * 2u;
-        if (desired > LANTERN_AGG_PROOF_CACHE_LIMIT) {
-            desired = LANTERN_AGG_PROOF_CACHE_LIMIT;
+        if (desired > max_length) {
+            desired = max_length;
         }
         if (desired <= pool->capacity) {
             return -1;
@@ -359,6 +474,19 @@ int lantern_aggregated_payload_pool_add(
     return 0;
 }
 
+int lantern_aggregated_payload_pool_add(
+    struct lantern_aggregated_payload_pool *pool,
+    const LanternRoot *data_root,
+    const LanternAttestationData *data,
+    const LanternAggregatedSignatureProof *proof) {
+    return aggregated_payload_pool_add_with_limit(
+        pool,
+        data_root,
+        data,
+        proof,
+        LANTERN_AGG_PROOF_CACHE_LIMIT);
+}
+
 void lantern_store_init(LanternStore *store) {
     if (!store) {
         return;
@@ -381,6 +509,8 @@ void lantern_store_reset(LanternStore *store) {
     attestation_signature_map_reset(&store->attestation_signatures);
     lantern_aggregated_payload_pool_reset(&store->new_aggregated_payloads);
     lantern_aggregated_payload_pool_reset(&store->known_aggregated_payloads);
+    latest_vote_map_reset(&store->new_votes);
+    latest_vote_map_reset(&store->known_votes);
 }
 
 int lantern_store_set_attestation_signature(
@@ -427,6 +557,32 @@ size_t lantern_store_remove_attestation_signatures_for_data_root(
     return removed;
 }
 
+static int store_add_aggregated_payload(
+    struct lantern_aggregated_payload_pool *pool,
+    struct lantern_latest_vote_map *votes,
+    size_t cache_limit,
+    const LanternRoot *data_root,
+    const LanternAttestationData *data,
+    const LanternAggregatedSignatureProof *proof) {
+    if (!pool || !votes || !data_root || !data || !proof) {
+        return -1;
+    }
+    size_t vote_capacity = proof_participant_limit(proof);
+    if (latest_vote_map_reserve(votes, vote_capacity) != 0) {
+        return -1;
+    }
+    int rc = aggregated_payload_pool_add_with_limit(
+        pool,
+        data_root,
+        data,
+        proof,
+        cache_limit);
+    if (rc == 0) {
+        latest_vote_map_record_proof(votes, data_root, data, proof);
+    }
+    return rc;
+}
+
 int lantern_store_add_new_aggregated_payload(
     LanternStore *store,
     const LanternRoot *data_root,
@@ -435,8 +591,10 @@ int lantern_store_add_new_aggregated_payload(
     if (!store) {
         return -1;
     }
-    return lantern_aggregated_payload_pool_add(
+    return store_add_aggregated_payload(
         &store->new_aggregated_payloads,
+        &store->new_votes,
+        LANTERN_NEW_AGG_PROOF_CACHE_LIMIT,
         data_root,
         data,
         proof);
@@ -450,8 +608,10 @@ int lantern_store_add_known_aggregated_payload(
     if (!store) {
         return -1;
     }
-    return lantern_aggregated_payload_pool_add(
+    return store_add_aggregated_payload(
         &store->known_aggregated_payloads,
+        &store->known_votes,
+        LANTERN_KNOWN_AGG_PROOF_CACHE_LIMIT,
         data_root,
         data,
         proof);
@@ -462,6 +622,7 @@ void lantern_store_clear_new_aggregated_payloads(LanternStore *store) {
         return;
     }
     lantern_aggregated_payload_pool_reset(&store->new_aggregated_payloads);
+    latest_vote_map_clear(&store->new_votes);
 }
 
 size_t lantern_store_remove_new_aggregated_payloads_matching(
@@ -500,6 +661,9 @@ size_t lantern_store_remove_new_aggregated_payloads_matching(
 
 size_t lantern_store_promote_new_aggregated_payloads(LanternStore *store) {
     if (!store) {
+        return 0u;
+    }
+    if (latest_vote_map_promote(&store->known_votes, &store->new_votes) != 0) {
         return 0u;
     }
     size_t moved = 0u;

--- a/src/core/client.c
+++ b/src/core/client.c
@@ -106,7 +106,6 @@ static lantern_client_error client_apply_options(
     {
         return LANTERN_CLIENT_ERR_ALLOC;
     }
-    lantern_log_set_node_id(client->node_id);
     if (set_owned_string(&client->listen_address, options->listen_address) != 0)
     {
         return LANTERN_CLIENT_ERR_ALLOC;
@@ -461,8 +460,6 @@ void lantern_shutdown(struct lantern_client *client)
         pthread_mutex_destroy(&client->state_lock);
     }
     lantern_client_reset_local_validators(client);
-    lantern_log_reset_node_id();
-
     lantern_string_list_reset(&client->bootnodes);
     lantern_storage_close(&client->storage);
     free(client->data_dir);

--- a/src/core/client/checkpoint.c
+++ b/src/core/client/checkpoint.c
@@ -1,11 +1,11 @@
 /**
- * @file client_checkpoint.c
+ * @file checkpoint.c
  * @brief State loading and checkpoint sync handling
  *
- * @see client_internal.h for shared internal declarations
+ * @see internal.h for shared internal declarations
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include "lantern/consensus/containers.h"
 #include "lantern/consensus/hash.h"

--- a/src/core/client/fork_choice.c
+++ b/src/core/client/fork_choice.c
@@ -1,11 +1,11 @@
 /**
- * @file client_fork_choice.c
+ * @file fork_choice.c
  * @brief Fork-choice interval advancement and aggregated-payload pools
  *
- * @see client_internal.h for shared internal declarations
+ * @see internal.h for shared internal declarations
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include "lantern/consensus/fork_choice.h"
 #include "lantern/consensus/slot_clock.h"

--- a/src/core/client/http.c
+++ b/src/core/client/http.c
@@ -1,5 +1,5 @@
 /**
- * @file client_http.c
+ * @file http.c
  * @brief HTTP server and metrics callbacks
  *
  * Implements callback functions for the HTTP server and metrics collection.
@@ -12,7 +12,7 @@
  *       5. connection_lock
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <inttypes.h>
 #include <pthread.h>

--- a/src/core/client/init.c
+++ b/src/core/client/init.c
@@ -1,5 +1,5 @@
 /**
- * @file client_init.c
+ * @file init.c
  * @brief Client initialization helpers
  *
  * @spec subspecs/containers/state/genesis.py in tools/leanSpec
@@ -8,14 +8,14 @@
  * validator population.
  *
  * Related files:
- * - client.c: Main client initialization and lifecycle
- * - client_keys.c: Key loading and management
+ * - lifecycle.c: Main client initialization and lifecycle
+ * - keys.c: Key loading and management
  *
  * @note Thread safety: Functions are called during single-threaded
  *       initialization phase. No locking required.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include "lantern/genesis/genesis.h"
 #include "lantern/networking/libp2p.h"

--- a/src/core/client/internal.h
+++ b/src/core/client/internal.h
@@ -1,13 +1,13 @@
 /**
- * @file client_internal.h
+ * @file internal.h
  * @brief Internal declarations for the client module
  *
  * This header contains internal types, constants, and function declarations
  * shared across client implementation files. It is NOT part of the public API.
  *
  * This is the main internal header that includes specialized headers:
- * - client_sync_internal.h: Block/vote synchronization
- * - client_services_internal.h: Networking, validator, HTTP, reqresp services
+ * - sync_internal.h: Block/vote synchronization
+ * - services_internal.h: Networking, validator, HTTP, reqresp services
  *
  * @note Lock ordering (acquire in this order to prevent deadlocks):
  *       1. state_lock
@@ -335,7 +335,7 @@ int collect_startup_attestation_subnets(
 
 
 /* ============================================================================
- * Genesis helpers (defined in client_init.c)
+ * Genesis helpers (defined in init.c)
  * ============================================================================ */
 
 int copy_genesis_paths(
@@ -351,7 +351,7 @@ int populate_local_validators(struct lantern_client *client);
 #endif
 
 /* Include specialized internal headers */
-#include "client_sync_internal.h"
-#include "client_services_internal.h"
+#include "sync_internal.h"
+#include "services_internal.h"
 
 #endif /* LANTERN_CLIENT_INTERNAL_H */

--- a/src/core/client/keys.c
+++ b/src/core/client/keys.c
@@ -1,5 +1,5 @@
 /**
- * @file client_keys.c
+ * @file keys.c
  * @brief XMSS key management for local validators
  *
  * Implements key loading, path resolution, and manifest parsing for xmss
@@ -13,7 +13,7 @@
  *       5. connection_lock
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <ctype.h>
 #include <errno.h>

--- a/src/core/client/lifecycle.c
+++ b/src/core/client/lifecycle.c
@@ -1,5 +1,5 @@
 /**
- * @file client.c
+ * @file lifecycle.c
  * @brief Lantern client core initialization and lifecycle management
  *
  * Implements the main client structure initialization, startup sequence,
@@ -10,7 +10,7 @@
  * - Validator services
  * - HTTP and metrics servers
  *
- * @see client_internal.h for shared internal declarations
+ * @see internal.h for shared internal declarations
  */
 
 #include "lantern/core/client.h"
@@ -27,7 +27,7 @@
 #include <time.h>
 
 #include "internal/yaml_parser.h"
-#include "client_internal.h"
+#include "internal.h"
 #include "lantern/consensus/containers.h"
 #include "lantern/consensus/fork_choice.h"
 #include "lantern/consensus/hash.h"

--- a/src/core/client/network.c
+++ b/src/core/client/network.c
@@ -1,5 +1,5 @@
 /**
- * @file client_network.c
+ * @file network.c
  * @brief Networking and connection management functions
  *
  * Implements peer connection tracking, peer dialer service, ping service,
@@ -13,7 +13,7 @@
  *       5. connection_lock
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <pthread.h>
 #include <stdio.h>

--- a/src/core/client/network_internal.h
+++ b/src/core/client/network_internal.h
@@ -1,5 +1,5 @@
 /**
- * @file client_network_internal.h
+ * @file network_internal.h
  * @brief Internal declarations for networking and peer management
  *
  * @spec subspecs/networking/connection.py - connection management
@@ -9,8 +9,8 @@
  * It is NOT part of the public API.
  *
  * Related files:
- * - client_network.c: Network connection management
- * - client_peers.c: Peer status tracking
+ * - network.c: Network connection management
+ * - peers.c: Peer status tracking
  *
  * @note Lock ordering (acquire in this order to prevent deadlocks):
  *       1. state_lock

--- a/src/core/client/options.c
+++ b/src/core/client/options.c
@@ -1,11 +1,11 @@
 /**
- * @file client_options.c
+ * @file options.c
  * @brief Configuration parsing for the Lantern client options struct
  *
- * @see client_internal.h for shared internal declarations
+ * @see internal.h for shared internal declarations
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <ctype.h>
 #include <errno.h>

--- a/src/core/client/peers.c
+++ b/src/core/client/peers.c
@@ -1,5 +1,5 @@
 /**
- * @file client_peers.c
+ * @file peers.c
  * @brief Peer status and vote metric tracking
  *
  * Implements peer status entry management and vote metrics tracking
@@ -13,7 +13,7 @@
  *       5. connection_lock
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <pthread.h>
 #include <stdlib.h>

--- a/src/core/client/pending.c
+++ b/src/core/client/pending.c
@@ -1,5 +1,5 @@
 /**
- * @file client_pending.c
+ * @file pending.c
  * @brief Pending and persisted block list management
  *
  * Implements list operations for pending blocks (waiting for parent)
@@ -10,7 +10,7 @@
  *       - Persisted list helpers are thread-safe.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/core/client/reqresp.c
+++ b/src/core/client/reqresp.c
@@ -1,5 +1,5 @@
 /**
- * @file client_reqresp.c
+ * @file reqresp.c
  * @brief Request/response protocol callbacks and peer status handling
  *
  * @spec subspecs/networking/reqresp in tools/leanSpec
@@ -15,8 +15,8 @@
  *       5. connection_lock
  */
 
-#include "client_internal.h"
-#include "client_network_internal.h"
+#include "internal.h"
+#include "network_internal.h"
 
 #include <inttypes.h>
 #include <pthread.h>

--- a/src/core/client/services_internal.h
+++ b/src/core/client/services_internal.h
@@ -1,5 +1,5 @@
 /**
- * @file client_services_internal.h
+ * @file services_internal.h
  * @brief Internal declarations for validator, HTTP, and reqresp services
  *
  * @spec subspecs/networking/reqresp.py - request/response protocols
@@ -9,11 +9,11 @@
  * It is NOT part of the public API.
  *
  * Related files:
- * - client_validator.c: Validator duty execution
- * - client_http.c: HTTP API callbacks
- * - client_reqresp.c: Request/response protocol handling
- * - client_sync.c: Block request scheduling
- * - client_keys.c: Key management
+ * - validator.c: Validator duty execution
+ * - http.c: HTTP API callbacks
+ * - reqresp.c: Request/response protocol handling
+ * - sync.c: Block request scheduling
+ * - keys.c: Key management
  *
  * @note Lock ordering (acquire in this order to prevent deadlocks):
  *       1. state_lock
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 /* Include network internal header for shared types */
-#include "client_network_internal.h"
+#include "network_internal.h"
 
 
 /* ============================================================================

--- a/src/core/client/subnets.c
+++ b/src/core/client/subnets.c
@@ -1,11 +1,11 @@
 /**
- * @file client_subnets.c
+ * @file subnets.c
  * @brief Attestation-subnet accessors and startup subnet collection
  *
- * @see client_internal.h for shared internal declarations
+ * @see internal.h for shared internal declarations
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include "lantern/consensus/containers.h"
 

--- a/src/core/client/sync.c
+++ b/src/core/client/sync.c
@@ -1,5 +1,5 @@
 /**
- * @file client_sync.c
+ * @file sync.c
  * @brief Block and vote synchronization infrastructure
  *
  * @spec subspecs/forkchoice/store.py in tools/leanSpec
@@ -8,14 +8,14 @@
  * from storage, pending block management, and validator state refresh.
  *
  * Related files:
- * - client_sync_votes.c: Vote processing and validation
- * - client_sync_blocks.c: Block import and signature verification
+ * - sync_votes.c: Vote processing and validation
+ * - sync_blocks.c: Block import and signature verification
  *
  * @note Thread safety: Functions that access shared state acquire appropriate
- *       locks as documented. See client_internal.h for lock ordering.
+ *       locks as documented. See internal.h for lock ordering.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <inttypes.h>
 #include <stdlib.h>

--- a/src/core/client/sync_blocks.c
+++ b/src/core/client/sync_blocks.c
@@ -1,5 +1,5 @@
 /**
- * @file client_sync_blocks.c
+ * @file sync_blocks.c
  * @brief Block import and signature verification
  *
  * @spec subspecs/containers/block/block.py in tools/leanSpec
@@ -10,14 +10,14 @@
  * state transitions, and block recording.
  *
  * Related files:
- * - client_sync.c: Main sync logic and gossip handlers
- * - client_sync_votes.c: Vote processing
+ * - sync.c: Main sync logic and gossip handlers
+ * - sync_votes.c: Vote processing
  *
  * @note Thread safety: Functions that access shared state acquire appropriate
- *       locks as documented. See client_internal.h for lock ordering.
+ *       locks as documented. See internal.h for lock ordering.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <errno.h>
 #include <inttypes.h>

--- a/src/core/client/sync_internal.h
+++ b/src/core/client/sync_internal.h
@@ -1,5 +1,5 @@
 /**
- * @file client_sync_internal.h
+ * @file sync_internal.h
  * @brief Internal declarations for block/vote synchronization
  *
  * @spec subspecs/sync/sync.py - synchronization protocol
@@ -8,10 +8,10 @@
  * block and vote synchronization. It is NOT part of the public API.
  *
  * Related files:
- * - client_sync.c: Block/vote synchronization main logic
- * - client_sync_blocks.c: Block import and fork choice
- * - client_sync_votes.c: Vote processing and validation
- * - client_pending.c: Pending block management
+ * - sync.c: Block/vote synchronization main logic
+ * - sync_blocks.c: Block import and fork choice
+ * - sync_votes.c: Vote processing and validation
+ * - pending.c: Pending block management
  *
  * @note Lock ordering (acquire in this order to prevent deadlocks):
  *       1. state_lock
@@ -24,7 +24,7 @@
 #ifndef LANTERN_CLIENT_SYNC_INTERNAL_H
 #define LANTERN_CLIENT_SYNC_INTERNAL_H
 
-#include "client_network_internal.h"
+#include "network_internal.h"
 #include "lantern/core/client.h"
 #include "lantern/consensus/containers.h"
 #include "lantern/consensus/state.h"

--- a/src/core/client/sync_votes.c
+++ b/src/core/client/sync_votes.c
@@ -1,5 +1,5 @@
 /**
- * @file client_sync_votes.c
+ * @file sync_votes.c
  * @brief Vote (attestation) processing and validation
  *
  * @spec subspecs/containers/attestation/attestation.py in tools/leanSpec
@@ -9,14 +9,14 @@
  * recording received votes to fork choice and state.
  *
  * Related files:
- * - client_sync.c: Main sync logic and gossip handlers
- * - client_sync_blocks.c: Block import logic
+ * - sync.c: Main sync logic and gossip handlers
+ * - sync_blocks.c: Block import logic
  *
  * @note Thread safety: Functions that access shared state acquire appropriate
- *       locks as documented. See client_internal.h for lock ordering.
+ *       locks as documented. See internal.h for lock ordering.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <inttypes.h>
 #include <string.h>
@@ -43,7 +43,7 @@ enum lantern_vote_record_status
 
 
 /* ============================================================================
- * External Functions (from client_sync.c)
+ * External Functions (from sync.c)
  * ============================================================================ */
 
 bool lantern_client_verify_vote_signature(

--- a/src/core/client/utils.c
+++ b/src/core/client/utils.c
@@ -1,5 +1,5 @@
 /**
- * @file client_utils.c
+ * @file utils.c
  * @brief Client utility functions and locking primitives
  *
  * Implements utility functions used across client modules including:
@@ -11,7 +11,7 @@
  * @note Thread safety: Lock functions are thread-safe.
  */
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include <errno.h>
 #include <inttypes.h>

--- a/src/core/client/validator.c
+++ b/src/core/client/validator.c
@@ -1,5 +1,5 @@
 /**
- * @file client_validator.c
+ * @file validator.c
  * @brief Validator service and duty management
  *
  * Implements the validator service thread, block proposal,
@@ -13,7 +13,7 @@
  *       5. connection_lock
  */
 
-#include "client_services_internal.h"
+#include "services_internal.h"
 
 #include <inttypes.h>
 #include <pthread.h>
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "client_internal.h"
+#include "internal.h"
 
 #include "lantern/consensus/fork_choice.h"
 #include "lantern/consensus/hash.h"

--- a/src/core/client_fork_choice.c
+++ b/src/core/client_fork_choice.c
@@ -41,55 +41,6 @@ static void log_aggregated_payload_interval_transition(
         client->store.known_aggregated_payloads.length);
 }
 
-static void sync_aggregated_payload_pools_after_time_advance(
-    struct lantern_client *client,
-    uint64_t previous_intervals,
-    bool has_proposal) {
-    if (!client || client->store.block_len == 0u) {
-        return;
-    }
-    if (client->store.time_intervals <= previous_intervals) {
-        return;
-    }
-    for (uint64_t step = previous_intervals + 1u;
-         step <= client->store.time_intervals;
-         ++step) {
-        uint64_t interval_index = step % LANTERN_INTERVALS_PER_SLOT;
-        bool step_has_proposal = has_proposal && (step == client->store.time_intervals);
-        if (interval_index == LANTERN_DUTY_PHASE_SAFE_TARGET) {
-            log_aggregated_payload_interval_transition(
-                client,
-                "safe_target",
-                step,
-                interval_index,
-                client->store.new_aggregated_payloads.length,
-                client->store.known_aggregated_payloads.length,
-                0u);
-        } else if (interval_index == LANTERN_DUTY_PHASE_VOTE_ACCEPT
-            || (interval_index == LANTERN_DUTY_PHASE_PROPOSAL && step_has_proposal)) {
-            size_t new_before = client->store.new_aggregated_payloads.length;
-            size_t known_before = client->store.known_aggregated_payloads.length;
-            size_t promoted = lantern_store_promote_new_aggregated_payloads(&client->store);
-            if (promoted > 0u && lantern_fork_choice_accept_new_aggregated_payloads(&client->store) != 0) {
-                lantern_log_warn(
-                    "forkchoice",
-                    &(struct lantern_log_metadata){.validator = client->node_id},
-                    "failed to recompute head after aggregated payload promotion");
-            }
-            log_aggregated_payload_interval_transition(
-                client,
-                interval_index == LANTERN_DUTY_PHASE_VOTE_ACCEPT
-                    ? "accept_new"
-                    : "proposal_accept_new",
-                step,
-                interval_index,
-                new_before,
-                known_before,
-                promoted);
-        }
-    }
-}
-
 static bool interval_range_first_with_phase(
     uint64_t start,
     uint64_t end,
@@ -144,6 +95,8 @@ int lantern_client_tick_fork_choice_interval_locked(
     if (next_interval < previous_intervals) {
         return -1;
     }
+    size_t new_before = client->store.new_aggregated_payloads.length;
+    size_t known_before = client->store.known_aggregated_payloads.length;
 
     double tick_start_seconds = lantern_time_now_seconds();
     int rc = lantern_fork_choice_advance_to(&client->store, next_interval, has_proposal);
@@ -163,7 +116,32 @@ int lantern_client_tick_fork_choice_interval_locked(
         client->last_tick_interval_started_seconds = tick_start_seconds;
     }
 
-    sync_aggregated_payload_pools_after_time_advance(client, previous_intervals, has_proposal);
+    uint64_t phase = next_interval % LANTERN_INTERVALS_PER_SLOT;
+    if (phase == LANTERN_DUTY_PHASE_SAFE_TARGET) {
+        log_aggregated_payload_interval_transition(
+            client,
+            "safe_target",
+            next_interval,
+            phase,
+            new_before,
+            known_before,
+            0u);
+    } else if (phase == LANTERN_DUTY_PHASE_VOTE_ACCEPT
+        || (phase == LANTERN_DUTY_PHASE_PROPOSAL && has_proposal)) {
+        size_t new_after = client->store.new_aggregated_payloads.length;
+        size_t promoted = new_before >= new_after ? new_before - new_after : 0u;
+        log_aggregated_payload_interval_transition(
+            client,
+            phase == LANTERN_DUTY_PHASE_VOTE_ACCEPT
+                ? "accept_new"
+                : "proposal_accept_new",
+            next_interval,
+            phase,
+            new_before,
+            known_before,
+            promoted);
+    }
+
     return 0;
 }
 
@@ -215,11 +193,8 @@ int lantern_client_skip_fork_choice_intervals_locked(
     if (has_accept) {
         size_t new_before = client->store.new_aggregated_payloads.length;
         size_t known_before = client->store.known_aggregated_payloads.length;
-        if (lantern_fork_choice_accept_new_aggregated_payloads(&client->store) != 0) {
-            return -1;
-        }
         size_t promoted = lantern_store_promote_new_aggregated_payloads(&client->store);
-        if (promoted > 0u && lantern_fork_choice_accept_new_aggregated_payloads(&client->store) != 0) {
+        if (lantern_fork_choice_accept_new_aggregated_payloads(&client->store) != 0) {
             return -1;
         }
         log_aggregated_payload_interval_transition(
@@ -276,17 +251,13 @@ int lantern_client_advance_fork_choice_time_locked(
         if (lantern_client_skip_fork_choice_intervals_locked(client, skip_to_interval) != 0) {
             return -1;
         }
-        previous_intervals = client->store.time_intervals;
     }
 
     if (target_rc > 0) {
         return 0;
     }
-    int rc = lantern_fork_choice_advance_to(&client->store, target_interval, has_proposal);
-    if (rc != 0) {
-        return rc;
-    }
-    sync_aggregated_payload_pools_after_time_advance(client, previous_intervals, has_proposal);
-    return 0;
+    return lantern_fork_choice_advance_to(
+        &client->store,
+        target_interval,
+        has_proposal);
 }
-

--- a/src/core/client_validator.c
+++ b/src/core/client_validator.c
@@ -98,11 +98,6 @@ static bool validator_record_aggregation_skipped_once(
     return true;
 }
 
-static double validator_elapsed_seconds(double started_seconds, double finished_seconds)
-{
-    return finished_seconds >= started_seconds ? finished_seconds - started_seconds : 0.0;
-}
-
 static void validator_add_stage_seconds(double *stage_seconds, double seconds)
 {
     if (!stage_seconds || seconds <= 0.0)
@@ -662,7 +657,9 @@ lantern_client_error validator_collect_and_aggregate_attestation_signatures(
     double lock_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         stage_timings ? &stage_timings->lock_waits_seconds : NULL,
-        validator_elapsed_seconds(lock_started_seconds, lock_finished_seconds));
+        lantern_time_elapsed_seconds(
+            lock_started_seconds,
+            lock_finished_seconds));
     if (!state_locked)
     {
         return LANTERN_CLIENT_ERR_RUNTIME;
@@ -694,7 +691,9 @@ lantern_client_error validator_collect_and_aggregate_attestation_signatures(
     double collection_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         stage_timings ? &stage_timings->vote_collection_seconds : NULL,
-        validator_elapsed_seconds(collection_started_seconds, collection_finished_seconds));
+        lantern_time_elapsed_seconds(
+            collection_started_seconds,
+            collection_finished_seconds));
     double other_started_seconds = lantern_time_now_seconds();
     if (!raw_only && snapshot_rc == 0)
     {
@@ -711,7 +710,9 @@ lantern_client_error validator_collect_and_aggregate_attestation_signatures(
     double other_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         stage_timings ? &stage_timings->other_prover_setup_seconds : NULL,
-        validator_elapsed_seconds(other_started_seconds, other_finished_seconds));
+        lantern_time_elapsed_seconds(
+            other_started_seconds,
+            other_finished_seconds));
 
     lantern_client_unlock_state(client, state_locked);
 
@@ -738,7 +739,9 @@ lantern_client_error validator_collect_and_aggregate_attestation_signatures(
         double commit_lock_finished_seconds = lantern_time_now_seconds();
         validator_add_stage_seconds(
             stage_timings ? &stage_timings->lock_waits_seconds : NULL,
-            validator_elapsed_seconds(commit_lock_started_seconds, commit_lock_finished_seconds));
+            lantern_time_elapsed_seconds(
+                commit_lock_started_seconds,
+                commit_lock_finished_seconds));
         if (!commit_locked)
         {
             rc = LANTERN_CLIENT_ERR_RUNTIME;
@@ -1245,7 +1248,9 @@ static lantern_client_error validator_prepare_block_proposal_job(
     double lock_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         &job->stage_timings.lock_waits_seconds,
-        validator_elapsed_seconds(lock_started_seconds, lock_finished_seconds));
+        lantern_time_elapsed_seconds(
+            lock_started_seconds,
+            lock_finished_seconds));
     if (!state_locked)
     {
         result = LANTERN_CLIENT_ERR_RUNTIME;
@@ -1283,7 +1288,9 @@ static lantern_client_error validator_prepare_block_proposal_job(
     double collection_finished_for_stage_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         &job->stage_timings.vote_collection_seconds,
-        validator_elapsed_seconds(collection_started_seconds, collection_finished_for_stage_seconds));
+        lantern_time_elapsed_seconds(
+            collection_started_seconds,
+            collection_finished_for_stage_seconds));
     collect_finished_seconds = lantern_time_now_seconds();
 
     job->block.block.slot = slot;
@@ -1315,7 +1322,9 @@ static lantern_client_error validator_prepare_block_proposal_job(
     double other_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         &job->stage_timings.other_prover_setup_seconds,
-        validator_elapsed_seconds(other_started_seconds, other_finished_seconds));
+        lantern_time_elapsed_seconds(
+            other_started_seconds,
+            other_finished_seconds));
     lantern_client_unlock_state(client, state_locked);
     state_locked = false;
 
@@ -1339,11 +1348,15 @@ static lantern_client_error validator_prepare_block_proposal_job(
     other_finished_seconds = lantern_time_now_seconds();
     validator_add_stage_seconds(
         &job->stage_timings.other_prover_setup_seconds,
-        validator_elapsed_seconds(other_started_seconds, other_finished_seconds));
+        lantern_time_elapsed_seconds(
+            other_started_seconds,
+            other_finished_seconds));
 
     lean_metrics_record_block_aggregated_payloads(job->block.block.body.attestations.length);
     lean_metrics_record_block_building_payload_aggregation_time(
-        validator_elapsed_seconds(collect_started_seconds, collect_finished_seconds));
+        lantern_time_elapsed_seconds(
+            collect_started_seconds,
+            collect_finished_seconds));
 
     *out_job = job;
     job = NULL;
@@ -1521,9 +1534,13 @@ static int finish_block_proposal_job(struct lantern_async_block_proposal_job *jo
         &job->block);
     lantern_signature_set_stage_timings(NULL);
     double proof_finished_seconds = lantern_time_now_seconds();
-    double proof_seconds = validator_elapsed_seconds(proof_started_seconds, proof_finished_seconds);
+    double proof_seconds = lantern_time_elapsed_seconds(
+        proof_started_seconds,
+        proof_finished_seconds);
     double total_seconds =
-        validator_elapsed_seconds(job->build_started_seconds, proof_finished_seconds);
+        lantern_time_elapsed_seconds(
+            job->build_started_seconds,
+            proof_finished_seconds);
 
     if (proof_rc != LANTERN_CLIENT_OK)
     {
@@ -2063,7 +2080,9 @@ int validator_publish_attestations(struct lantern_client *client, uint64_t slot)
             }
         }
         lean_metrics_record_attestations_production_time(
-            lantern_time_now_seconds() - production_start);
+            lantern_time_elapsed_seconds(
+                production_start,
+                lantern_time_now_seconds()));
     }
 
     if (have_lock)
@@ -2124,7 +2143,9 @@ int validator_publish_aggregated_attestations(struct lantern_client *client, uin
     size_t successful_aggregations = 0u;
     double aggregation_finished_seconds = lantern_time_now_seconds();
     double aggregation_seconds =
-        validator_elapsed_seconds(aggregation_started_seconds, aggregation_finished_seconds);
+        lantern_time_elapsed_seconds(
+            aggregation_started_seconds,
+            aggregation_finished_seconds);
     uint64_t aggregated_attestations_total = 0;
     if (result == LANTERN_CLIENT_OK) {
         aggregated_attestations_total = (uint64_t)aggregated_payloads.length;
@@ -2698,4 +2719,3 @@ lantern_client_error client_setup_validators(
 
     return LANTERN_CLIENT_OK;
 }
-

--- a/src/support/log.c
+++ b/src/support/log.c
@@ -3,19 +3,21 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <pthread.h>
+#include <stdarg.h>
+#include <stdatomic.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
-static char g_node_id[96] = {0};
-static pthread_mutex_t g_log_mutex = PTHREAD_MUTEX_INITIALIZER;
-static enum LanternLogLevel g_min_level = LANTERN_LOG_LEVEL_INFO;
+static pthread_mutex_t s_log_mutex = PTHREAD_MUTEX_INITIALIZER;
+static atomic_int s_min_level = LANTERN_LOG_LEVEL_INFO;
 
-static int equals_ignore_case(const char *lhs, const char *rhs);
+static bool equals_ignore_case(const char *lhs, const char *rhs);
 
-static const char *level_to_string(enum LanternLogLevel level) {
-    switch (level) {
+static const char *level_to_string(enum lantern_log_level level)
+{
+    switch (level)
+    {
     case LANTERN_LOG_LEVEL_TRACE:
         return "TRACE";
     case LANTERN_LOG_LEVEL_DEBUG:
@@ -31,136 +33,157 @@ static const char *level_to_string(enum LanternLogLevel level) {
     }
 }
 
-void lantern_log_set_node_id(const char *node_id) {
-    if (!node_id) {
-        g_node_id[0] = '\0';
+void lantern_log_set_level(enum lantern_log_level level)
+{
+    if (level < LANTERN_LOG_LEVEL_TRACE || level > LANTERN_LOG_LEVEL_ERROR)
+    {
         return;
     }
-    size_t len = strlen(node_id);
-    if (len >= sizeof(g_node_id)) {
-        len = sizeof(g_node_id) - 1;
+
+    atomic_store_explicit(&s_min_level, level, memory_order_relaxed);
+}
+
+static bool equals_ignore_case(const char *lhs, const char *rhs)
+{
+    if (!lhs || !rhs)
+    {
+        return false;
     }
-    memcpy(g_node_id, node_id, len);
-    g_node_id[len] = '\0';
-}
 
-void lantern_log_reset_node_id(void) {
-    g_node_id[0] = '\0';
-}
-
-void lantern_log_set_level(enum LanternLogLevel level) {
-    g_min_level = level;
-}
-
-static int equals_ignore_case(const char *lhs, const char *rhs) {
-    if (!lhs || !rhs) {
-        return 0;
-    }
-    while (*lhs && *rhs) {
+    while (*lhs && *rhs)
+    {
         unsigned char a = (unsigned char)(*lhs);
         unsigned char b = (unsigned char)(*rhs);
-        if (tolower(a) != tolower(b)) {
-            return 0;
+        if (tolower(a) != tolower(b))
+        {
+            return false;
         }
+
         ++lhs;
         ++rhs;
     }
+
     return *lhs == '\0' && *rhs == '\0';
 }
 
-static int parse_level(const char *text, enum LanternLogLevel *out_level) {
-    if (!text || !out_level) {
+static int parse_level(const char *text, enum lantern_log_level *out_level)
+{
+    if (!text || !out_level)
+    {
         return -1;
     }
-    if (equals_ignore_case(text, "trace")) {
+
+    if (equals_ignore_case(text, "trace"))
+    {
         *out_level = LANTERN_LOG_LEVEL_TRACE;
         return 0;
     }
-    if (equals_ignore_case(text, "debug")) {
+
+    if (equals_ignore_case(text, "debug"))
+    {
         *out_level = LANTERN_LOG_LEVEL_DEBUG;
         return 0;
     }
-    if (equals_ignore_case(text, "info")) {
+
+    if (equals_ignore_case(text, "info"))
+    {
         *out_level = LANTERN_LOG_LEVEL_INFO;
         return 0;
     }
-    if (equals_ignore_case(text, "warn") || equals_ignore_case(text, "warning")) {
+
+    if (equals_ignore_case(text, "warn") || equals_ignore_case(text, "warning"))
+    {
         *out_level = LANTERN_LOG_LEVEL_WARN;
         return 0;
     }
-    if (equals_ignore_case(text, "error")) {
+
+    if (equals_ignore_case(text, "error"))
+    {
         *out_level = LANTERN_LOG_LEVEL_ERROR;
         return 0;
     }
+
     return -1;
 }
 
-int lantern_log_set_level_from_string(const char *text, enum LanternLogLevel *out_level) {
-    enum LanternLogLevel parsed = LANTERN_LOG_LEVEL_INFO;
-    if (parse_level(text, &parsed) != 0) {
+int lantern_log_set_level_from_string(const char *text,
+                                      enum lantern_log_level *out_level)
+{
+    enum lantern_log_level parsed = LANTERN_LOG_LEVEL_INFO;
+    if (parse_level(text, &parsed) != 0)
+    {
         return -1;
     }
+
     lantern_log_set_level(parsed);
-    if (out_level) {
+    if (out_level)
+    {
         *out_level = parsed;
     }
+
     return 0;
 }
 
-static void format_timestamp(char buffer[32]) {
+static void format_timestamp(char buffer[32])
+{
     struct timespec ts;
-    if (timespec_get(&ts, TIME_UTC) != TIME_UTC) {
+    if (timespec_get(&ts, TIME_UTC) != TIME_UTC)
+    {
         buffer[0] = '\0';
         return;
     }
+
     struct tm tm_result;
-    if (!gmtime_r(&ts.tv_sec, &tm_result)) {
+    if (!gmtime_r(&ts.tv_sec, &tm_result))
+    {
         buffer[0] = '\0';
         return;
     }
-    int written = snprintf(
-        buffer, 32, "%04d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
-        tm_result.tm_year + 1900,
-        tm_result.tm_mon + 1,
-        tm_result.tm_mday,
-        tm_result.tm_hour,
-        tm_result.tm_min,
-        tm_result.tm_sec,
-        ts.tv_nsec / 1000000L);
-    if (written < 0) {
+
+    int written =
+        snprintf(buffer, 32, "%04d-%02d-%02dT%02d:%02d:%02d.%03ldZ",
+                 tm_result.tm_year + 1900, tm_result.tm_mon + 1,
+                 tm_result.tm_mday, tm_result.tm_hour, tm_result.tm_min,
+                 tm_result.tm_sec, ts.tv_nsec / 1000000L);
+    if (written < 0 || written >= 32)
+    {
         buffer[0] = '\0';
-        return;
     }
 }
 
-static void format_component_tag(const char *component, char out[16]) {
+static void format_component_tag(const char *component, char out[16])
+{
     char lowered[11];
     const char *text = component && component[0] ? component : "?";
     size_t i = 0;
-    for (; text[i] && i < sizeof(lowered) - 1u; ++i) {
+    for (; i < sizeof(lowered) - 1u && text[i]; ++i)
+    {
         lowered[i] = (char)tolower((unsigned char)text[i]);
     }
     lowered[i] = '\0';
-    snprintf(out, 16, "[%s]", lowered);
+
+    (void)snprintf(out, 16, "[%s]", lowered);
 }
 
-void lantern_log_log(
-    enum LanternLogLevel level,
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    va_list args) {
-    if (level < g_min_level) {
+static void log_message_v(enum lantern_log_level level, const char *component,
+                          const struct lantern_log_metadata *metadata,
+                          const char *fmt, va_list args)
+{
+    int min_level = atomic_load_explicit(&s_min_level, memory_order_relaxed);
+    if ((int)level < min_level)
+    {
         return;
     }
-    (void)metadata;
 
-    /* Format the user message */
     char formatted[1024];
-    int msg_written = vsnprintf(formatted, sizeof(formatted), fmt ? fmt : "", args);
-    if (msg_written < 0) {
+    int msg_written =
+        vsnprintf(formatted, sizeof(formatted), fmt ? fmt : "", args);
+    if (msg_written < 0)
+    {
         formatted[0] = '\0';
-    } else if ((size_t)msg_written >= sizeof(formatted)) {
+    }
+    else if ((size_t)msg_written >= sizeof(formatted))
+    {
         formatted[sizeof(formatted) - 1] = '\0';
     }
 
@@ -170,81 +193,83 @@ void lantern_log_log(
     FILE *target = level >= LANTERN_LOG_LEVEL_WARN ? stderr : stdout;
     char tag[16];
     format_component_tag(component, tag);
-    static const char kUnknownTimestamp[] = "????" "-??" "-??T??:??:??.???Z";
+    static const char unknown_timestamp[] = "????"
+                                            "-??"
+                                            "-??T??:??:??.???Z";
 
-    pthread_mutex_lock(&g_log_mutex);
-    fprintf(
-        target,
-        "%s  %-5s  %-12s %s\n",
-        timestamp[0] ? timestamp : kUnknownTimestamp,
-        level_to_string(level),
-        tag,
-        formatted);
+    if (pthread_mutex_lock(&s_log_mutex) != 0)
+    {
+        return;
+    }
 
-    fflush(target);
-    pthread_mutex_unlock(&g_log_mutex);
+    /* Logging is best-effort because callers cannot recover from stream errors.
+     */
+    (void)fprintf(target, "%s  %-5s  %-12s",
+                  timestamp[0] ? timestamp : unknown_timestamp,
+                  level_to_string(level), tag);
+    if (metadata && metadata->validator)
+    {
+        (void)fprintf(target, " validator=%s", metadata->validator);
+    }
+    if (metadata && metadata->peer)
+    {
+        (void)fprintf(target, " peer=%s", metadata->peer);
+    }
+    if (metadata && metadata->has_slot)
+    {
+        (void)fprintf(target, " slot=%" PRIu64, metadata->slot);
+    }
+    (void)fprintf(target, " %s\n", formatted);
+    (void)fflush(target);
+    (void)pthread_mutex_unlock(&s_log_mutex);
 }
 
-static void log_variadic(
-    enum LanternLogLevel level,
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    va_list args) {
-    lantern_log_log(level, component, metadata, fmt, args);
-}
-
-void lantern_log_trace(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) {
+void lantern_log_trace(const char *component,
+                       const struct lantern_log_metadata *metadata,
+                       const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    log_variadic(LANTERN_LOG_LEVEL_TRACE, component, metadata, fmt, args);
+    log_message_v(LANTERN_LOG_LEVEL_TRACE, component, metadata, fmt, args);
     va_end(args);
 }
 
-void lantern_log_debug(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) {
+void lantern_log_debug(const char *component,
+                       const struct lantern_log_metadata *metadata,
+                       const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    log_variadic(LANTERN_LOG_LEVEL_DEBUG, component, metadata, fmt, args);
+    log_message_v(LANTERN_LOG_LEVEL_DEBUG, component, metadata, fmt, args);
     va_end(args);
 }
 
-void lantern_log_info(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) {
+void lantern_log_info(const char *component,
+                      const struct lantern_log_metadata *metadata,
+                      const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    log_variadic(LANTERN_LOG_LEVEL_INFO, component, metadata, fmt, args);
+    log_message_v(LANTERN_LOG_LEVEL_INFO, component, metadata, fmt, args);
     va_end(args);
 }
 
-void lantern_log_warn(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) {
+void lantern_log_warn(const char *component,
+                      const struct lantern_log_metadata *metadata,
+                      const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    log_variadic(LANTERN_LOG_LEVEL_WARN, component, metadata, fmt, args);
+    log_message_v(LANTERN_LOG_LEVEL_WARN, component, metadata, fmt, args);
     va_end(args);
 }
 
-void lantern_log_error(
-    const char *component,
-    const struct lantern_log_metadata *metadata,
-    const char *fmt,
-    ...) {
+void lantern_log_error(const char *component,
+                       const struct lantern_log_metadata *metadata,
+                       const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
-    log_variadic(LANTERN_LOG_LEVEL_ERROR, component, metadata, fmt, args);
+    log_message_v(LANTERN_LOG_LEVEL_ERROR, component, metadata, fmt, args);
     va_end(args);
 }

--- a/src/support/secure_mem.c
+++ b/src/support/secure_mem.c
@@ -1,36 +1,20 @@
 #include "lantern/support/secure_mem.h"
 
-#include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
-#if defined(__STDC_LIB_EXT1__)
-#define HAVE_MEMSET_S 1
-#endif
-
-#if defined(_MSC_VER)
-#include <windows.h>
-#endif
-
-void lantern_secure_zero(void *ptr, size_t len) {
-    if (!ptr || len == 0) {
+void lantern_secure_zero(void *ptr, size_t len)
+{
+    if (!ptr || len == 0)
+    {
         return;
     }
 
-#if defined(HAVE_MEMSET_S)
-    memset_s(ptr, len, 0, len);
-    return;
-#elif defined(_WIN32)
-    SecureZeroMemory(ptr, len);
-    return;
-#elif defined(__GNUC__) || defined(__clang__)
-    __builtin_memset(ptr, 0, len);
-    __asm__ __volatile__("" : : "r"(ptr) : "memory");
-    return;
-#else
-    volatile uint8_t *volatile bytes = (volatile uint8_t *volatile)ptr;
-    for (size_t i = 0; i < len; ++i) {
-        bytes[i] = 0;
+    /* Volatile stores keep the compiler from removing the secret clear. */
+    volatile uint8_t *bytes = ptr;
+    while (len > 0)
+    {
+        *bytes = 0;
+        ++bytes;
+        --len;
     }
-#endif
 }

--- a/src/support/string_list.c
+++ b/src/support/string_list.c
@@ -1,54 +1,82 @@
 #include "lantern/support/string_list.h"
 
-#include "lantern/support/strings.h"
-
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-void lantern_string_list_init(struct lantern_string_list *list) {
-    if (!list) {
+#include "lantern/support/strings.h"
+
+void lantern_string_list_init(struct lantern_string_list *list)
+{
+    if (!list)
+    {
         return;
     }
+
     list->items = NULL;
     list->len = 0;
     list->capacity = 0;
 }
 
-void lantern_string_list_reset(struct lantern_string_list *list) {
-    if (!list) {
+void lantern_string_list_reset(struct lantern_string_list *list)
+{
+    if (!list)
+    {
         return;
     }
-    if (list->items) {
+
+    if (list->items)
+    {
         size_t limit = list->len;
-        if (list->capacity > 0 && limit > list->capacity) {
+        if (list->capacity > 0 && limit > list->capacity)
+        {
             limit = list->capacity;
         }
-        for (size_t i = 0; i < limit; ++i) {
+
+        for (size_t i = 0; i < limit; ++i)
+        {
             free(list->items[i]);
             list->items[i] = NULL;
         }
         free(list->items);
     }
+
     list->items = NULL;
     list->len = 0;
     list->capacity = 0;
 }
 
-static int lantern_string_list_reserve(struct lantern_string_list *list, size_t new_capacity) {
-    if (new_capacity <= list->capacity) {
+static int string_list_reserve(struct lantern_string_list *list,
+                               size_t new_capacity)
+{
+    if (new_capacity <= list->capacity)
+    {
         return 0;
     }
-    size_t adjusted = list->capacity == 0 ? 4 : list->capacity;
-    while (adjusted < new_capacity) {
-        adjusted *= 2;
-    }
-
-    char **items = realloc(list->items, adjusted * sizeof(char *));
-    if (!items) {
+    if (new_capacity > SIZE_MAX / sizeof(*list->items))
+    {
         return -1;
     }
 
-    for (size_t i = list->capacity; i < adjusted; ++i) {
+    size_t adjusted = list->capacity == 0 ? 4 : list->capacity;
+    while (adjusted < new_capacity)
+    {
+        if (adjusted > SIZE_MAX / 2u)
+        {
+            adjusted = new_capacity;
+            break;
+        }
+        adjusted *= 2u;
+    }
+
+    char **items = realloc(list->items, adjusted * sizeof(*items));
+    if (!items)
+    {
+        return -1;
+    }
+
+    for (size_t i = list->capacity; i < adjusted; ++i)
+    {
         items[i] = NULL;
     }
 
@@ -57,17 +85,22 @@ static int lantern_string_list_reserve(struct lantern_string_list *list, size_t 
     return 0;
 }
 
-int lantern_string_list_append(struct lantern_string_list *list, const char *value) {
-    if (!list || !value) {
+int lantern_string_list_append(struct lantern_string_list *list,
+                               const char *value)
+{
+    if (!list || !value || list->len == SIZE_MAX)
+    {
         return -1;
     }
 
-    if (lantern_string_list_reserve(list, list->len + 1) != 0) {
+    if (string_list_reserve(list, list->len + 1u) != 0)
+    {
         return -1;
     }
 
     char *copy = lantern_string_duplicate(value);
-    if (!copy) {
+    if (!copy)
+    {
         return -1;
     }
 
@@ -75,73 +108,103 @@ int lantern_string_list_append(struct lantern_string_list *list, const char *val
     return 0;
 }
 
-bool lantern_string_list_contains(const struct lantern_string_list *list, const char *value) {
-    if (!list || !value) {
+bool lantern_string_list_contains(const struct lantern_string_list *list,
+                                  const char *value)
+{
+    if (!list || !value)
+    {
         return false;
     }
-    for (size_t i = 0; i < list->len; ++i) {
-        if (list->items[i] && strcmp(list->items[i], value) == 0) {
+
+    for (size_t i = 0; i < list->len; ++i)
+    {
+        if (list->items[i] && strcmp(list->items[i], value) == 0)
+        {
             return true;
         }
     }
+
     return false;
 }
 
-bool lantern_string_list_remove(struct lantern_string_list *list, const char *value) {
-    if (!list || !value) {
+bool lantern_string_list_remove(struct lantern_string_list *list,
+                                const char *value)
+{
+    if (!list || !value)
+    {
         return false;
     }
-    for (size_t i = 0; i < list->len; ++i) {
-        if (!list->items[i] || strcmp(list->items[i], value) != 0) {
+
+    for (size_t i = 0; i < list->len; ++i)
+    {
+        if (!list->items[i] || strcmp(list->items[i], value) != 0)
+        {
             continue;
         }
+
         free(list->items[i]);
-        if (i + 1u < list->len) {
-            memmove(
-                &list->items[i],
-                &list->items[i + 1u],
-                (list->len - i - 1u) * sizeof(*list->items));
+        if (i + 1u < list->len)
+        {
+            memmove(&list->items[i], &list->items[i + 1u],
+                    (list->len - i - 1u) * sizeof(*list->items));
         }
         list->len -= 1u;
         list->items[list->len] = NULL;
         return true;
     }
+
     return false;
 }
 
-int lantern_string_list_append_unique(struct lantern_string_list *list, const char *value) {
-    if (!list || !value) {
+int lantern_string_list_append_unique(struct lantern_string_list *list,
+                                      const char *value)
+{
+    if (!list || !value)
+    {
         return -1;
     }
-    if (*value == '\0' || lantern_string_list_contains(list, value)) {
+
+    if (*value == '\0' || lantern_string_list_contains(list, value))
+    {
         return 0;
     }
+
     return lantern_string_list_append(list, value);
 }
 
-int lantern_string_list_copy(struct lantern_string_list *dst, const struct lantern_string_list *src) {
-    if (!dst || !src) {
+int lantern_string_list_copy(struct lantern_string_list *dst,
+                             const struct lantern_string_list *src)
+{
+    if (!dst || !src)
+    {
         return -1;
     }
-
-    lantern_string_list_reset(dst);
-
-    if (src->len == 0) {
+    if (dst == src)
+    {
         return 0;
     }
 
-    if (lantern_string_list_reserve(dst, src->len) != 0) {
+    struct lantern_string_list copy;
+    lantern_string_list_init(&copy);
+
+    if (src->len > 0 && string_list_reserve(&copy, src->len) != 0)
+    {
         return -1;
     }
 
-    for (size_t i = 0; i < src->len; ++i) {
-        char *copy = lantern_string_duplicate(src->items[i]);
-        if (!copy) {
-            lantern_string_list_reset(dst);
+    for (size_t i = 0; i < src->len; ++i)
+    {
+        char *item = lantern_string_duplicate(src->items[i]);
+        if (!item)
+        {
+            lantern_string_list_reset(&copy);
             return -1;
         }
-        dst->items[dst->len++] = copy;
+
+        copy.items[copy.len++] = item;
     }
 
+    lantern_string_list_reset(dst);
+    *dst = copy;
     return 0;
 }

--- a/src/support/strings.c
+++ b/src/support/strings.c
@@ -5,129 +5,186 @@
 #include <stdlib.h>
 #include <string.h>
 
-char *lantern_string_duplicate(const char *source) {
-    if (!source) {
+char *lantern_string_duplicate(const char *source)
+{
+    if (!source)
+    {
         return NULL;
     }
+
     return lantern_string_duplicate_len(source, strlen(source));
 }
 
-char *lantern_string_duplicate_len(const char *source, size_t length) {
-    if (!source) {
+char *lantern_string_duplicate_len(const char *source, size_t length)
+{
+    if (!source || length == SIZE_MAX)
+    {
         return NULL;
     }
-    char *copy = malloc(length + 1);
-    if (!copy) {
+
+    char *copy = malloc(length + 1u);
+    if (!copy)
+    {
         return NULL;
     }
+
     memcpy(copy, source, length);
     copy[length] = '\0';
     return copy;
 }
 
-size_t lantern_string_copy(char *dst, size_t dst_len, const char *src) {
-    if (!dst || dst_len == 0) {
+size_t lantern_string_copy(char *dst, size_t dst_len, const char *src)
+{
+    if (!dst || dst_len == 0)
+    {
         return 0;
     }
-    if (!src) {
+    if (!src)
+    {
         dst[0] = '\0';
         return 0;
     }
 
     const size_t src_len = strlen(src);
     size_t copy_len = src_len;
-    if (copy_len >= dst_len) {
-        copy_len = dst_len - 1;
+    if (copy_len >= dst_len)
+    {
+        copy_len = dst_len - 1u;
     }
-    if (copy_len > 0) {
+    if (copy_len > 0)
+    {
         memcpy(dst, src, copy_len);
     }
+
     dst[copy_len] = '\0';
     return src_len;
 }
 
-char *lantern_trim_whitespace(char *value) {
-    if (!value) {
+char *lantern_trim_whitespace(char *value)
+{
+    if (!value)
+    {
         return NULL;
     }
-    while (*value && isspace((unsigned char)*value)) {
+
+    while (*value && isspace((unsigned char)*value))
+    {
         ++value;
     }
+
     char *end = value + strlen(value);
-    while (end > value && isspace((unsigned char)*(end - 1))) {
+    while (end > value && isspace((unsigned char)*(end - 1)))
+    {
         --end;
     }
+
     *end = '\0';
     return value;
 }
 
-static int hex_value(char c) {
-    if (c >= '0' && c <= '9') {
-        return c - '0';
+static int hex_value(char value)
+{
+    if (value >= '0' && value <= '9')
+    {
+        return value - '0';
     }
-    if (c >= 'a' && c <= 'f') {
-        return c - 'a' + 10;
+    if (value >= 'a' && value <= 'f')
+    {
+        return value - 'a' + 10;
     }
-    if (c >= 'A' && c <= 'F') {
-        return c - 'A' + 10;
+    if (value >= 'A' && value <= 'F')
+    {
+        return value - 'A' + 10;
     }
+
     return -1;
 }
 
-int lantern_hex_decode(const char *hex, uint8_t *out, size_t out_len) {
-    if (!hex || !out || out_len == 0) {
+int lantern_hex_decode(const char *hex, uint8_t *out, size_t out_len)
+{
+    if (!hex || !out || out_len == 0 || out_len > SIZE_MAX / 2u)
+    {
         return -1;
     }
 
-    while (*hex && isspace((unsigned char)*hex)) {
+    while (*hex && isspace((unsigned char)*hex))
+    {
         ++hex;
     }
-    if (hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) {
+    if (hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X'))
+    {
         hex += 2;
     }
 
     size_t hex_len = strlen(hex);
-    while (hex_len > 0 && isspace((unsigned char)hex[hex_len - 1])) {
+    while (hex_len > 0 && isspace((unsigned char)hex[hex_len - 1u]))
+    {
         --hex_len;
     }
 
-    if (hex_len != out_len * 2) {
+    if (hex_len != out_len * 2u)
+    {
         return -1;
     }
 
-    for (size_t i = 0; i < out_len; ++i) {
-        int hi = hex_value(hex[i * 2]);
-        int lo = hex_value(hex[i * 2 + 1]);
-        if (hi < 0 || lo < 0) {
+    for (size_t i = 0; i < out_len; ++i)
+    {
+        int hi = hex_value(hex[i * 2u]);
+        int lo = hex_value(hex[i * 2u + 1u]);
+        if (hi < 0 || lo < 0)
+        {
             return -1;
         }
+
         out[i] = (uint8_t)((hi << 4) | lo);
     }
+
     return 0;
 }
 
-int lantern_bytes_to_hex(const uint8_t *bytes, size_t len, char *out, size_t out_len, int include_prefix) {
+int lantern_bytes_to_hex(const uint8_t *bytes, size_t len, char *out,
+                         size_t out_len, bool include_prefix)
+{
     static const char hex_digits[] = "0123456789abcdef";
-    if (!bytes || !out) {
+    if (!bytes || !out)
+    {
         return -1;
     }
-    size_t required = (len * 2) + (include_prefix ? 2 : 0) + 1;
-    if (out_len < required) {
-        if (out_len > 0) {
+
+    size_t extra = include_prefix ? 3u : 1u;
+    if (len > (SIZE_MAX - extra) / 2u)
+    {
+        if (out_len > 0)
+        {
             out[0] = '\0';
         }
         return -1;
     }
+
+    size_t required = (len * 2u) + extra;
+    if (out_len < required)
+    {
+        if (out_len > 0)
+        {
+            out[0] = '\0';
+        }
+        return -1;
+    }
+
     size_t offset = 0;
-    if (include_prefix) {
+    if (include_prefix)
+    {
         out[offset++] = '0';
         out[offset++] = 'x';
     }
-    for (size_t i = 0; i < len; ++i) {
+
+    for (size_t i = 0; i < len; ++i)
+    {
         uint8_t byte = bytes[i];
-        out[offset++] = hex_digits[(byte >> 4) & 0x0F];
-        out[offset++] = hex_digits[byte & 0x0F];
+        out[offset++] = hex_digits[(byte >> 4) & 0x0f];
+        out[offset++] = hex_digits[byte & 0x0f];
     }
+
     out[offset] = '\0';
     return 0;
 }

--- a/src/support/time.c
+++ b/src/support/time.c
@@ -1,32 +1,47 @@
 #include "lantern/support/time.h"
 
-#include <sys/time.h>
+#if defined(_WIN32)
+#include <windows.h>
+
+static double platform_time_now_seconds(void)
+{
+    LARGE_INTEGER counter;
+    LARGE_INTEGER frequency;
+    if (!QueryPerformanceCounter(&counter) ||
+        !QueryPerformanceFrequency(&frequency) || frequency.QuadPart <= 0)
+    {
+        return -1.0;
+    }
+
+    return (double)counter.QuadPart / (double)frequency.QuadPart;
+}
+#else
 #include <time.h>
 
-#if defined(__APPLE__) && !defined(CLOCK_MONOTONIC)
-#include <mach/mach_time.h>
-#endif
+static double platform_time_now_seconds(void)
+{
+    struct timespec value;
+    if (clock_gettime(CLOCK_MONOTONIC, &value) != 0)
+    {
+        return -1.0;
+    }
 
-double lantern_time_now_seconds(void) {
-#if defined(CLOCK_MONOTONIC)
-    struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-        return (double)ts.tv_sec + ((double)ts.tv_nsec / 1e9);
+    return (double)value.tv_sec + ((double)value.tv_nsec / 1e9);
+}
+#endif /* _WIN32 */
+
+double lantern_time_now_seconds(void)
+{
+    return platform_time_now_seconds();
+}
+
+double lantern_time_elapsed_seconds(double started_seconds,
+                                    double finished_seconds)
+{
+    if (started_seconds < 0.0 || finished_seconds < started_seconds)
+    {
+        return 0.0;
     }
-#elif defined(__APPLE__)
-    static mach_timebase_info_data_t timebase = {0};
-    static double scale = 0.0;
-    if (scale == 0.0) {
-        if (mach_timebase_info(&timebase) == KERN_SUCCESS && timebase.denom != 0) {
-            scale = ((double)timebase.numer / (double)timebase.denom) / 1e9;
-        } else {
-            scale = 1.0 / 1e9;
-        }
-    }
-    uint64_t now = mach_absolute_time();
-    return (double)now * scale;
-#endif
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double)tv.tv_sec + ((double)tv.tv_usec / 1e6);
+
+    return finished_seconds - started_seconds;
 }

--- a/tests/integration/consensus_fixture_runner.c
+++ b/tests/integration/consensus_fixture_runner.c
@@ -11,7 +11,7 @@
 #include "tests/support/fixture_loader.h"
 #include "src/test_driver/driver.h"
 #include "../support/state_store_adapter.h"
-#include "../../src/core/client_sync_internal.h"
+#include "../../src/core/client/sync_internal.h"
 
 #include <dirent.h>
 #include <errno.h>

--- a/tests/unit/client_test_helpers.c
+++ b/tests/unit/client_test_helpers.c
@@ -1,6 +1,6 @@
 #include "client_test_helpers.h"
 
-#include "../../src/core/client_internal.h"
+#include "../../src/core/client/internal.h"
 
 #include <ctype.h>
 #include <errno.h>

--- a/tests/unit/test_client_gossip.c
+++ b/tests/unit/test_client_gossip.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../src/core/client_services_internal.h"
+#include "../../src/core/client/services_internal.h"
 #include "client_test_helpers.h"
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/signature.h"

--- a/tests/unit/test_client_pending.c
+++ b/tests/unit/test_client_pending.c
@@ -6,9 +6,9 @@
 #include <unistd.h>
 
 #include "client_test_helpers.h"
-#include "../../src/core/client_network_internal.h"
-#include "../../src/core/client_services_internal.h"
-#include "../../src/core/client_sync_internal.h"
+#include "../../src/core/client/network_internal.h"
+#include "../../src/core/client/services_internal.h"
+#include "../../src/core/client/sync_internal.h"
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/signature.h"
 #include "lantern/consensus/state.h"

--- a/tests/unit/test_client_state_staleness.c
+++ b/tests/unit/test_client_state_staleness.c
@@ -5,7 +5,7 @@
 
 #include "lantern/consensus/state.h"
 
-#include "../../src/core/client_internal.h"
+#include "../../src/core/client/internal.h"
 
 static int expect_case(
     const char *label,

--- a/tests/unit/test_client_vote.c
+++ b/tests/unit/test_client_vote.c
@@ -8,7 +8,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "../../src/core/client_services_internal.h"
+#include "../../src/core/client/services_internal.h"
 #include "client_test_helpers.h"
 #include "lantern/consensus/hash.h"
 #include "lantern/consensus/signature.h"

--- a/tests/unit/test_fork_choice.c
+++ b/tests/unit/test_fork_choice.c
@@ -1542,6 +1542,12 @@ static int test_fork_choice_advance_time_schedules_votes(void) {
     assert(lantern_fork_choice_advance_to(&store, 4u, false) == 0);
     head = store.head;
     assert(roots_equal(&head, &block_voted_root));
+    assert(store.new_aggregated_payloads.length == 0u);
+    assert(store.known_aggregated_payloads.length == 3u);
+    assert(store.known_votes.capacity >= 3u);
+    assert(store.known_votes.entries[0].present);
+    assert(store.known_votes.entries[1].present);
+    assert(store.known_votes.entries[2].present);
 
     const LanternRoot *safe_final = &store.safe_target;
     assert(safe_final && roots_equal(safe_final, &block_voted_root));
@@ -1914,6 +1920,153 @@ static int test_fork_choice_accept_new_aggregated_payloads_updates_head(void) {
     return 0;
 }
 
+static int test_latest_votes_survive_payload_eviction(void) {
+    LanternStore store;
+    lantern_store_init(&store);
+
+    LanternAggregatedSignatureProof validator_zero_proof;
+    LanternAggregatedSignatureProof validator_one_proof;
+    assert(build_dummy_proof(&validator_zero_proof, 0u, 0x21) == 0);
+    assert(build_dummy_proof(&validator_one_proof, 1u, 0x31) == 0);
+
+    LanternAttestationData first = {0};
+    first.slot = 1u;
+    first.head.slot = 1u;
+    fill_root(&first.head.root, 0x41);
+    first.target = first.head;
+    LanternRoot first_root;
+    assert(lantern_hash_tree_root_attestation_data(&first, &first_root) == SSZ_SUCCESS);
+    assert(lantern_store_add_known_aggregated_payload(
+        &store,
+        &first_root,
+        &first,
+        &validator_zero_proof) == 0);
+
+    for (size_t i = 0u; i < 512u; ++i) {
+        LanternAttestationData data = {0};
+        data.slot = (uint64_t)i + 2u;
+        data.head.slot = data.slot;
+        fill_root(&data.head.root, (uint8_t)(i + 1u));
+        data.target = data.head;
+        LanternRoot data_root;
+        assert(lantern_hash_tree_root_attestation_data(&data, &data_root) == SSZ_SUCCESS);
+        assert(lantern_store_add_known_aggregated_payload(
+            &store,
+            &data_root,
+            &data,
+            &validator_one_proof) == 0);
+    }
+
+    assert(store.known_aggregated_payloads.length == 512u);
+    bool first_payload_retained = false;
+    for (size_t i = 0u; i < store.known_aggregated_payloads.length; ++i) {
+        if (roots_equal(
+                &store.known_aggregated_payloads.entries[i].data_root,
+                &first_root)) {
+            first_payload_retained = true;
+            break;
+        }
+    }
+    assert(!first_payload_retained);
+    assert(store.known_votes.capacity >= 2u);
+    assert(store.known_votes.entries[0].present);
+    assert(roots_equal(&store.known_votes.entries[0].data_root, &first_root));
+
+    LanternAggregatedSignatureProof validator_two_proof;
+    assert(build_dummy_proof(&validator_two_proof, 2u, 0x41) == 0);
+    LanternAttestationData first_new = {0};
+    first_new.slot = 1000u;
+    first_new.head.slot = first_new.slot;
+    fill_root(&first_new.head.root, 0x51);
+    first_new.target = first_new.head;
+    LanternRoot first_new_root;
+    assert(lantern_hash_tree_root_attestation_data(
+        &first_new,
+        &first_new_root) == SSZ_SUCCESS);
+    assert(lantern_store_add_new_aggregated_payload(
+        &store,
+        &first_new_root,
+        &first_new,
+        &validator_two_proof) == 0);
+    for (size_t i = 0u; i < 64u; ++i) {
+        LanternAttestationData data = {0};
+        data.slot = (uint64_t)i + 1001u;
+        data.head.slot = data.slot;
+        fill_root(&data.head.root, (uint8_t)(i + 0x61u));
+        data.target = data.head;
+        LanternRoot data_root;
+        assert(lantern_hash_tree_root_attestation_data(&data, &data_root) == SSZ_SUCCESS);
+        assert(lantern_store_add_new_aggregated_payload(
+            &store,
+            &data_root,
+            &data,
+            &validator_one_proof) == 0);
+    }
+    assert(store.new_aggregated_payloads.length == 64u);
+    assert(store.new_votes.capacity >= 3u);
+    assert(store.new_votes.entries[2].present);
+    assert(roots_equal(&store.new_votes.entries[2].data_root, &first_new_root));
+    assert(lantern_store_promote_new_aggregated_payloads(&store) == 64u);
+    assert(store.known_votes.entries[2].present);
+    assert(roots_equal(&store.known_votes.entries[2].data_root, &first_new_root));
+
+    lantern_aggregated_signature_proof_reset(&validator_two_proof);
+    lantern_aggregated_signature_proof_reset(&validator_one_proof);
+    lantern_aggregated_signature_proof_reset(&validator_zero_proof);
+    lantern_store_reset(&store);
+    return 0;
+}
+
+static int test_latest_vote_equal_slot_tie_break_is_deterministic(void) {
+    LanternStore store;
+    lantern_store_init(&store);
+
+    LanternAggregatedSignatureProof proof;
+    assert(build_dummy_proof(&proof, 0u, 0x51) == 0);
+
+    LanternAttestationData first = {0};
+    first.slot = 10u;
+    first.head.slot = 10u;
+    fill_root(&first.head.root, 0x61);
+    first.target = first.head;
+    LanternRoot first_root;
+    assert(lantern_hash_tree_root_attestation_data(&first, &first_root) == SSZ_SUCCESS);
+
+    LanternAttestationData second = first;
+    fill_root(&second.head.root, 0x71);
+    second.target = second.head;
+    LanternRoot second_root;
+    assert(lantern_hash_tree_root_attestation_data(&second, &second_root) == SSZ_SUCCESS);
+
+    const LanternAttestationData *lower_data = &first;
+    const LanternRoot *lower_root = &first_root;
+    const LanternAttestationData *higher_data = &second;
+    const LanternRoot *higher_root = &second_root;
+    if (memcmp(first_root.bytes, second_root.bytes, LANTERN_ROOT_SIZE) > 0) {
+        lower_data = &second;
+        lower_root = &second_root;
+        higher_data = &first;
+        higher_root = &first_root;
+    }
+
+    assert(lantern_store_add_known_aggregated_payload(
+        &store,
+        higher_root,
+        higher_data,
+        &proof) == 0);
+    assert(lantern_store_add_known_aggregated_payload(
+        &store,
+        lower_root,
+        lower_data,
+        &proof) == 0);
+    assert(store.known_votes.entries[0].present);
+    assert(roots_equal(&store.known_votes.entries[0].data_root, higher_root));
+
+    lantern_aggregated_signature_proof_reset(&proof);
+    lantern_store_reset(&store);
+    return 0;
+}
+
 int main(void) {
     if (test_fork_choice_block_sequence() != 0) {
         return 1;
@@ -1964,6 +2117,12 @@ int main(void) {
         return 1;
     }
     if (test_fork_choice_accept_new_aggregated_payloads_updates_head() != 0) {
+        return 1;
+    }
+    if (test_latest_votes_survive_payload_eviction() != 0) {
+        return 1;
+    }
+    if (test_latest_vote_equal_slot_tie_break_is_deterministic() != 0) {
         return 1;
     }
     return 0;

--- a/tests/unit/test_genesis_anchor.c
+++ b/tests/unit/test_genesis_anchor.c
@@ -20,9 +20,9 @@
 #include "../support/validator_registry.h"
 #include "../support/storage_cleanup.h"
 #include "client_test_helpers.h"
-#include "../../src/core/client_internal.h"
-#include "../../src/core/client_services_internal.h"
-#include "../../src/core/client_sync_internal.h"
+#include "../../src/core/client/internal.h"
+#include "../../src/core/client/services_internal.h"
+#include "../../src/core/client/sync_internal.h"
 
 static void fill_pubkeys(uint8_t *pubkeys, size_t count)
 {

--- a/tests/unit/test_libp2p.c
+++ b/tests/unit/test_libp2p.c
@@ -1,4 +1,4 @@
-#include "../../src/core/client_network_internal.h"
+#include "../../src/core/client/network_internal.h"
 
 #include "lantern/core/client.h"
 #include "lantern/metrics/lean_metrics.h"

--- a/tests/unit/test_support.c
+++ b/tests/unit/test_support.c
@@ -1,0 +1,153 @@
+#include "lantern/support/log.h"
+#include "lantern/support/secure_mem.h"
+#include "lantern/support/string_list.h"
+#include "lantern/support/strings.h"
+#include "lantern/support/time.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+static int test_string_boundaries(void)
+{
+    uint8_t byte = 0;
+    char output[4] = "x";
+
+    if (lantern_string_duplicate_len("x", SIZE_MAX) != NULL)
+    {
+        return 1;
+    }
+    if (lantern_hex_decode("", &byte, (SIZE_MAX / 2u) + 1u) == 0)
+    {
+        return 1;
+    }
+    if (lantern_bytes_to_hex(&byte, (SIZE_MAX / 2u) + 1u, output,
+                             sizeof(output), false) == 0 ||
+        output[0] != '\0')
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_string_list_boundaries(void)
+{
+    struct lantern_string_list list;
+    lantern_string_list_init(&list);
+    if (lantern_string_list_append(&list, "alpha") != 0)
+    {
+        return 1;
+    }
+    if (lantern_string_list_copy(&list, &list) != 0 || list.len != 1u ||
+        strcmp(list.items[0], "alpha") != 0)
+    {
+        lantern_string_list_reset(&list);
+        return 1;
+    }
+    lantern_string_list_reset(&list);
+
+    list.len = SIZE_MAX;
+    if (lantern_string_list_append(&list, "overflow") == 0)
+    {
+        return 1;
+    }
+    lantern_string_list_reset(&list);
+    return 0;
+}
+
+static int test_secure_zero(void)
+{
+    uint8_t secret[] = {1u, 2u, 3u, 4u};
+    lantern_secure_zero(secret, sizeof(secret));
+    for (size_t i = 0; i < sizeof(secret); ++i)
+    {
+        if (secret[i] != 0u)
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int test_time_helpers(void)
+{
+    double first = lantern_time_now_seconds();
+    double second = lantern_time_now_seconds();
+    if (first < 0.0 || second < first)
+    {
+        return 1;
+    }
+    if (lantern_time_elapsed_seconds(-1.0, second) != 0.0 ||
+        lantern_time_elapsed_seconds(2.0, 1.0) != 0.0 ||
+        lantern_time_elapsed_seconds(1.0, 2.5) != 1.5)
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+static int test_log_metadata(void)
+{
+    FILE *capture = tmpfile();
+    if (!capture)
+    {
+        return 1;
+    }
+
+    int saved_stdout = dup(STDOUT_FILENO);
+    if (saved_stdout < 0 || fflush(stdout) != 0 ||
+        dup2(fileno(capture), STDOUT_FILENO) < 0)
+    {
+        if (saved_stdout >= 0)
+        {
+            close(saved_stdout);
+        }
+        fclose(capture);
+        return 1;
+    }
+
+    const struct lantern_log_metadata metadata = {
+        .validator = "validator-a",
+        .peer = "peer-b",
+        .slot = 7u,
+        .has_slot = true,
+    };
+    lantern_log_set_level(LANTERN_LOG_LEVEL_INFO);
+    lantern_log_info("support", &metadata, "message %d", 3);
+
+    int restore_result = dup2(saved_stdout, STDOUT_FILENO);
+    close(saved_stdout);
+    if (restore_result < 0 || fseek(capture, 0, SEEK_SET) != 0)
+    {
+        fclose(capture);
+        return 1;
+    }
+
+    char text[2048];
+    size_t length = fread(text, 1u, sizeof(text) - 1u, capture);
+    text[length] = '\0';
+    fclose(capture);
+
+    return strstr(text, "validator=validator-a") &&
+                   strstr(text, "peer=peer-b") && strstr(text, "slot=7") &&
+                   strstr(text, "message 3")
+               ? 0
+               : 1;
+}
+
+int main(void)
+{
+    if (test_string_boundaries() != 0 || test_string_list_boundaries() != 0 ||
+        test_secure_zero() != 0 || test_time_helpers() != 0 ||
+        test_log_metadata() != 0)
+    {
+        fprintf(stderr, "support tests failed\n");
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This change keeps a per-validator latest-vote map independent from bounded aggregated-payload caches so fork-choice safe-target logic retains the newest vote even when cached payload entries are evicted. It adds a root-to-block index to speed ancestry lookups during fork-choice evaluation, promotes pending votes into the known set when intervals advance, and updates safe-target handling around those transitions. Tests cover vote retention through cache eviction and deterministic tie-breaking for equal-slot votes.